### PR TITLE
Query for Smart Batteries even if IsSmartCharging is False

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -247,11 +247,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             _LOGGER.debug("Data enode chargers: %s", data_enode_chargers)
 
             data_smart_batteries = None
-            if self.api.is_authenticated and is_smart_charging:
-                data_smart_batteries = await self.api.smart_batteries()
-                # use this in production
-                # if self.api.is_authenticated and is_smart_charging
-                # Use this for testing, enabling smart charging testdata
+            if self.api.is_authenticated:
+                try:
+                    data_smart_batteries = await self.api.smart_batteries()
+                except Exception as err:
+                    _LOGGER.debug("Failed to fetch smart batteries: %s", err)
+                    data_smart_batteries = None
             _LOGGER.debug("Data smart batteries: %s", data_smart_batteries)
 
             data_smart_battery_details = []


### PR DESCRIPTION
I have smart battery trading _without_ smart charging for the car enabled. The current conditional prevents getting battery information in the integration.

My smart charging not being activated:
<img width="1067" height="112" alt="image" src="https://github.com/user-attachments/assets/393bf663-c807-44fc-bacb-0fa846dad890" />

The change is to check if there are any batteries with a try / except. 

After making making this code change on my instance, I was able to load the battery:
<img width="831" height="90" alt="image" src="https://github.com/user-attachments/assets/8da18e70-c53c-461a-9628-670c18ea4c2e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching smart battery data by handling errors gracefully and ensuring data is retrieved whenever the API is authenticated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->