### PR TITLE
Fix in-delivery status logging state transition

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -222,7 +222,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             # Mark that we've logged this to avoid spam
             self._not_in_delivery_logged = True
-        elif not is_not_in_delivery and hasattr(self, '_in_delivery_logged'):
+        elif not is_not_in_delivery and hasattr(self, '_not_in_delivery_logged'):
             _LOGGER.info(
                 "Frank Energie site now has historical data available. "
                 "All sensors should be fully functional."


### PR DESCRIPTION
### Motivation
- Correct a logic bug in the coordinator that prevented the recovery log for IN_DELIVERY status from being emitted and left a stale logging flag set.

### Description
- Fixed the attribute check in `FrankEnergieCoordinator._log_not_in_delivery_status` to test for `_not_in_delivery_logged` when clearing the flag.
- Ensure the flag is removed with `delattr(self, '_not_in_delivery_logged')` so the recovery message can be logged again on status change.
- Change is limited to `custom_components/frank_energie/coordinator.py` and does not alter external behavior beyond logging state management.

### Testing
- Ran `python -m compileall custom_components/frank_energie/coordinator.py`, which succeeded.
- Ran `pytest -q`, which failed to collect tests due to the environment missing the `homeassistant` package (expected in this environment).
- Ran `flake8 custom_components/frank_energie/coordinator.py`, which reported pre-existing line-length (`E501`) warnings unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991ffd4d948322b4a89b3ceab440e6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery status logging to ensure consistent state tracking when services become unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->