### PR TITLE
fix: Handle auth errors wrapped as FrankEnergieException in _async_update_data

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -305,6 +305,13 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 raise UpdateFailed("Authentication temporarily failed") from err
 
             except (RequestException, FrankEnergieException, ClientError) as err:
+                # FrankEnergieException can wrap AuthException ("Not authorized")
+                # Route auth errors to _try_renew_token instead of treating as network error
+                if "Not authorized" in str(err) or "Unauthorized" in str(err):
+                    _LOGGER.warning(
+                        "Auth error wrapped as FrankEnergieException: %s. Attempting token renewal.", err)
+                    await self._try_renew_token()
+                    raise UpdateFailed("Authentication temporarily failed, token renewal attempted") from err
                 _LOGGER.warning(
                     "Temporary network error while fetching Frank Energie data: %s",
                     err,


### PR DESCRIPTION
Problem
When Frank Energie's 24-hour token expires, the integration fails to recover automatically and requires manual re-authentication in the HA UI.
Root cause: In _async_update_data, the python-frank-energie library occasionally raises a FrankEnergieException with the message "Not authorized" rather than a proper AuthException. This happens because the auth error gets wrapped at the library level before it reaches the coordinator.
The current catch block at line 307 treats all FrankEnergieException as a temporary network error — logging a warning and raising UpdateFailed — without ever calling _try_renew_token(). This means the token is never renewed and the integration stays broken until the user manually intervenes.

`# Current behaviour — auth errors silently treated as network errors
except (RequestException, FrankEnergieException, ClientError) as err:
    _LOGGER.warning("Temporary network error while fetching Frank Energie data: %s", err)
    raise UpdateFailed from err`

Observed in logs:

`ERROR python_frank_energie.frank_energie Failed to query smart battery sessions: Unexpected error: Not authorized
ERROR python_frank_energie.frank_energie Failed to query smart battery sessions: Unexpected error: Not authorized`
These appear at exactly 24h intervals — confirming this is the token expiry cycle, not a transient network issue.

Note on _handle_fetch_exceptions
v2026.5.10 added a _handle_fetch_exceptions helper that correctly handles AuthException → _try_renew_token. However it is currently never called anywhere in the coordinator. This PR addresses the immediate issue in the existing catch block. Separately wiring up _handle_fetch_exceptions or extending it to also handle FrankEnergieException("Not authorized") would be a clean follow-up.

Fix
Add a string check inside the FrankEnergieException catch to detect wrapped auth errors and route them to _try_renew_token():

`except (RequestException, FrankEnergieException, ClientError) as err:
    # FrankEnergieException can wrap AuthException ("Not authorized")
    # Route auth errors to _try_renew_token instead of treating as network error
    if "Not authorized" in str(err) or "Unauthorized" in str(err):
        _LOGGER.warning(
            "Auth error wrapped as FrankEnergieException: %s. Attempting token renewal.", err)
        await self._try_renew_token()
        raise UpdateFailed("Authentication temporarily failed, token renewal attempted") from err
    _LOGGER.warning(
        "Temporary network error while fetching Frank Energie data: %s", err)
    raise UpdateFailed from err`


Testing

Tested on HA 2026.5.x with python-frank-energie==2026.5.10 
Token renewal confirmed working cleanly at 24h interval with no manual intervention required
Dashboard remained live throughout the renewal cycle
Confirmed the issue is purely the 24h token expiry — not multi-device token collision (tested by actively using the Frank Energie mobile app during HA operation with no effect on the session)

## Summary by Sourcery

Bug Fixes:
- In FrankEnergieException omhulde (wrapped) authenticatiefouten detecteren tijdens coordinator-updates en een token-vernieuwing starten in plaats van ze als tijdelijke netwerkfouten te behandelen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Detect wrapped auth errors in FrankEnergieException during coordinator updates and trigger token renewal instead of treating them as transient network failures.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling: the app now detects authorization failures, automatically attempts token renewal, and surfaces a clearer authentication-failed status when renewal is attempted or needed.
  * Non-auth network errors continue to be treated as temporary connectivity issues and reported accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HiDiHo01/home-assistant-frank_energie/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->