### PR TITLE
fix(coordinator): fallback to None when month summary fetch fails during setup

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -508,7 +508,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             _LOGGER.warning(
                 "Authentication failed while fetching month summary: %s", ex
             )
-            return MonthSummary.from_dict({})
+            return None
         except (RequestException, FrankEnergieException, ClientError) as ex:
             error_msg = str(ex).lower()
             if "no reading dates" in error_msg:
@@ -518,7 +518,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 )
             else:
                 _LOGGER.warning("No month summary data available: %s", ex)
-            return MonthSummary.from_dict({})
+            return None
 
     async def _fetch_invoices(self) -> Invoices | None:
         """Fetch invoices from the API."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -318,3 +318,26 @@ async def test_fetch_today_data_dynamic_auth_failure(coordinator, mock_frank_ene
 
     # Verify token renewal was triggered
     coordinator._try_renew_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_month_summary_exception(coordinator, mock_frank_energie):
+    """Test that _fetch_month_summary handles generic/request exceptions by returning None."""
+    from python_frank_energie.exceptions import FrankEnergieException
+
+    mock_frank_energie.is_authenticated = True
+    mock_frank_energie.month_summary.side_effect = FrankEnergieException("site_reference error")
+    result = await coordinator._fetch_month_summary()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_month_summary_auth_exception(coordinator, mock_frank_energie):
+    """Test that _fetch_month_summary handles authentication exceptions by returning None."""
+    from python_frank_energie.exceptions import AuthException
+
+    mock_frank_energie.is_authenticated = True
+    mock_frank_energie.month_summary.side_effect = AuthException("auth error")
+    result = await coordinator._fetch_month_summary()
+    assert result is None
+

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,7 +13,10 @@ from custom_components.frank_energie.coordinator import FrankEnergieCoordinator
 from custom_components.frank_energie import FrankEnergieComponent
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from python_frank_energie import FrankEnergie
+from python_frank_energie.exceptions import FrankEnergieException, RequestException
 from python_frank_energie.models import MonthSummary, Invoices, User
+from aiohttp import ClientError
+
 
 # Sample data for mocking
 mock_entry_data = {
@@ -321,14 +324,23 @@ async def test_fetch_today_data_dynamic_auth_failure(coordinator, mock_frank_ene
 
 
 @pytest.mark.asyncio
-async def test_fetch_month_summary_exception(coordinator, mock_frank_energie):
-    """Test that _fetch_month_summary handles generic/request exceptions by returning None."""
-    from python_frank_energie.exceptions import FrankEnergieException
-
+@pytest.mark.parametrize(
+    "exception_cls",
+    [
+        FrankEnergieException,
+        RequestException,
+        ClientError,
+    ],
+)
+async def test_fetch_month_summary_exceptions_return_none(
+    coordinator, mock_frank_energie, exception_cls
+):
+    """Test that _fetch_month_summary handles non-auth exceptions by returning None."""
     mock_frank_energie.is_authenticated = True
-    mock_frank_energie.month_summary.side_effect = FrankEnergieException("site_reference error")
+    mock_frank_energie.month_summary.side_effect = exception_cls("test error")
     result = await coordinator._fetch_month_summary()
     assert result is None
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary
This Pull Request resolves a setup crash that prevents the integration from loading when the `site_reference` is missing or invalid. It replaces the empty dictionary fallback `MonthSummary.from_dict({})` with `None`, which is fully supported and safely handled by downstream sensors.

# Key Changes
- Modified `_fetch_month_summary` in [coordinator.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/coordinator.py#L501-L521) to return `None` upon exceptions instead of `MonthSummary.from_dict({})`.
- Added unit tests in [test_coordinator.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/tests/test_coordinator.py#L321-L343) (`test_fetch_month_summary_exception` and `test_fetch_month_summary_auth_exception`) to mock API errors and verify fallback to `None`.

# Why this is needed
When the API fails to fetch the month summary (e.g. during initial config flow or when site reference is None), the previous code attempted to construct an empty model using `MonthSummary.from_dict({})`. This triggered a `RequestException` due to missing required schema fields (`actualCostsUntilLastMeterReadingDate`), causing the coordinator refresh to fail completely and preventing integration load. Returning `None` avoids this validation crash and permits safe startup.

## Summary by Sourcery

Fouten bij het ophalen van maandoverzichten tijdens het opzetten van de coördinator afhandelen om te voorkomen dat de integratie crasht.

Bugfixes:
- `None` retourneren in plaats van een lege `MonthSummary` te construeren wanneer authenticatie- of verzoekfouten optreden tijdens het ophalen van het maandoverzicht, zodat validatiecrashes tijdens het opzetten worden voorkomen.

Tests:
- Unit-tests toegevoegd die generieke/verzoek- en authenticatie-excepties bij het ophalen van het maandoverzicht afdekken om te garanderen dat `None` wordt geretourneerd in deze foutscenario’s.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle failures when fetching month summaries during coordinator setup to avoid crashing the integration.

Bug Fixes:
- Return None instead of constructing an empty MonthSummary when authentication or request errors occur while fetching the month summary, preventing validation crashes during setup.

Tests:
- Add unit tests covering generic/request and authentication exceptions when fetching the month summary to ensure None is returned in these failure scenarios.

</details>