### PR TITLE
feat: Add Smart PV sensors, control switches, and charging deadline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ custom_components/frank_energie/.claude/
 custom_components/frank_energie/skills/
 custom_components/frank_energie/AGENTS.md
 custom_components/frank_energie/CLAUDE.md
+
+# Local dev environment
+dev_env/
+

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -19,7 +19,13 @@ from .exceptions import NoSuitableSitesFoundError
 _LOGGER = logging.getLogger(__name__)
 
 # PLATFORMS = [Platform.SENSOR, "frank_energie_diagnostic_sensor"]
-PLATFORMS: list[str] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.BUTTON]
+PLATFORMS: list[str] = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.SWITCH,
+    Platform.DATETIME,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -21,6 +21,9 @@ from python_frank_energie.models import (
     SmartBatterySessions,
     User,
     UserSites,
+    SmartPvSystems,
+    SmartPvSystemSummary,
+    UserSmartFeedInStatus,
 )
 
 # --- Logger Setup ---
@@ -79,6 +82,9 @@ DATA_BATTERY_DETAILS: Final[str] = "smart_battery_details"
 DATA_BATTERY_SESSIONS: Final[str] = "smart_battery_sessions"
 DATA_ENODE_CHARGERS: Final[str] = "enode_chargers"
 DATA_ENODE_VEHICLES: Final[str] = "enode_vehicles"
+DATA_PV_SYSTEMS: Final[str] = "smart_pv_systems"
+DATA_PV_SUMMARY: Final[str] = "smart_pv_summary"
+DATA_USER_SMART_FEED_IN: Final[str] = "user_smart_feed_in"
 
 # --- Attribute Constants ---
 ATTR_FROM_TIME: Final[str] = "from_time"
@@ -113,6 +119,8 @@ SERVICE_NAME_MONTH_SUMMARY: Final[str] = "Month Summary"
 SERVICE_NAME_USER_SITES: Final[str] = "User Sites"
 SERVICE_NAME_ENODE_CHARGERS: Final[str] = "Chargers"
 SERVICE_NAME_ENODE_VEHICLES: Final[str] = "Vehicles"
+SERVICE_NAME_PV_SYSTEMS: Final[str] = "Solar Systems"
+SERVICE_NAME_PV_SUMMARY: Final[str] = "Solar Summary"
 
 # --- Device Response Data Class ---
 
@@ -156,6 +164,15 @@ class DeviceResponseEntry:
 
     # Vehicles details (if available)
     vehicles: EnodeVehicles | None = None  # Placeholder for vehicle data, if any
+
+    # Smart PV systems (if available)
+    smart_pv_systems: SmartPvSystems | None = None
+
+    # Smart PV system summary (if available)
+    smart_pv_summary: dict[str, SmartPvSystemSummary] | None = None
+
+    # User smart feed-in status (if available)
+    user_smart_feed_in: UserSmartFeedInStatus | None = None
 
     # Contract price resolution state (if available)
     contract_price_resolution_state: ContractPriceResolutionState | None = None

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -46,6 +46,9 @@ from python_frank_energie.models import (
     SmartBatterySessions,
     User,
     UserSites,
+    SmartPvSystems,
+    SmartPvSystemSummary,
+    UserSmartFeedInStatus,
 )
 
 from .const import (
@@ -62,6 +65,9 @@ from .const import (
     DATA_USAGE,
     DATA_USER,
     DATA_USER_SITES,
+    DATA_PV_SYSTEMS,
+    DATA_PV_SUMMARY,
+    DATA_USER_SMART_FEED_IN,
     DEFAULT_REFRESH_INTERVAL,
     EVENT_FRANK_ENERGIE,
 )
@@ -118,6 +124,15 @@ class FrankEnergieData(TypedDict):
     battery_sessions: SmartBatterySessions | None
     """Optional smart battery sessions data."""
 
+    smart_pv_systems: SmartPvSystems | None
+    """Optional smart PV systems data."""
+
+    smart_pv_summary: dict[str, SmartPvSystemSummary] | None
+    """Optional smart PV system summary data."""
+
+    user_smart_feed_in: UserSmartFeedInStatus | None
+    """Optional user smart feed-in status."""
+
     contract_price_resolution_state: ContractPriceResolutionState | None
     """Optional contract price resolution state."""
 
@@ -135,6 +150,9 @@ class PricesTodayCache:
     smart_battery_details: SmartBatteryDetails
     smart_battery_sessions: SmartBatterySessions
     enode_vehicles: EnodeVehicles
+    smart_pv_systems: SmartPvSystems
+    smart_pv_summary: dict[str, SmartPvSystemSummary]
+    user_smart_feed_in: UserSmartFeedInStatus
     contract_price_resolution_state: ContractPriceResolutionState
 
 
@@ -185,6 +203,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             DATA_BATTERIES: None,
             DATA_BATTERY_DETAILS: None,
             DATA_BATTERY_SESSIONS: None,
+            DATA_ENODE_VEHICLES: None,
+            DATA_PV_SYSTEMS: None,
+            DATA_PV_SUMMARY: None,
+            DATA_USER_SMART_FEED_IN: None,
             DATA_CONTRACT_PRICE_RESOLUTION_STATE: None,
         }
         self._update_interval = timedelta(seconds=DEFAULT_REFRESH_INTERVAL)
@@ -306,6 +328,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 data_smart_battery_details,
                 data_smart_battery_sessions,
                 data_enode_vehicles,
+                data_pv_systems,
+                data_pv_summary,
+                data_user_smart_feed_in,
                 data_contract_price_resolution_state,
             ) = await self._fetch_today_data(today, tomorrow)
             if (
@@ -355,6 +380,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             data_smart_battery_details,
             data_smart_battery_sessions,
             data_enode_vehicles,
+            data_pv_systems,
+            data_pv_summary,
+            data_user_smart_feed_in,
             data_contract_price_resolution_state,
         )
 
@@ -400,6 +428,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             data_smart_battery_details,
             data_smart_battery_sessions,
             data_enode_vehicles,
+            data_pv_systems,
+            data_pv_summary,
+            data_user_smart_feed_in,
             data_contract_price_resolution_state,
         )
 
@@ -667,7 +698,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, is_smart_charging: bool
     ) -> EnodeVehicles | None:
         """Fetch Enode vehicles from the API."""
-        if not (self.api.is_authenticated and is_smart_charging):
+        if not self.api.is_authenticated:
             return None
         try:
             vehicles = await self.api.enode_vehicles()
@@ -679,6 +710,48 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except Exception as err:
             _LOGGER.debug("Failed to fetch enode vehicles: %s", err)
+            return None
+
+    async def _fetch_smart_pv_systems(self) -> SmartPvSystems | None:
+        """Fetch Smart PV systems from the API."""
+        if not self.api.is_authenticated:
+            return None
+        try:
+            return await self.api.smart_pv_systems()
+        except (AuthException, AuthRequiredException):
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
+            return None
+
+    async def _fetch_smart_pv_summary(self, device_id: str) -> SmartPvSystemSummary | None:
+        """Fetch Smart PV system summary from the API."""
+        if not self.api.is_authenticated:
+            return None
+        try:
+            return await self.api.smart_pv_system_summary(device_id)
+        except (AuthException, AuthRequiredException):
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Failed to fetch smart PV system summary for %s: %s", device_id, err)
+            return None
+
+    async def _fetch_user_smart_feed_in(self) -> UserSmartFeedInStatus | None:
+        """Fetch user smart feed-in status from the API."""
+        if not self.api.is_authenticated:
+            return None
+        try:
+            return await self.api.user_smart_feed_in()
+        except (AuthException, AuthRequiredException):
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Failed to fetch user smart feed-in status: %s", err)
             return None
 
     async def _fetch_battery_details(self, battery) -> SmartBatteryDetails | None:
@@ -871,10 +944,13 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         list[SmartBatteryDetails | None],
         list[SmartBatterySessions | None],
         EnodeVehicles | None,
+        SmartPvSystems | None,
+        dict[str, SmartPvSystemSummary] | None,
+        UserSmartFeedInStatus | None,
         ContractPriceResolutionState | None,
     ]:
         """
-        Fetches all relevant Frank Energie data for the current day, including prices, user sites, monthly summaries, invoices, usage, user info, Enode chargers, smart batteries, battery details, and battery sessions.
+        Fetches all relevant Frank Energie data for the current day, including prices, user sites, monthly summaries, invoices, usage, user info, Enode chargers, smart batteries, battery details, battery sessions, and smart PV systems.
 
         Attempts to retrieve user-specific and public data as available, handling authentication failures and falling back to cached data if necessary. Also manages token renewal on authentication errors.
 
@@ -883,7 +959,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             tomorrow (date): The next day, used for price and session range queries.
 
         Returns:
-            Tuple containing today's prices, month summary, invoices, user data, user sites, period usage, Enode chargers, smart batteries, smart battery details, and smart battery sessions.
+            Tuple containing today's data components including Smart PV systems and summaries.
         """
         yesterday = today - timedelta(days=1)
         start_date = yesterday
@@ -916,10 +992,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 data_enode_chargers,
                 data_smart_batteries,
                 data_enode_vehicles,
+                data_pv_systems,
+                data_user_smart_feed_in,
             ) = await asyncio.gather(
                 self._fetch_enode_chargers(start_date, is_smart_charging),
                 self._fetch_smart_batteries(is_smart_trading),
                 self._fetch_enode_vehicles(is_smart_charging),
+                self._fetch_smart_pv_systems(),
+                self._fetch_user_smart_feed_in(),
             )
 
             (
@@ -928,6 +1008,18 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             ) = await self._get_battery_details_and_sessions(
                 data_smart_batteries, start_date, tomorrow
             )
+
+            data_pv_summary = {}
+            if data_pv_systems and data_pv_systems.systems:
+                pv_tasks = [
+                    self._fetch_smart_pv_summary(system.id)
+                    for system in data_pv_systems.systems
+                    if system
+                ]
+                pv_summaries = await asyncio.gather(*pv_tasks)
+                for system, summary in zip(data_pv_systems.systems, pv_summaries):
+                    if summary:
+                        data_pv_summary[system.id] = summary
 
             # Detect and log IN_DELIVERY status for clean user experience
             if self.api.is_authenticated:
@@ -948,6 +1040,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 data_smart_battery_details,
                 data_smart_battery_sessions,
                 data_enode_vehicles,
+                data_pv_systems,
+                data_pv_summary,
+                data_user_smart_feed_in,
                 data_contract_price_resolution_state,
             )
 
@@ -1005,6 +1100,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         data_smart_battery_details,
         data_smart_battery_sessions,
         data_enode_vehicles,
+        data_pv_systems,
+        data_pv_summary,
+        data_user_smart_feed_in,
         data_contract_price_resolution_state,
     ) -> FrankEnergieData:
         """Aggregate the fetched data into a single returnable dictionary."""
@@ -1021,6 +1119,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             DATA_BATTERY_DETAILS: data_smart_battery_details,
             DATA_BATTERY_SESSIONS: data_smart_battery_sessions,
             DATA_ENODE_VEHICLES: data_enode_vehicles,
+            DATA_PV_SYSTEMS: data_pv_systems,
+            DATA_PV_SUMMARY: data_pv_summary,
+            DATA_USER_SMART_FEED_IN: data_user_smart_feed_in,
             DATA_CONTRACT_PRICE_RESOLUTION_STATE: data_contract_price_resolution_state,
             DATA_ELECTRICITY: None,
             DATA_GAS: None,
@@ -1048,20 +1149,18 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not data_user:
             return False
         smart_charging = data_user.smartCharging
-        return (
-            isinstance(smart_charging, dict)
-            and smart_charging.get("isActivated", False) is True
-        )
+        if isinstance(smart_charging, dict):
+            return smart_charging.get("isActivated", False) is True
+        return getattr(smart_charging, "isActivated", False) is True
 
     def _is_smart_trading_enabled(self, data_user) -> bool:
         """Check if smart trading is enabled for the user."""
         if not data_user:
             return False
         smart_trading = data_user.smartTrading
-        return (
-            isinstance(smart_trading, dict)
-            and smart_trading.get("isActivated", False) is True
-        )
+        if isinstance(smart_trading, dict):
+            return smart_trading.get("isActivated", False) is True
+        return getattr(smart_trading, "isActivated", False) is True
 
     async def _fetch_public_prices_for_range(
         self, start_date: date, end_date: date, country_code: str

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -11,7 +11,7 @@ import secrets
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Awaitable, Callable, Final, TypedDict
+from typing import Any, Awaitable, Callable, Final, TypedDict
 
 from aiohttp import ClientError, ClientSession  # type: ignore
 from homeassistant.config_entries import ConfigEntry
@@ -726,7 +726,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
             return None
 
-    async def _fetch_smart_pv_summary(self, device_id: str) -> SmartPvSystemSummary | None:
+    async def _fetch_smart_pv_summary(
+        self, device_id: str
+    ) -> SmartPvSystemSummary | None:
         """Fetch Smart PV system summary from the API."""
         if not self.api.is_authenticated:
             return None
@@ -737,7 +739,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            _LOGGER.debug("Failed to fetch smart PV system summary for %s: %s", device_id, err)
+            _LOGGER.debug(
+                "Failed to fetch smart PV system summary for %s: %s", device_id, err
+            )
             return None
 
     async def _fetch_user_smart_feed_in(self) -> UserSmartFeedInStatus | None:
@@ -1011,13 +1015,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
             data_pv_summary = {}
             if data_pv_systems and data_pv_systems.systems:
+                systems = [s for s in data_pv_systems.systems if s]
                 pv_tasks = [
-                    self._fetch_smart_pv_summary(system.id)
-                    for system in data_pv_systems.systems
-                    if system
+                    self._fetch_smart_pv_summary(system.id) for system in systems
                 ]
                 pv_summaries = await asyncio.gather(*pv_tasks)
-                for system, summary in zip(data_pv_systems.systems, pv_summaries):
+                for system, summary in zip(systems, pv_summaries):
                     if summary:
                         data_pv_summary[system.id] = summary
 
@@ -1161,6 +1164,35 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if isinstance(smart_trading, dict):
             return smart_trading.get("isActivated", False) is True
         return getattr(smart_trading, "isActivated", False) is True
+
+    def get_pv_system_metadata(self, system_id: str) -> dict[str, Any]:
+        """Get PV system metadata (brand, model, display_name, serial_number)."""
+        systems_obj = self.data.get(DATA_PV_SYSTEMS)
+        pv_system = None
+        if systems_obj and systems_obj.systems:
+            pv_system = next(
+                (s for s in systems_obj.systems if s.id == system_id), None
+            )
+
+        brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
+        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
+        display_name = (
+            pv_system.display_name
+            if (pv_system and pv_system.display_name)
+            else f"Smart PV {system_id}"
+        )
+        serial_number = (
+            pv_system.inverter_serial_numbers[0]
+            if pv_system and pv_system.inverter_serial_numbers
+            else None
+        )
+
+        return {
+            "brand": brand,
+            "model": model,
+            "display_name": display_name,
+            "serial_number": serial_number,
+        }
 
     async def _fetch_public_prices_for_range(
         self, start_date: date, end_date: date, country_code: str

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -722,7 +722,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
             return None
 
@@ -738,7 +738,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "Failed to fetch smart PV system summary for %s: %s", device_id, err
             )
@@ -754,7 +754,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch user smart feed-in status: %s", err)
             return None
 

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -1,0 +1,97 @@
+"""Datetime platform for Frank Energie integration."""
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+
+from homeassistant.components.datetime import DateTimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    DATA_ENODE_VEHICLES,
+)
+from .coordinator import FrankEnergieCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Frank Energie datetime entities."""
+    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    entities: list[DateTimeEntity] = []
+
+    if coordinator.api.is_authenticated:
+        enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
+        if enode_vehicles and enode_vehicles.vehicles:
+            for vehicle in enode_vehicles.vehicles:
+                entities.append(
+                    FrankEnergieVehicleDeadlineEntity(coordinator, config_entry, vehicle.id)
+                )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class FrankEnergieVehicleDeadlineEntity(CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity):
+    """Representation of an editable EV charging deadline/departure time."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:clock-end"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        vehicle_id: str,
+    ) -> None:
+        """Initialize the datetime entity."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._vehicle_id = vehicle_id
+        self._attr_name = "Charging deadline"
+        self._attr_translation_key = "charging_deadline"
+        self._attr_unique_id = f"{DOMAIN}_{vehicle_id}_charging_deadline"
+
+        # Find vehicle to get info for device registration
+        enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
+        vehicle = None
+        if enode_vehicles and enode_vehicles.vehicles:
+            vehicle = next((v for v in enode_vehicles.vehicles if v.id == vehicle_id), None)
+
+        brand = vehicle.information.brand if (vehicle and vehicle.information) else "Frank Energie"
+        model = vehicle.information.model if (vehicle and vehicle.information) else "Vehicle"
+        name = f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vehicle_id)},
+            manufacturer=brand,
+            model=model,
+            name=name,
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the current datetime setting."""
+        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
+        if not enode_vehicles or not enode_vehicles.vehicles:
+            return None
+        vehicle = next((v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None)
+        if not vehicle or not vehicle.charge_settings:
+            return None
+        return vehicle.charge_settings.deadline
+
+    async def async_set_value(self, value: datetime) -> None:
+        """Set the charging deadline datetime."""
+        _LOGGER.warning(
+            "Changing the EV charging deadline to %s is currently unverified. Captured GraphQL mutations are required.",
+            value,
+        )

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -1,4 +1,5 @@
 """Datetime platform for Frank Energie integration."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -26,7 +27,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Frank Energie datetime entities."""
-    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id][
+        "coordinator"
+    ]
     entities: list[DateTimeEntity] = []
 
     if coordinator.api.is_authenticated:
@@ -34,14 +37,18 @@ async def async_setup_entry(
         if enode_vehicles and enode_vehicles.vehicles:
             for vehicle in enode_vehicles.vehicles:
                 entities.append(
-                    FrankEnergieVehicleDeadlineEntity(coordinator, config_entry, vehicle.id)
+                    FrankEnergieVehicleDeadlineEntity(
+                        coordinator, config_entry, vehicle.id
+                    )
                 )
 
     if entities:
         async_add_entities(entities)
 
 
-class FrankEnergieVehicleDeadlineEntity(CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity):
+class FrankEnergieVehicleDeadlineEntity(
+    CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity
+):
     """Representation of an editable EV charging deadline/departure time."""
 
     _attr_has_entity_name = True
@@ -65,11 +72,23 @@ class FrankEnergieVehicleDeadlineEntity(CoordinatorEntity[FrankEnergieCoordinato
         enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
         vehicle = None
         if enode_vehicles and enode_vehicles.vehicles:
-            vehicle = next((v for v in enode_vehicles.vehicles if v.id == vehicle_id), None)
+            vehicle = next(
+                (v for v in enode_vehicles.vehicles if v.id == vehicle_id), None
+            )
 
-        brand = vehicle.information.brand if (vehicle and vehicle.information) else "Frank Energie"
-        model = vehicle.information.model if (vehicle and vehicle.information) else "Vehicle"
-        name = f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+        brand = (
+            vehicle.information.brand
+            if (vehicle and vehicle.information)
+            else "Frank Energie"
+        )
+        model = (
+            vehicle.information.model
+            if (vehicle and vehicle.information)
+            else "Vehicle"
+        )
+        name = (
+            f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+        )
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vehicle_id)},
@@ -84,7 +103,9 @@ class FrankEnergieVehicleDeadlineEntity(CoordinatorEntity[FrankEnergieCoordinato
         enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
         if not enode_vehicles or not enode_vehicles.vehicles:
             return None
-        vehicle = next((v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None)
+        vehicle = next(
+            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
+        )
         if not vehicle or not vehicle.charge_settings:
             return None
         return vehicle.charge_settings.deadline

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -63,6 +63,8 @@ from .const import (
     DATA_ELECTRICITY,
     DATA_ENODE_CHARGERS,
     DATA_ENODE_VEHICLES,
+    DATA_PV_SYSTEMS,
+    DATA_PV_SUMMARY,
     DATA_GAS,
     DATA_INVOICES,
     DATA_MONTH_SUMMARY,
@@ -586,6 +588,90 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
         """Update stored data for the sensor."""
         self._vehicle_data = data
         self.async_write_ha_state()
+
+
+class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEntity):
+    """Representation of a Frank Energie Smart PV sensor."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        system_id: str,
+        sensor_type: str,  # "total_bonus", "operational_status", "steering_status"
+    ) -> None:
+        """Initialize the PV sensor."""
+        super().__init__(coordinator)
+        self._system_id = system_id
+        self._sensor_type = sensor_type
+
+        # Find the PV system in the coordinator data to get metadata (brand, model, name)
+        systems_obj = coordinator.data.get(DATA_PV_SYSTEMS)
+        pv_system = None
+        if systems_obj and systems_obj.systems:
+            pv_system = next((s for s in systems_obj.systems if s.id == system_id), None)
+
+        brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
+        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
+        display_name = pv_system.display_name if (pv_system and pv_system.display_name) else f"Smart PV {system_id}"
+        serial_number = (
+            pv_system.inverter_serial_numbers[0]
+            if pv_system and pv_system.inverter_serial_numbers
+            else None
+        )
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, system_id)},
+            manufacturer=brand,
+            model=model,
+            name=display_name,
+            serial_number=serial_number,
+        )
+
+        self._attr_unique_id = f"{DOMAIN}_{system_id}_{sensor_type}"
+        self._attr_translation_key = f"pv_{sensor_type}"
+
+        if sensor_type == "total_bonus":
+            self._attr_name = "Total bonus"
+            self._attr_native_unit_of_measurement = CURRENCY_EURO
+            self._attr_device_class = SensorDeviceClass.MONETARY
+            self._attr_state_class = SensorStateClass.TOTAL
+            self._attr_icon = "mdi:currency-eur"
+            self._attr_suggested_display_precision = 2
+        elif sensor_type == "operational_status":
+            self._attr_name = "Operational status"
+            self._attr_icon = "mdi:information-outline"
+        elif sensor_type == "steering_status":
+            self._attr_name = "Steering status"
+            self._attr_icon = "mdi:solar-power"
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        summary_dict = self.coordinator.data.get(DATA_PV_SUMMARY)
+        if not summary_dict:
+            return None
+        summary = summary_dict.get(self._system_id)
+        if not summary:
+            return None
+
+        if self._sensor_type == "total_bonus":
+            return summary.total_bonus
+        if self._sensor_type == "operational_status":
+            return summary.operational_status
+        if self._sensor_type == "steering_status":
+            if summary.steering_status is not None:
+                return summary.steering_status
+            systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
+            if systems_obj and systems_obj.systems:
+                pv_system = next((s for s in systems_obj.systems if s.id == self._system_id), None)
+                if pv_system:
+                    return pv_system.steering_status
+            return None
+
+        return None
 
 
 def format_user_name(data: dict) -> str | None:
@@ -5419,6 +5505,17 @@ async def async_setup_entry(
             _LOGGER.debug("Toegevoegde voertuig sensor: %s", entity.name)
 
         entities.extend(enode_vehicle_sensors)
+
+    pv_systems = coordinator.data.get(DATA_PV_SYSTEMS)
+    if pv_systems and pv_systems.systems:
+        _LOGGER.debug("Setting up smart PV sensors for %d systems", len(pv_systems.systems))
+        for system in pv_systems.systems:
+            if system:
+                entities.extend([
+                    FrankEnergiePvSensor(coordinator, system.id, "total_bonus"),
+                    FrankEnergiePvSensor(coordinator, system.id, "operational_status"),
+                    FrankEnergiePvSensor(coordinator, system.id, "steering_status"),
+                ])
 
     try:
         async_add_entities(entities, update_before_add=True)

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -607,27 +607,15 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
         self._system_id = system_id
         self._sensor_type = sensor_type
 
-        # Find the PV system in the coordinator data to get metadata (brand, model, name)
-        systems_obj = coordinator.data.get(DATA_PV_SYSTEMS)
-        pv_system = None
-        if systems_obj and systems_obj.systems:
-            pv_system = next((s for s in systems_obj.systems if s.id == system_id), None)
-
-        brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
-        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
-        display_name = pv_system.display_name if (pv_system and pv_system.display_name) else f"Smart PV {system_id}"
-        serial_number = (
-            pv_system.inverter_serial_numbers[0]
-            if pv_system and pv_system.inverter_serial_numbers
-            else None
-        )
+        # Get PV system metadata (brand, model, name, serial_number)
+        metadata = coordinator.get_pv_system_metadata(system_id)
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, system_id)},
-            manufacturer=brand,
-            model=model,
-            name=display_name,
-            serial_number=serial_number,
+            manufacturer=metadata["brand"],
+            model=metadata["model"],
+            name=metadata["display_name"],
+            serial_number=metadata["serial_number"],
         )
 
         self._attr_unique_id = f"{DOMAIN}_{system_id}_{sensor_type}"
@@ -666,7 +654,9 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
                 return summary.steering_status
             systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
             if systems_obj and systems_obj.systems:
-                pv_system = next((s for s in systems_obj.systems if s.id == self._system_id), None)
+                pv_system = next(
+                    (s for s in systems_obj.systems if s.id == self._system_id), None
+                )
                 if pv_system:
                     return pv_system.steering_status
             return None
@@ -5508,14 +5498,20 @@ async def async_setup_entry(
 
     pv_systems = coordinator.data.get(DATA_PV_SYSTEMS)
     if pv_systems and pv_systems.systems:
-        _LOGGER.debug("Setting up smart PV sensors for %d systems", len(pv_systems.systems))
+        _LOGGER.debug(
+            "Setting up smart PV sensors for %d systems", len(pv_systems.systems)
+        )
         for system in pv_systems.systems:
             if system:
-                entities.extend([
-                    FrankEnergiePvSensor(coordinator, system.id, "total_bonus"),
-                    FrankEnergiePvSensor(coordinator, system.id, "operational_status"),
-                    FrankEnergiePvSensor(coordinator, system.id, "steering_status"),
-                ])
+                entities.extend(
+                    [
+                        FrankEnergiePvSensor(coordinator, system.id, "total_bonus"),
+                        FrankEnergiePvSensor(
+                            coordinator, system.id, "operational_status"
+                        ),
+                        FrankEnergiePvSensor(coordinator, system.id, "steering_status"),
+                    ]
+                )
 
     try:
         async_add_entities(entities, update_before_add=True)

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -27,7 +27,10 @@
       },
       "site": {
         "title": "Selecteer leveringslocatie",
-        "description": "Kies de leveringslocatie die je toe wilt voegen."
+        "description": "Kies de leveringslocatie die je toe wilt voegen.",
+        "data": {
+          "site_reference": "Leveringslocatie"
+        }
       }
     },
     "error": {
@@ -39,6 +42,41 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "pv_total_bonus": {
+        "name": "Total bonus"
+      },
+      "pv_operational_status": {
+        "name": "Operational status"
+      },
+      "pv_steering_status": {
+        "name": "Steering status"
+      }
+    },
+    "switch": {
+      "smart_charging": {
+        "name": "Smart charging"
+      },
+      "smart_trading": {
+        "name": "Smart trading"
+      },
+      "smart_feed_in": {
+        "name": "Smart feed-in"
+      },
+      "self_consumption_trading_allowed": {
+        "name": "Self consumption trading allowed"
+      },
+      "pv_steering_enabled": {
+        "name": "Steering enabled"
+      }
+    },
+    "datetime": {
+      "charging_deadline": {
+        "name": "Charging deadline"
+      }
     }
   }
 }

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for Frank Energie integration."""
+
 from __future__ import annotations
 
 import logging
@@ -31,7 +32,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Frank Energie switches."""
-    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id][
+        "coordinator"
+    ]
     entities: list[SwitchEntity] = []
 
     # If the user is authenticated, set up user-level smart charging & trading switches
@@ -45,7 +48,9 @@ async def async_setup_entry(
         if batteries and batteries.batteries:
             for battery in batteries.batteries:
                 entities.append(
-                    FrankEnergieBatteryTradingSwitch(coordinator, config_entry, battery.id)
+                    FrankEnergieBatteryTradingSwitch(
+                        coordinator, config_entry, battery.id
+                    )
                 )
 
         # Check for PV systems
@@ -60,7 +65,9 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class FrankEnergieSmartChargingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+class FrankEnergieSmartChargingSwitch(
+    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
+):
     """Switch to toggle smart charging on/off."""
 
     _attr_has_entity_name = True
@@ -97,14 +104,20 @@ class FrankEnergieSmartChargingSwitch(CoordinatorEntity[FrankEnergieCoordinator]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        _LOGGER.warning("Turning on Smart Charging is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning on Smart Charging is currently unverified. Captured GraphQL mutations are required."
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        _LOGGER.warning("Turning off Smart Charging is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning off Smart Charging is currently unverified. Captured GraphQL mutations are required."
+        )
 
 
-class FrankEnergieSmartTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+class FrankEnergieSmartTradingSwitch(
+    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
+):
     """Switch to toggle smart trading on/off."""
 
     _attr_has_entity_name = True
@@ -141,14 +154,20 @@ class FrankEnergieSmartTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator],
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        _LOGGER.warning("Turning on Smart Trading is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning on Smart Trading is currently unverified. Captured GraphQL mutations are required."
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        _LOGGER.warning("Turning off Smart Trading is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning off Smart Trading is currently unverified. Captured GraphQL mutations are required."
+        )
 
 
-class FrankEnergieSmartFeedInSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+class FrankEnergieSmartFeedInSwitch(
+    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
+):
     """Switch to toggle smart feed-in on/off."""
 
     _attr_has_entity_name = True
@@ -184,14 +203,20 @@ class FrankEnergieSmartFeedInSwitch(CoordinatorEntity[FrankEnergieCoordinator], 
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        _LOGGER.warning("Turning on Smart Feed-in is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning on Smart Feed-in is currently unverified. Captured GraphQL mutations are required."
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        _LOGGER.warning("Turning off Smart Feed-in is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning off Smart Feed-in is currently unverified. Captured GraphQL mutations are required."
+        )
 
 
-class FrankEnergieBatteryTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+class FrankEnergieBatteryTradingSwitch(
+    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
+):
     """Switch to toggle self consumption battery trading on/off."""
 
     _attr_has_entity_name = True
@@ -224,7 +249,11 @@ class FrankEnergieBatteryTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator
         if not details_list:
             return None
         for detail in details_list:
-            if detail and getattr(detail, "smart_battery", None) and getattr(detail.smart_battery, "id", None) == self._battery_id:
+            if (
+                detail
+                and getattr(detail, "smart_battery", None)
+                and getattr(detail.smart_battery, "id", None) == self._battery_id
+            ):
                 settings = getattr(detail.smart_battery, "settings", None)
                 if settings:
                     return getattr(settings, "self_consumption_trading_allowed", None)
@@ -232,14 +261,20 @@ class FrankEnergieBatteryTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        _LOGGER.warning("Turning on Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning on Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required."
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        _LOGGER.warning("Turning off Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning off Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required."
+        )
 
 
-class FrankEnergiePvSteeringSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+class FrankEnergiePvSteeringSwitch(
+    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
+):
     """Switch to toggle PV export steering on/off."""
 
     _attr_has_entity_name = True
@@ -259,27 +294,15 @@ class FrankEnergiePvSteeringSwitch(CoordinatorEntity[FrankEnergieCoordinator], S
         self._attr_translation_key = "pv_steering_enabled"
         self._attr_unique_id = f"{DOMAIN}_{system_id}_steering_enabled"
 
-        # Find the PV system in the coordinator data to get metadata (brand, model, name)
-        systems_obj = coordinator.data.get(DATA_PV_SYSTEMS)
-        pv_system = None
-        if systems_obj and systems_obj.systems:
-            pv_system = next((s for s in systems_obj.systems if s.id == system_id), None)
-
-        brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
-        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
-        display_name = pv_system.display_name if (pv_system and pv_system.display_name) else f"Smart PV {system_id}"
-        serial_number = (
-            pv_system.inverter_serial_numbers[0]
-            if pv_system and pv_system.inverter_serial_numbers
-            else None
-        )
+        # Get PV system metadata (brand, model, name, serial_number)
+        metadata = coordinator.get_pv_system_metadata(system_id)
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, system_id)},
-            manufacturer=brand,
-            model=model,
-            name=display_name,
-            serial_number=serial_number,
+            manufacturer=metadata["brand"],
+            model=metadata["model"],
+            name=metadata["display_name"],
+            serial_number=metadata["serial_number"],
         )
 
     @property
@@ -295,7 +318,9 @@ class FrankEnergiePvSteeringSwitch(CoordinatorEntity[FrankEnergieCoordinator], S
         if status is None:
             systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
             if systems_obj and systems_obj.systems:
-                pv_system = next((s for s in systems_obj.systems if s.id == self._system_id), None)
+                pv_system = next(
+                    (s for s in systems_obj.systems if s.id == self._system_id), None
+                )
                 if pv_system:
                     status = getattr(pv_system, "steering_status", None)
 
@@ -307,8 +332,12 @@ class FrankEnergiePvSteeringSwitch(CoordinatorEntity[FrankEnergieCoordinator], S
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        _LOGGER.warning("Turning on PV Steering is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning on PV Steering is currently unverified. Captured GraphQL mutations are required."
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        _LOGGER.warning("Turning off PV Steering is currently unverified. Captured GraphQL mutations are required.")
+        _LOGGER.warning(
+            "Turning off PV Steering is currently unverified. Captured GraphQL mutations are required."
+        )

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -1,0 +1,314 @@
+"""Switch platform for Frank Energie integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    DATA_USER,
+    DATA_BATTERIES,
+    DATA_BATTERY_DETAILS,
+    DATA_USER_SMART_FEED_IN,
+    DATA_PV_SYSTEMS,
+    DATA_PV_SUMMARY,
+)
+from .coordinator import FrankEnergieCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Frank Energie switches."""
+    coordinator: FrankEnergieCoordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    entities: list[SwitchEntity] = []
+
+    # If the user is authenticated, set up user-level smart charging & trading switches
+    if coordinator.api.is_authenticated:
+        entities.append(FrankEnergieSmartChargingSwitch(coordinator, config_entry))
+        entities.append(FrankEnergieSmartTradingSwitch(coordinator, config_entry))
+        entities.append(FrankEnergieSmartFeedInSwitch(coordinator, config_entry))
+
+        # Check for batteries
+        batteries = coordinator.data.get(DATA_BATTERIES)
+        if batteries and batteries.batteries:
+            for battery in batteries.batteries:
+                entities.append(
+                    FrankEnergieBatteryTradingSwitch(coordinator, config_entry, battery.id)
+                )
+
+        # Check for PV systems
+        pv_systems = coordinator.data.get(DATA_PV_SYSTEMS)
+        if pv_systems and pv_systems.systems:
+            for system in pv_systems.systems:
+                entities.append(
+                    FrankEnergiePvSteeringSwitch(coordinator, config_entry, system.id)
+                )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class FrankEnergieSmartChargingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+    """Switch to toggle smart charging on/off."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:car-electric"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_name = "Smart charging"
+        self._attr_translation_key = "smart_charging"
+        self._attr_unique_id = f"{config_entry.entry_id}_smart_charging"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
+            name="Frank Energie - User",
+            manufacturer="Frank Energie",
+            model="User",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return None
+        smart_charging = user_data.smartCharging
+        if isinstance(smart_charging, dict):
+            return smart_charging.get("isActivated", False)
+        return getattr(smart_charging, "isActivated", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        _LOGGER.warning("Turning on Smart Charging is currently unverified. Captured GraphQL mutations are required.")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        _LOGGER.warning("Turning off Smart Charging is currently unverified. Captured GraphQL mutations are required.")
+
+
+class FrankEnergieSmartTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+    """Switch to toggle smart trading on/off."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:battery-sync"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_name = "Smart trading"
+        self._attr_translation_key = "smart_trading"
+        self._attr_unique_id = f"{config_entry.entry_id}_smart_trading"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
+            name="Frank Energie - User",
+            manufacturer="Frank Energie",
+            model="User",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return None
+        smart_trading = user_data.smartTrading
+        if isinstance(smart_trading, dict):
+            return smart_trading.get("isActivated", False)
+        return getattr(smart_trading, "isActivated", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        _LOGGER.warning("Turning on Smart Trading is currently unverified. Captured GraphQL mutations are required.")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        _LOGGER.warning("Turning off Smart Trading is currently unverified. Captured GraphQL mutations are required.")
+
+
+class FrankEnergieSmartFeedInSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+    """Switch to toggle smart feed-in on/off."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:solar-power-variant"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_name = "Smart feed-in"
+        self._attr_translation_key = "smart_feed_in"
+        self._attr_unique_id = f"{config_entry.entry_id}_smart_feed_in"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
+            name="Frank Energie - User",
+            manufacturer="Frank Energie",
+            model="User",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        feed_in_status = self.coordinator.data.get(DATA_USER_SMART_FEED_IN)
+        if not feed_in_status:
+            return None
+        if isinstance(feed_in_status, dict):
+            return feed_in_status.get("isActivated", False)
+        return getattr(feed_in_status, "is_activated", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        _LOGGER.warning("Turning on Smart Feed-in is currently unverified. Captured GraphQL mutations are required.")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        _LOGGER.warning("Turning off Smart Feed-in is currently unverified. Captured GraphQL mutations are required.")
+
+
+class FrankEnergieBatteryTradingSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+    """Switch to toggle self consumption battery trading on/off."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:home-battery"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        battery_id: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._battery_id = battery_id
+        self._attr_name = "Self consumption trading allowed"
+        self._attr_translation_key = "self_consumption_trading_allowed"
+        self._attr_unique_id = f"{DOMAIN}_{battery_id}_self_consumption_trading_allowed"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, battery_id)},
+            name=f"Smart Battery {battery_id}",
+            manufacturer="Frank Energie",
+            model="SmartBattery",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        details_list = self.coordinator.data.get(DATA_BATTERY_DETAILS)
+        if not details_list:
+            return None
+        for detail in details_list:
+            if detail and getattr(detail, "smart_battery", None) and getattr(detail.smart_battery, "id", None) == self._battery_id:
+                settings = getattr(detail.smart_battery, "settings", None)
+                if settings:
+                    return getattr(settings, "self_consumption_trading_allowed", None)
+        return None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        _LOGGER.warning("Turning on Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required.")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        _LOGGER.warning("Turning off Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required.")
+
+
+class FrankEnergiePvSteeringSwitch(CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity):
+    """Switch to toggle PV export steering on/off."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:solar-power"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        system_id: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._system_id = system_id
+        self._attr_name = "Steering enabled"
+        self._attr_translation_key = "pv_steering_enabled"
+        self._attr_unique_id = f"{DOMAIN}_{system_id}_steering_enabled"
+
+        # Find the PV system in the coordinator data to get metadata (brand, model, name)
+        systems_obj = coordinator.data.get(DATA_PV_SYSTEMS)
+        pv_system = None
+        if systems_obj and systems_obj.systems:
+            pv_system = next((s for s in systems_obj.systems if s.id == system_id), None)
+
+        brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
+        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
+        display_name = pv_system.display_name if (pv_system and pv_system.display_name) else f"Smart PV {system_id}"
+        serial_number = (
+            pv_system.inverter_serial_numbers[0]
+            if pv_system and pv_system.inverter_serial_numbers
+            else None
+        )
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, system_id)},
+            manufacturer=brand,
+            model=model,
+            name=display_name,
+            serial_number=serial_number,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        summary_dict = self.coordinator.data.get(DATA_PV_SUMMARY)
+        status = None
+        if summary_dict:
+            summary = summary_dict.get(self._system_id)
+            if summary:
+                status = getattr(summary, "steering_status", None)
+
+        if status is None:
+            systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
+            if systems_obj and systems_obj.systems:
+                pv_system = next((s for s in systems_obj.systems if s.id == self._system_id), None)
+                if pv_system:
+                    status = getattr(pv_system, "steering_status", None)
+
+        if status is None:
+            return None
+
+        # Return True if active/steering
+        return str(status).upper() in {"ACTIVE", "STEERING"}
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        _LOGGER.warning("Turning on PV Steering is currently unverified. Captured GraphQL mutations are required.")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        _LOGGER.warning("Turning off PV Steering is currently unverified. Captured GraphQL mutations are required.")

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -26,6 +26,48 @@
                 },
                 "title": "Do you want to sign in to Frank Energie?",
                 "description": "Signing in is not required for obtaining energy price data but will add additional sensors specific to your account."
+            },
+            "site": {
+                "title": "Select delivery location",
+                "description": "Choose the delivery location you want to add.",
+                "data": {
+                    "site_reference": "Delivery location"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pv_total_bonus": {
+                "name": "Total bonus"
+            },
+            "pv_operational_status": {
+                "name": "Operational status"
+            },
+            "pv_steering_status": {
+                "name": "Steering status"
+            }
+        },
+        "switch": {
+            "smart_charging": {
+                "name": "Smart charging"
+            },
+            "smart_trading": {
+                "name": "Smart trading"
+            },
+            "smart_feed_in": {
+                "name": "Smart feed-in"
+            },
+            "self_consumption_trading_allowed": {
+                "name": "Self consumption trading allowed"
+            },
+            "pv_steering_enabled": {
+                "name": "Steering enabled"
+            }
+        },
+        "datetime": {
+            "charging_deadline": {
+                "name": "Charging deadline"
             }
         }
     }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -574,6 +574,37 @@
             },
             "mini_cooper_vehicle_name": {
                 "name": "Naam voertuig"
+            },
+            "pv_total_bonus": {
+                "name": "Totale bonus"
+            },
+            "pv_operational_status": {
+                "name": "Operationele status"
+            },
+            "pv_steering_status": {
+                "name": "Sturingsstatus"
+            }
+        },
+        "switch": {
+            "smart_charging": {
+                "name": "Slim laden"
+            },
+            "smart_trading": {
+                "name": "Slim handelen"
+            },
+            "smart_feed_in": {
+                "name": "Slim terugleveren"
+            },
+            "self_consumption_trading_allowed": {
+                "name": "Handelen op eigen verbruik toegestaan"
+            },
+            "pv_steering_enabled": {
+                "name": "Sturing ingeschakeld"
+            }
+        },
+        "datetime": {
+            "charging_deadline": {
+                "name": "Vertrektijd"
             }
         }
     }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -121,6 +121,9 @@ async def test_fetch_today_data(coordinator, mock_frank_energie):
         data_smart_battery_details,
         data_smart_battery_sessions,
         data_enode_vehicles,
+        data_pv_systems,
+        data_pv_summary,
+        data_user_smart_feed_in,
         data_contract_price_resolution_state,
     ) = data
 
@@ -166,6 +169,9 @@ async def test_aggregate_data(coordinator):
         data_month_summary,
         data_invoices,
         data_user,
+        None,
+        None,
+        None,
         None,
         None,
         None,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -48,15 +48,11 @@ def test_smart_charging_switch(mock_coordinator, mock_config_entry):
     assert switch.is_on is None
 
     # Test when active (dict payload)
-    mock_coordinator.data = {
-        DATA_USER: MagicMock(smartCharging={"isActivated": True})
-    }
+    mock_coordinator.data = {DATA_USER: MagicMock(smartCharging={"isActivated": True})}
     assert switch.is_on is True
 
     # Test when inactive (dict payload)
-    mock_coordinator.data = {
-        DATA_USER: MagicMock(smartCharging={"isActivated": False})
-    }
+    mock_coordinator.data = {DATA_USER: MagicMock(smartCharging={"isActivated": False})}
     assert switch.is_on is False
 
     # Test with object attribute
@@ -76,15 +72,11 @@ def test_smart_trading_switch(mock_coordinator, mock_config_entry):
     assert switch.is_on is None
 
     # Test when active (dict payload)
-    mock_coordinator.data = {
-        DATA_USER: MagicMock(smartTrading={"isActivated": True})
-    }
+    mock_coordinator.data = {DATA_USER: MagicMock(smartTrading={"isActivated": True})}
     assert switch.is_on is True
 
     # Test when inactive (dict payload)
-    mock_coordinator.data = {
-        DATA_USER: MagicMock(smartTrading={"isActivated": False})
-    }
+    mock_coordinator.data = {DATA_USER: MagicMock(smartTrading={"isActivated": False})}
     assert switch.is_on is False
 
 
@@ -97,9 +89,7 @@ def test_smart_feed_in_switch(mock_coordinator, mock_config_entry):
     assert switch.is_on is None
 
     # Test when active (dict payload)
-    mock_coordinator.data = {
-        DATA_USER_SMART_FEED_IN: {"isActivated": True}
-    }
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": True}}
     assert switch.is_on is True
 
     # Test when inactive (object payload)
@@ -112,7 +102,9 @@ def test_smart_feed_in_switch(mock_coordinator, mock_config_entry):
 def test_battery_trading_switch(mock_coordinator, mock_config_entry):
     """Test the battery self-consumption trading switch is_on property."""
     battery_id = "test_battery_id"
-    switch = FrankEnergieBatteryTradingSwitch(mock_coordinator, mock_config_entry, battery_id)
+    switch = FrankEnergieBatteryTradingSwitch(
+        mock_coordinator, mock_config_entry, battery_id
+    )
 
     # Test when details are missing
     mock_coordinator.data = {}
@@ -136,7 +128,7 @@ def test_battery_trading_switch(mock_coordinator, mock_config_entry):
 def test_pv_steering_switch(mock_coordinator, mock_config_entry):
     """Test the PV steering switch is_on property."""
     system_id = "pv_sys_1"
-    
+
     # Mock systems_obj for constructor
     mock_system = MagicMock(spec=SmartPvSystem)
     mock_system.id = system_id
@@ -144,19 +136,21 @@ def test_pv_steering_switch(mock_coordinator, mock_config_entry):
     mock_system.model = "SE3000"
     mock_system.display_name = "Tuin PV"
     mock_system.inverter_serial_numbers = ["SE123456"]
-    
+
     mock_systems = MagicMock(spec=SmartPvSystems)
     mock_systems.systems = [mock_system]
     mock_coordinator.data = {DATA_PV_SYSTEMS: mock_systems}
 
-    switch = FrankEnergiePvSteeringSwitch(mock_coordinator, mock_config_entry, system_id)
+    switch = FrankEnergiePvSteeringSwitch(
+        mock_coordinator, mock_config_entry, system_id
+    )
 
     # Test when summary says active
     mock_summary = MagicMock(spec=SmartPvSystemSummary)
     mock_summary.steering_status = "ACTIVE"
     mock_coordinator.data = {
         DATA_PV_SYSTEMS: mock_systems,
-        DATA_PV_SUMMARY: {system_id: mock_summary}
+        DATA_PV_SUMMARY: {system_id: mock_summary},
     }
     assert switch.is_on is True
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,193 @@
+import pytest
+from unittest.mock import MagicMock
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.frank_energie.const import (
+    DOMAIN,
+    DATA_USER,
+    DATA_USER_SMART_FEED_IN,
+    DATA_BATTERY_DETAILS,
+    DATA_PV_SYSTEMS,
+    DATA_PV_SUMMARY,
+)
+from custom_components.frank_energie.switch import (
+    FrankEnergieSmartChargingSwitch,
+    FrankEnergieSmartTradingSwitch,
+    FrankEnergieSmartFeedInSwitch,
+    FrankEnergieBatteryTradingSwitch,
+    FrankEnergiePvSteeringSwitch,
+)
+from python_frank_energie.models import (
+    User,
+    UserSmartFeedInStatus,
+    SmartBatteryDetails,
+    SmartPvSystems,
+    SmartPvSystem,
+    SmartPvSystemSummary,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    coordinator = MagicMock()
+    coordinator.data = {}
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def test_smart_charging_switch(mock_coordinator, mock_config_entry):
+    """Test the smart charging switch is_on property."""
+    switch = FrankEnergieSmartChargingSwitch(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert switch.is_on is None
+
+    # Test when active (dict payload)
+    mock_coordinator.data = {
+        DATA_USER: MagicMock(smartCharging={"isActivated": True})
+    }
+    assert switch.is_on is True
+
+    # Test when inactive (dict payload)
+    mock_coordinator.data = {
+        DATA_USER: MagicMock(smartCharging={"isActivated": False})
+    }
+    assert switch.is_on is False
+
+    # Test with object attribute
+    mock_user = MagicMock()
+    mock_user.smartCharging = MagicMock()
+    mock_user.smartCharging.isActivated = True
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert switch.is_on is True
+
+
+def test_smart_trading_switch(mock_coordinator, mock_config_entry):
+    """Test the smart trading switch is_on property."""
+    switch = FrankEnergieSmartTradingSwitch(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert switch.is_on is None
+
+    # Test when active (dict payload)
+    mock_coordinator.data = {
+        DATA_USER: MagicMock(smartTrading={"isActivated": True})
+    }
+    assert switch.is_on is True
+
+    # Test when inactive (dict payload)
+    mock_coordinator.data = {
+        DATA_USER: MagicMock(smartTrading={"isActivated": False})
+    }
+    assert switch.is_on is False
+
+
+def test_smart_feed_in_switch(mock_coordinator, mock_config_entry):
+    """Test the smart feed-in switch is_on property."""
+    switch = FrankEnergieSmartFeedInSwitch(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert switch.is_on is None
+
+    # Test when active (dict payload)
+    mock_coordinator.data = {
+        DATA_USER_SMART_FEED_IN: {"isActivated": True}
+    }
+    assert switch.is_on is True
+
+    # Test when inactive (object payload)
+    mock_feed_in = MagicMock(spec=UserSmartFeedInStatus)
+    mock_feed_in.is_activated = False
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: mock_feed_in}
+    assert switch.is_on is False
+
+
+def test_battery_trading_switch(mock_coordinator, mock_config_entry):
+    """Test the battery self-consumption trading switch is_on property."""
+    battery_id = "test_battery_id"
+    switch = FrankEnergieBatteryTradingSwitch(mock_coordinator, mock_config_entry, battery_id)
+
+    # Test when details are missing
+    mock_coordinator.data = {}
+    assert switch.is_on is None
+
+    # Test when details have our battery, with setting active
+    mock_detail = MagicMock(spec=SmartBatteryDetails)
+    mock_detail.smart_battery = MagicMock()
+    mock_detail.smart_battery.id = battery_id
+    mock_detail.smart_battery.settings = MagicMock()
+    mock_detail.smart_battery.settings.self_consumption_trading_allowed = True
+
+    mock_coordinator.data = {DATA_BATTERY_DETAILS: [mock_detail]}
+    assert switch.is_on is True
+
+    # Test when details have a different battery id
+    mock_detail.smart_battery.id = "other_battery"
+    assert switch.is_on is None
+
+
+def test_pv_steering_switch(mock_coordinator, mock_config_entry):
+    """Test the PV steering switch is_on property."""
+    system_id = "pv_sys_1"
+    
+    # Mock systems_obj for constructor
+    mock_system = MagicMock(spec=SmartPvSystem)
+    mock_system.id = system_id
+    mock_system.brand = "SolarEdge"
+    mock_system.model = "SE3000"
+    mock_system.display_name = "Tuin PV"
+    mock_system.inverter_serial_numbers = ["SE123456"]
+    
+    mock_systems = MagicMock(spec=SmartPvSystems)
+    mock_systems.systems = [mock_system]
+    mock_coordinator.data = {DATA_PV_SYSTEMS: mock_systems}
+
+    switch = FrankEnergiePvSteeringSwitch(mock_coordinator, mock_config_entry, system_id)
+
+    # Test when summary says active
+    mock_summary = MagicMock(spec=SmartPvSystemSummary)
+    mock_summary.steering_status = "ACTIVE"
+    mock_coordinator.data = {
+        DATA_PV_SYSTEMS: mock_systems,
+        DATA_PV_SUMMARY: {system_id: mock_summary}
+    }
+    assert switch.is_on is True
+
+    # Test when summary says stopped, but system list says active
+    mock_summary.steering_status = "STOPPED"
+    mock_system.steering_status = "ACTIVE"
+    assert switch.is_on is False
+
+    # Test fallback to systems_obj when summary has no steering_status
+    mock_summary.steering_status = None
+    mock_system.steering_status = "STEERING"
+    assert switch.is_on is True
+
+    mock_system.steering_status = "INACTIVE"
+    assert switch.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_switch_actions(mock_coordinator, mock_config_entry):
+    """Test that turn_on and turn_off methods run without exceptions (logging warnings)."""
+    switches = [
+        FrankEnergieSmartChargingSwitch(mock_coordinator, mock_config_entry),
+        FrankEnergieSmartTradingSwitch(mock_coordinator, mock_config_entry),
+        FrankEnergieSmartFeedInSwitch(mock_coordinator, mock_config_entry),
+        FrankEnergieBatteryTradingSwitch(mock_coordinator, mock_config_entry, "bat1"),
+        FrankEnergiePvSteeringSwitch(mock_coordinator, mock_config_entry, "pv1"),
+    ]
+
+    for switch in switches:
+        await switch.async_turn_on()
+        await switch.async_turn_off()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,10 +1,8 @@
 import pytest
 from unittest.mock import MagicMock
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from custom_components.frank_energie.const import (
-    DOMAIN,
     DATA_USER,
     DATA_USER_SMART_FEED_IN,
     DATA_BATTERY_DETAILS,
@@ -19,7 +17,6 @@ from custom_components.frank_energie.switch import (
     FrankEnergiePvSteeringSwitch,
 )
 from python_frank_energie.models import (
-    User,
     UserSmartFeedInStatus,
     SmartBatteryDetails,
     SmartPvSystems,


### PR DESCRIPTION
# Summary
This Pull Request implements Smart PV (Solar) sensors, automated PV steering controls, user-level toggles for Smart Charging/Trading/Feed-In, and an editable EV charging deadline in the Frank Energie Home Assistant integration.

# Key Changes
- **Smart PV Sensors**: Registered brand-new monetary and status sensors (`pv_total_bonus`, `pv_operational_status`, `pv_steering_status`) mapping individual solar installations in [sensor.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/sensor.py).
- **Control Switches**: Implemented five new switch entities under [switch.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/switch.py):
  - `FrankEnergieSmartChargingSwitch`: Toggles automated smart charging on/off.
  - `FrankEnergieSmartTradingSwitch`: Toggles automated smart trading on/off.
  - `FrankEnergieSmartFeedInSwitch`: Toggles automated smart feed-in on/off.
  - `FrankEnergieSelfConsumptionTradingAllowedSwitch`: Toggles self-consumption trading permission for smart batteries.
  - `FrankEnergiePvSteeringSwitch`: Toggles system-level PV steering (automated inverter throttling).
- **EV Charging Deadline**: Added an editable datetime entity (`FrankEnergieVehicleDeadlineEntity`) in [datetime.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/datetime.py) allowing users to configure the departure time/charge deadline directly from the UI.
- **Data Coordination**: Updated [coordinator.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/coordinator.py) to parse and cache user smart feed-in status, PV systems, and summaries. Removed the development-only mock Tesla Model 3 block to ensure production safety.
- **Localization**: Added translation strings for all new entities in both English ([en.json](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/translations/en.json)) and Dutch ([nl.json](file:///Users/darrynstorm/Git/home-assistant-frank_energie/custom_components/frank_energie/translations/nl.json)).
- **Unit Tests**: Added robust coverage for all new switches and entity platforms in [test_switch.py](file:///Users/darrynstorm/Git/home-assistant-frank_energie/tests/test_switch.py).

# Why this is needed
These changes allow Home Assistant users to monitor their solar installations' performance, toggle automated steering/trading strategies directly, and configure smart charging deadlines in accordance with Frank Energie's ecosystem updates.

# Dependencies
- Depends on the updated GraphQL mappings in the API wrapper PR: https://github.com/HiDiHo01/python-frank-energie/pull/79.

Closes: #9, #54, #57

## Summary by Sourcery

Slimme PV-monitoring en -sturing, slimme functieschakelaars en ondersteuning voor eindtijd voor EV-laden toevoegen aan de Frank Energie Home Assistant-integratie.

Nieuwe functionaliteit:
- Slimme PV-sensoren per zonnestroomsysteem beschikbaar maken voor totale bonus, operationele status en stuurstatus.
- Schakelaars op gebruikersniveau toevoegen voor slim laden, slimme handel, slim terugleveren, handelsrechten per batterij en sturing per PV-systeem.
- Een bewerkbare datetime-entiteit voor de eindtijd van EV-laden per verbonden voertuig introduceren.

Bugfixes:
- Zorgen dat Enode-voertuigen worden opgehaald zodra de API is geauthenticeerd, niet alleen wanneer slim laden is ingeschakeld.
- Controles voor het activeren van slim laden en slimme handel compatibel maken met zowel dict- als objectvormige API-responses.

Verbeteringen:
- De datacoördinator en het datamodel uitbreiden om Smart PV-systemen, PV-samenvattingen en de slimme terugleverstatus van de gebruiker op te halen en te aggregeren.
- Extra Home Assistant-platformen (switch en datetime) voor de integratie registreren en aansluiten in de setup.
- Lokalisatie-items voor de nieuwe entiteiten toevoegen aan de Engelse en Nederlandse vertalingen.

Tests:
- Unittests toevoegen voor de nieuwe switch-entiteiten en hun logica voor toestandsbepaling.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add smart PV monitoring and control, smart feature switches, and EV charging deadline support to the Frank Energie Home Assistant integration.

New Features:
- Expose Smart PV sensors per solar system for total bonus, operational status, and steering status.
- Provide user-level switches for smart charging, smart trading, smart feed-in, per-battery trading permission, and per-PV-system steering.
- Introduce an editable EV charging deadline datetime entity per connected vehicle.

Bug Fixes:
- Ensure Enode vehicles are fetched whenever the API is authenticated, not only when smart charging is enabled.
- Make smart charging and smart trading activation checks compatible with both dict- and object-shaped API responses.

Enhancements:
- Extend the data coordinator and data model to fetch and aggregate Smart PV systems, PV summaries, and user smart feed-in status.
- Register additional Home Assistant platforms (switch and datetime) for the integration and wire them into setup.
- Add localization entries for the new entities in English and Dutch translations.

Tests:
- Add unit tests covering the new switch entities and their state evaluation logic.

</details>