### PR TITLE
feat: implement smart controls and settings entities

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -19,13 +19,14 @@ from .exceptions import NoSuitableSitesFoundError
 _LOGGER = logging.getLogger(__name__)
 
 # PLATFORMS = [Platform.SENSOR, "frank_energie_diagnostic_sensor"]
-PLATFORMS: list[str] = [
+# Sensor must be listed separately — see _async_forward_entry_setups below.
+_DEPENDENT_PLATFORMS: list[str] = [
     Platform.BINARY_SENSOR,
-    Platform.SENSOR,
     Platform.BUTTON,
     Platform.SWITCH,
     Platform.DATETIME,
 ]
+PLATFORMS: list[str] = [Platform.SENSOR] + _DEPENDENT_PLATFORMS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -198,11 +199,23 @@ entry.options: bevat de gegevens die via een options flow zijn aangepast/nagelev
         return FrankEnergieCoordinator(self.hass, self.entry, api)
 
     async def _async_forward_entry_setups(self) -> None:
-        """Forward entry setups to appropriate platforms."""
+        """Forward entry setups to appropriate platforms.
+
+        The sensor platform is set up first and awaited before the dependent
+        platforms (binary_sensor, button, switch, datetime) run. This ensures
+        all parent service devices (Frank Energie - Batteries, Chargers, etc.)
+        are registered in the device registry before child devices attempt to
+        link to them via via_device.
+        """
         _LOGGER.debug("Starting to forward entry setups to platforms")
         try:
+            # 1. Register all sensor (parent) devices first.
             await self.hass.config_entries.async_forward_entry_setups(
-                self.entry, PLATFORMS
+                self.entry, [Platform.SENSOR]
+            )
+            # 2. Now set up all remaining platforms concurrently.
+            await self.hass.config_entries.async_forward_entry_setups(
+                self.entry, _DEPENDENT_PLATFORMS
             )
             _LOGGER.debug("Successfully forwarded entry setups to platforms")
         except Exception:

--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -50,8 +50,9 @@ class FrankEnergieBinarySensorEntityDescription(
 
     entity_registry_enabled_default: bool = True
 
-    # If set, creates a per-item child device instead of the shared service device.
-    # The child device will have via_device pointing to the service_name device.
+    # If set, creates a per-item device (e.g. individual battery) instead of the
+    # shared service device.  No parent link (via_device) — omitted as it proved
+    # unreliable across HA versions.
     child_device_id: str | None = None
     child_device_name: str | None = None
     child_device_manufacturer: str | None = None
@@ -99,20 +100,14 @@ class FrankEnergieBinarySensor(
         )
 
         if description.child_device_id:
-            # Per-item device (e.g. individual battery) as a child of the service device.
-            # No entry_type here — batteries are physical hardware, not services.
-            parent_id = (
-                f"{config_entry.entry_id}_{description.service_name}"
-                if description.service_name
-                else config_entry.entry_id
-            )
+            # Per-item device (e.g. individual battery). Named from brand/model.
+            # No entry_type — batteries are physical hardware, not services.
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, description.child_device_id)},
                 name=description.child_device_name or description.child_device_id,
                 manufacturer=description.child_device_manufacturer or COMPONENT_TITLE,
                 model=description.service_name,
                 configuration_url=API_CONF_URL,
-                via_device=(DOMAIN, parent_id),
             )
         else:
             self._attr_device_info = DeviceInfo(

--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -16,7 +16,17 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import API_CONF_URL, COMPONENT_TITLE, DOMAIN, SERVICE_NAME_BATTERIES
+from .const import (
+    API_CONF_URL,
+    COMPONENT_TITLE,
+    DOMAIN,
+    DATA_BATTERIES,
+    DATA_BATTERY_DETAILS,
+    DATA_USER,
+    DATA_USER_SMART_FEED_IN,
+    SERVICE_NAME_BATTERIES,
+    SERVICE_NAME_USER,
+)
 from .coordinator import FrankEnergieCoordinator
 from .sensor import SmartBatteriesData
 
@@ -66,7 +76,7 @@ class FrankEnergieBinarySensor(
             if "smart_battery_" in description.key
             else None
         )
-        self._attr_unique_id = f"{config_entry.entry_id}_{description.key}"  # f"{battery_id}_{description.key}"
+        self._attr_unique_id = f"{config_entry.entry_id}_{description.key}"
         self._attr_name = (
             description.name if isinstance(description.name, str) else None
         )
@@ -120,6 +130,174 @@ class FrankEnergieBinarySensor(
         return attr_fn(data)
 
 
+# ---------------------------------------------------------------------------
+# User-level smart feature binary sensors
+# ---------------------------------------------------------------------------
+
+
+class FrankEnergieSmartFeatureBinarySensor(
+    CoordinatorEntity[FrankEnergieCoordinator],
+    BinarySensorEntity,
+):
+    """Read-only binary sensor for a Frank Energie smart feature activation state.
+
+    Used for Smart Charging, Smart Trading, Smart Feed-In, and Smart HVAC.
+    These features can only be enabled via the Frank app (subscription flow),
+    but can be disabled via HA buttons.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        key: str,
+        name: str,
+        icon: str,
+        translation_key: str,
+    ) -> None:
+        """Initialize the smart feature binary sensor."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._key = key
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = f"{config_entry.entry_id}_{key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_USER}")},
+            name=f"{COMPONENT_TITLE} - {SERVICE_NAME_USER}",
+            manufacturer=COMPONENT_TITLE,
+            model=SERVICE_NAME_USER,
+            configuration_url=API_CONF_URL,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    def _get_is_on(self) -> bool | None:
+        """Subclasses implement this to return the activation state."""
+        return None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the activation state of the smart feature."""
+        return self._get_is_on()
+
+
+class FrankEnergieSmartChargingBinarySensor(FrankEnergieSmartFeatureBinarySensor):
+    """Binary sensor for Smart Charging activation state."""
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="smart_charging",
+            name="Smart Charging",
+            icon="mdi:car-electric",
+            translation_key="smart_charging",
+        )
+
+    def _get_is_on(self) -> bool | None:
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return None
+        smart_charging = user_data.smartCharging
+        if isinstance(smart_charging, dict):
+            return smart_charging.get("isActivated", False)
+        return getattr(smart_charging, "isActivated", False)
+
+
+class FrankEnergieSmartTradingBinarySensor(FrankEnergieSmartFeatureBinarySensor):
+    """Binary sensor for Smart Trading activation state."""
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="smart_trading",
+            name="Smart Trading",
+            icon="mdi:battery-sync",
+            translation_key="smart_trading",
+        )
+
+    def _get_is_on(self) -> bool | None:
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return None
+        smart_trading = user_data.smartTrading
+        if isinstance(smart_trading, dict):
+            return smart_trading.get("isActivated", False)
+        return getattr(smart_trading, "isActivated", False)
+
+
+class FrankEnergieSmartFeedInBinarySensor(FrankEnergieSmartFeatureBinarySensor):
+    """Binary sensor for Smart Feed-In activation state."""
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="smart_feed_in",
+            name="Smart Feed-In",
+            icon="mdi:solar-power-variant",
+            translation_key="smart_feed_in",
+        )
+
+    def _get_is_on(self) -> bool | None:
+        feed_in_status = self.coordinator.data.get(DATA_USER_SMART_FEED_IN)
+        if not feed_in_status:
+            return None
+        if isinstance(feed_in_status, dict):
+            return feed_in_status.get("isActivated", False)
+        return getattr(feed_in_status, "is_activated", False)
+
+
+class FrankEnergieSmartHvacBinarySensor(FrankEnergieSmartFeatureBinarySensor):
+    """Binary sensor for Smart HVAC activation state."""
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="smart_hvac",
+            name="Smart HVAC",
+            icon="mdi:heat-pump",
+            translation_key="smart_hvac",
+        )
+
+    def _get_is_on(self) -> bool | None:
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return None
+        smart_hvac = getattr(user_data, "smartHvac", None)
+        if smart_hvac is None:
+            return None
+        if isinstance(smart_hvac, dict):
+            return smart_hvac.get("isActivated", False)
+        return getattr(smart_hvac, "isActivated", False)
+
+
+# ---------------------------------------------------------------------------
+# Battery self-consumption binary sensor (existing, kept from old approach)
+# ---------------------------------------------------------------------------
+
+
 def _build_dynamic_smart_batteries_descriptions(
     batteries: list["SmartBatteriesData._SmartBattery"],
 ) -> list[FrankEnergieBinarySensorEntityDescription] | None:
@@ -145,7 +323,7 @@ def _build_dynamic_smart_batteries_descriptions(
                 name=f"{name_prefix} Self Consumption Trading Allowed",
                 authenticated=True,
                 service_name=SERVICE_NAME_BATTERIES,
-                icon="mdi:power-plug",
+                icon="mdi:home-battery",
                 value_fn=lambda _, val=settings: (
                     bool(val.self_consumption_trading_allowed) if val else False
                 ),
@@ -168,50 +346,26 @@ async def async_setup_entry(
     ]
     coordinator: FrankEnergieCoordinator = coordinator_wrapper["coordinator"]
     _LOGGER.debug("Setting up binary sensors for entry %s", config_entry.entry_id)
-    _LOGGER.debug(
-        "Coordinator data: %s", coordinator.data
-    )  # Log the entire coordinator data for debugging
-    # 'smart_batteries': None, 'smart_battery_details': [], 'smart_battery_sessions': []
-    _LOGGER.debug(
-        "Smart Batteries data: %s", coordinator.data.get("smart_batteries")
-    )  # Log the smart batteries data for debugging
-    _LOGGER.debug(
-        "Smart Battery Details: %s", coordinator.data.get("smart_battery_details")
-    )  # Log the smart battery details for debugging
-    _LOGGER.debug(
-        "Smart Battery Sessions: %s", coordinator.data.get("smart_battery_sessions")
-    )  # Log the smart battery sessions for debugging
 
+    entities: list[BinarySensorEntity] = []
+
+    if coordinator.api.is_authenticated:
+        # --- User-level smart feature state sensors ---
+        entities.append(FrankEnergieSmartChargingBinarySensor(coordinator, config_entry))
+        entities.append(FrankEnergieSmartTradingBinarySensor(coordinator, config_entry))
+        entities.append(FrankEnergieSmartFeedInBinarySensor(coordinator, config_entry))
+        entities.append(FrankEnergieSmartHvacBinarySensor(coordinator, config_entry))
+
+    # --- Battery self-consumption trading (per battery, from SmartBatteryDetails) ---
     batteries_data: SmartBatteriesData | None = coordinator.data.get("smart_batteries")
     if batteries_data:
-        _LOGGER.debug(
-            "Found1 Batteries data: %s", batteries_data
-        )  # Log the entire data object for debugging
-
-    # batteries_data: SmartBatteriesData | None = coordinator.data.get("batteries")
-    if not batteries_data:
-        _LOGGER.debug(
-            "No batteries data found in coordinator. Cannot set up binary sensors."
+        batteries_list = getattr(batteries_data, "batteries", [])
+        _LOGGER.debug("Number of Batteries found: %s", len(batteries_list))
+        binary_descriptions = _build_dynamic_smart_batteries_descriptions(batteries_list)
+        entities.extend(
+            FrankEnergieBinarySensor(coordinator, description, config_entry)
+            for description in binary_descriptions
         )
-        return
 
-    # _LOGGER.debug("Found Batteries data: %s", batteries_data)  # Log the entire data object for debugging
-
-    batteries_list = getattr(
-        batteries_data, "batteries"
-    )  # get the list of batteries from the data object
-
-    # Log the number of batteries found for debugging
-    _LOGGER.debug("Number of Batteries found: %s", len(batteries_list))
-    _LOGGER.debug(
-        "Batteries list: %s", batteries_list
-    )  # Log the list of batteries for debugging
-
-    binary_descriptions = _build_dynamic_smart_batteries_descriptions(batteries_list)
-
-    entities: list[FrankEnergieBinarySensor] = [
-        FrankEnergieBinarySensor(coordinator, description, config_entry)
-        for description in binary_descriptions
-    ]
-
-    async_add_entities(entities)
+    if entities:
+        async_add_entities(entities)

--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -20,8 +20,6 @@ from .const import (
     API_CONF_URL,
     COMPONENT_TITLE,
     DOMAIN,
-    DATA_BATTERIES,
-    DATA_BATTERY_DETAILS,
     DATA_USER,
     DATA_USER_SMART_FEED_IN,
     SERVICE_NAME_BATTERIES,
@@ -345,7 +343,9 @@ def _build_dynamic_smart_batteries_descriptions(
                 icon="mdi:home-battery",
                 # Each battery gets its own child device under Frank Energie - Batteries
                 child_device_id=battery.id,
-                child_device_name=f"{battery.brand} Battery" if battery.brand else f"Battery {i + 1}",
+                child_device_name=f"{battery.brand} Battery"
+                if battery.brand
+                else f"Battery {i + 1}",
                 child_device_manufacturer=battery.brand or COMPONENT_TITLE,
                 value_fn=lambda _, val=settings: (
                     bool(val.self_consumption_trading_allowed) if val else False
@@ -374,7 +374,9 @@ async def async_setup_entry(
 
     if coordinator.api.is_authenticated:
         # --- User-level smart feature state sensors ---
-        entities.append(FrankEnergieSmartChargingBinarySensor(coordinator, config_entry))
+        entities.append(
+            FrankEnergieSmartChargingBinarySensor(coordinator, config_entry)
+        )
         entities.append(FrankEnergieSmartTradingBinarySensor(coordinator, config_entry))
         entities.append(FrankEnergieSmartFeedInBinarySensor(coordinator, config_entry))
         entities.append(FrankEnergieSmartHvacBinarySensor(coordinator, config_entry))
@@ -384,7 +386,9 @@ async def async_setup_entry(
     if batteries_data:
         batteries_list = getattr(batteries_data, "batteries", [])
         _LOGGER.debug("Number of Batteries found: %s", len(batteries_list))
-        binary_descriptions = _build_dynamic_smart_batteries_descriptions(batteries_list)
+        binary_descriptions = _build_dynamic_smart_batteries_descriptions(
+            batteries_list
+        )
         entities.extend(
             FrankEnergieBinarySensor(coordinator, description, config_entry)
             for description in binary_descriptions

--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -99,7 +99,8 @@ class FrankEnergieBinarySensor(
         )
 
         if description.child_device_id:
-            # Per-item device (e.g. individual battery) as a child of the service device
+            # Per-item device (e.g. individual battery) as a child of the service device.
+            # No entry_type here — batteries are physical hardware, not services.
             parent_id = (
                 f"{config_entry.entry_id}_{description.service_name}"
                 if description.service_name
@@ -111,7 +112,6 @@ class FrankEnergieBinarySensor(
                 manufacturer=description.child_device_manufacturer or COMPONENT_TITLE,
                 model=description.service_name,
                 configuration_url=API_CONF_URL,
-                entry_type=DeviceEntryType.SERVICE,
                 via_device=(DOMAIN, parent_id),
             )
         else:

--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -50,6 +50,12 @@ class FrankEnergieBinarySensorEntityDescription(
 
     entity_registry_enabled_default: bool = True
 
+    # If set, creates a per-item child device instead of the shared service device.
+    # The child device will have via_device pointing to the service_name device.
+    child_device_id: str | None = None
+    child_device_name: str | None = None
+    child_device_manufacturer: str | None = None
+
 
 class FrankEnergieBinarySensor(
     CoordinatorEntity[FrankEnergieCoordinator],
@@ -91,15 +97,33 @@ class FrankEnergieBinarySensor(
             if description.service_name == "" or description.service_name is None
             else {(DOMAIN, f"{config_entry.entry_id}_{description.service_name}")}
         )
-        self._attr_device_info = DeviceInfo(
-            identifiers=device_info_identifiers,
-            name=f"{COMPONENT_TITLE} - {description.service_name}",
-            translation_key=f"{COMPONENT_TITLE} - {description.service_name}",
-            manufacturer=COMPONENT_TITLE,
-            model=description.service_name,
-            configuration_url=API_CONF_URL,
-            entry_type=DeviceEntryType.SERVICE,
-        )
+
+        if description.child_device_id:
+            # Per-item device (e.g. individual battery) as a child of the service device
+            parent_id = (
+                f"{config_entry.entry_id}_{description.service_name}"
+                if description.service_name
+                else config_entry.entry_id
+            )
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, description.child_device_id)},
+                name=description.child_device_name or description.child_device_id,
+                manufacturer=description.child_device_manufacturer or COMPONENT_TITLE,
+                model=description.service_name,
+                configuration_url=API_CONF_URL,
+                entry_type=DeviceEntryType.SERVICE,
+                via_device=(DOMAIN, parent_id),
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers=device_info_identifiers,
+                name=f"{COMPONENT_TITLE} - {description.service_name}",
+                translation_key=f"{COMPONENT_TITLE} - {description.service_name}",
+                manufacturer=COMPONENT_TITLE,
+                model=description.service_name,
+                configuration_url=API_CONF_URL,
+                entry_type=DeviceEntryType.SERVICE,
+            )
 
     @property
     def is_on(self) -> bool | None:
@@ -324,6 +348,10 @@ def _build_dynamic_smart_batteries_descriptions(
                 authenticated=True,
                 service_name=SERVICE_NAME_BATTERIES,
                 icon="mdi:home-battery",
+                # Each battery gets its own child device under Frank Energie - Batteries
+                child_device_id=battery.id,
+                child_device_name=f"{battery.brand} Battery" if battery.brand else f"Battery {i + 1}",
+                child_device_manufacturer=battery.brand or COMPONENT_TITLE,
                 value_fn=lambda _, val=settings: (
                     bool(val.self_consumption_trading_allowed) if val else False
                 ),

--- a/custom_components/frank_energie/button.py
+++ b/custom_components/frank_energie/button.py
@@ -63,15 +63,9 @@ async def async_setup_entry(
 
     # --- Disable action buttons (only when authenticated) ---
     if coordinator.api.is_authenticated:
-        entities.append(
-            FrankEnergieDisableSmartTradingButton(coordinator, entry)
-        )
-        entities.append(
-            FrankEnergieDisableSmartFeedInButton(coordinator, entry)
-        )
-        entities.append(
-            FrankEnergieDisableSmartHvacButton(coordinator, entry)
-        )
+        entities.append(FrankEnergieDisableSmartTradingButton(coordinator, entry))
+        entities.append(FrankEnergieDisableSmartFeedInButton(coordinator, entry))
+        entities.append(FrankEnergieDisableSmartHvacButton(coordinator, entry))
 
     if entities:
         async_add_entities(entities)

--- a/custom_components/frank_energie/button.py
+++ b/custom_components/frank_energie/button.py
@@ -1,11 +1,25 @@
+"""Button platform for Frank Energie integration."""
+
+from __future__ import annotations
+
 import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    API_CONF_URL,
+    COMPONENT_TITLE,
+    DOMAIN,
+    DATA_USER,
+    DATA_USER_SMART_FEED_IN,
+    SERVICE_NAME_USER,
+)
+from .coordinator import FrankEnergieCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,12 +27,13 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up refresh buttons for Frank Energie coordinators."""
+    """Set up Frank Energie buttons."""
     entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: FrankEnergieCoordinator = entry_data["coordinator"]
 
     entities: list[ButtonEntity] = []
 
-    # Main prices coordinator
+    # --- Refresh buttons (one per coordinator) ---
     if "coordinator" in entry_data:
         entities.append(
             FrankEnergieRefreshButton(
@@ -28,7 +43,6 @@ async def async_setup_entry(
             )
         )
 
-    # Battery sessions
     if "battery_session_coordinator" in entry_data:
         entities.append(
             FrankEnergieRefreshButton(
@@ -38,7 +52,6 @@ async def async_setup_entry(
             )
         )
 
-    # Chargers
     if "charger_coordinator" in entry_data:
         entities.append(
             FrankEnergieRefreshButton(
@@ -46,6 +59,18 @@ async def async_setup_entry(
                 coordinator=entry_data["charger_coordinator"],
                 name="Refresh Chargers",
             )
+        )
+
+    # --- Disable action buttons (only when authenticated) ---
+    if coordinator.api.is_authenticated:
+        entities.append(
+            FrankEnergieDisableSmartTradingButton(coordinator, entry)
+        )
+        entities.append(
+            FrankEnergieDisableSmartFeedInButton(coordinator, entry)
+        )
+        entities.append(
+            FrankEnergieDisableSmartHvacButton(coordinator, entry)
         )
 
     if entities:
@@ -71,3 +96,162 @@ class FrankEnergieRefreshButton(ButtonEntity):
         """Handle button press to trigger manual refresh."""
         _LOGGER.debug("Manual refresh requested: %s", self._attr_name)
         await self._coordinator.async_request_refresh()
+
+
+class _FrankEnergieDisableButton(
+    CoordinatorEntity[FrankEnergieCoordinator], ButtonEntity
+):
+    """Base class for disable-action buttons.
+
+    These buttons are always present in the entity registry but are marked
+    unavailable when the feature is already inactive (HA best practice:
+    unavailable, not hidden).
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:power-off"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        key: str,
+        name: str,
+        translation_key: str,
+    ) -> None:
+        """Initialize the disable button."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_name = name
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = f"{config_entry.entry_id}_{key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_USER}")},
+            name=f"{COMPONENT_TITLE} - {SERVICE_NAME_USER}",
+            manufacturer=COMPONENT_TITLE,
+            model=SERVICE_NAME_USER,
+            configuration_url=API_CONF_URL,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    def _is_feature_active(self) -> bool:
+        """Return True if the feature is currently active. Subclasses implement this."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Button is available (pressable) only when the feature is active."""
+        return self._is_feature_active()
+
+    async def _do_disable(self) -> bool:
+        """Call the API mutation. Subclasses implement this."""
+        return False
+
+    async def async_press(self) -> None:
+        """Disable the Frank Energie smart feature."""
+        _LOGGER.debug("Pressing disable button: %s", self._attr_name)
+        success = await self._do_disable()
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error("Failed to disable feature via button: %s", self._attr_name)
+
+
+class FrankEnergieDisableSmartTradingButton(_FrankEnergieDisableButton):
+    """Button to disable Smart Trading.
+
+    Calls the DisableSmartTrading mutation. Becomes unavailable when
+    Smart Trading is already inactive.
+    """
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="disable_smart_trading",
+            name="Disable Smart Trading",
+            translation_key="disable_smart_trading",
+        )
+
+    def _is_feature_active(self) -> bool:
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return False
+        smart_trading = user_data.smartTrading
+        if isinstance(smart_trading, dict):
+            return bool(smart_trading.get("isActivated", False))
+        return bool(getattr(smart_trading, "isActivated", False))
+
+    async def _do_disable(self) -> bool:
+        return await self.coordinator.api.disable_smart_trading()
+
+
+class FrankEnergieDisableSmartFeedInButton(_FrankEnergieDisableButton):
+    """Button to disable Smart Feed-In.
+
+    Calls the SmartFeedInDisable mutation. Becomes unavailable when
+    Smart Feed-In is already inactive.
+    """
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="disable_smart_feed_in",
+            name="Disable Smart Feed-In",
+            translation_key="disable_smart_feed_in",
+        )
+
+    def _is_feature_active(self) -> bool:
+        feed_in_status = self.coordinator.data.get(DATA_USER_SMART_FEED_IN)
+        if not feed_in_status:
+            return False
+        if isinstance(feed_in_status, dict):
+            return bool(feed_in_status.get("isActivated", False))
+        return bool(getattr(feed_in_status, "is_activated", False))
+
+    async def _do_disable(self) -> bool:
+        return await self.coordinator.api.disable_smart_feed_in()
+
+
+class FrankEnergieDisableSmartHvacButton(_FrankEnergieDisableButton):
+    """Button to disable Smart HVAC.
+
+    Calls the SmartHvacDisable mutation. Becomes unavailable when
+    Smart HVAC is already inactive.
+    """
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            config_entry,
+            key="disable_smart_hvac",
+            name="Disable Smart HVAC",
+            translation_key="disable_smart_hvac",
+        )
+
+    def _is_feature_active(self) -> bool:
+        user_data = self.coordinator.data.get(DATA_USER)
+        if not user_data:
+            return False
+        smart_hvac = getattr(user_data, "smartHvac", None)
+        if smart_hvac is None:
+            return False
+        if isinstance(smart_hvac, dict):
+            return bool(smart_hvac.get("isActivated", False))
+        return bool(getattr(smart_hvac, "isActivated", False))
+
+    async def _do_disable(self) -> bool:
+        return await self.coordinator.api.disable_smart_hvac()

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1175,11 +1175,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
 
         brand = pv_system.brand if (pv_system and pv_system.brand) else "Frank Energie"
-        model = pv_system.model if (pv_system and pv_system.model) else "Smart PV"
+        model = pv_system.model if (pv_system and pv_system.model) else None
         display_name = (
             pv_system.display_name
             if (pv_system and pv_system.display_name)
-            else f"Smart PV {system_id}"
+            else " ".join(filter(None, [brand, model])) or "Smart PV"
         )
         serial_number = (
             pv_system.inverter_serial_numbers[0]

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -16,8 +16,6 @@ from .const import (
     DOMAIN,
     DATA_ENODE_CHARGERS,
     DATA_ENODE_VEHICLES,
-    SERVICE_NAME_ENODE_CHARGERS,
-    SERVICE_NAME_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
 
@@ -131,7 +129,6 @@ class FrankEnergieVehicleDeadlineEntity(
             manufacturer=brand,
             model=model,
             name=name,
-            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property
@@ -226,7 +223,6 @@ class FrankEnergieChargerDeadlineEntity(
             manufacturer=brand,
             model=model,
             name=name,
-            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_CHARGERS}"),
         )
 
     @property

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -19,6 +19,7 @@ from .const import (
     DATA_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
+from .helpers import build_charge_settings_input
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,29 +58,6 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
-
-
-def _build_charge_settings_input(settings) -> dict:
-    """Build the full charge settings dict required by the mutation.
-
-    All 13 fields must be present — the API does not support partial updates.
-    We read the current values from the coordinator and only override what
-    the user explicitly changed (deadline in this case).
-    """
-    return {
-        "id": settings.id,
-        "isSmartChargingEnabled": settings.is_smart_charging_enabled,
-        "isSolarChargingEnabled": settings.is_solar_charging_enabled,
-        "minChargeLimit": settings.min_charge_limit,
-        "maxChargeLimit": settings.max_charge_limit,
-        "hourMonday": settings.hour_monday,
-        "hourTuesday": settings.hour_tuesday,
-        "hourWednesday": settings.hour_wednesday,
-        "hourThursday": settings.hour_thursday,
-        "hourFriday": settings.hour_friday,
-        "hourSaturday": settings.hour_saturday,
-        "hourSunday": settings.hour_sunday,
-    }
 
 
 class FrankEnergieEnodeDeadlineEntity(
@@ -146,7 +124,7 @@ class FrankEnergieEnodeDeadlineEntity(
             )
             return
 
-        input_data = _build_charge_settings_input(device.charge_settings)
+        input_data = build_charge_settings_input(device.charge_settings)
         input_data["deadline"] = value.isoformat()
 
         _LOGGER.debug(

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -214,9 +214,15 @@ class FrankEnergieChargerDeadlineEntity(
 
         # Charger information is a plain dict (not a dataclass like vehicle)
         info = charger.information if charger else {}
-        brand = info.get("brand", "Frank Energie") if isinstance(info, dict) else "Frank Energie"
+        brand = (
+            info.get("brand", "Frank Energie")
+            if isinstance(info, dict)
+            else "Frank Energie"
+        )
         model = info.get("model", "Charger") if isinstance(info, dict) else "Charger"
-        name = f"{brand} {model}".strip() if (brand or model) else f"Charger {charger_id}"
+        name = (
+            f"{brand} {model}".strip() if (brand or model) else f"Charger {charger_id}"
+        )
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, charger_id)},

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -16,6 +16,8 @@ from .const import (
     DOMAIN,
     DATA_ENODE_CHARGERS,
     DATA_ENODE_VEHICLES,
+    SERVICE_NAME_ENODE_CHARGERS,
+    SERVICE_NAME_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
 
@@ -129,11 +131,17 @@ class FrankEnergieVehicleDeadlineEntity(
             manufacturer=brand,
             model=model,
             name=name,
+            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the current charging deadline."""
+        """Return the next calculated charging deadline from Frank.
+
+        Uses ``calculated_deadline`` (Frank's computed next target based on the
+        per-weekday hour schedule) rather than the nullable ``deadline`` field
+        which is a one-time override and can be a stale past date.
+        """
         enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
         if not enode_vehicles or not enode_vehicles.vehicles:
             return None
@@ -142,7 +150,7 @@ class FrankEnergieVehicleDeadlineEntity(
         )
         if not vehicle or not vehicle.charge_settings:
             return None
-        return vehicle.charge_settings.deadline
+        return vehicle.charge_settings.calculated_deadline
 
     async def async_set_value(self, value: datetime) -> None:
         """Set the EV charging deadline via EnodeUpdateVehicleChargeSettings."""
@@ -218,11 +226,17 @@ class FrankEnergieChargerDeadlineEntity(
             manufacturer=brand,
             model=model,
             name=name,
+            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_CHARGERS}"),
         )
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the current charging deadline."""
+        """Return the next calculated charging deadline from Frank.
+
+        Uses ``calculated_deadline`` (Frank's computed next target based on the
+        per-weekday hour schedule) rather than the nullable ``deadline`` field
+        which is a one-time override and can be a stale past date.
+        """
         enode_chargers = self.coordinator.data.get(DATA_ENODE_CHARGERS)
         if not enode_chargers or not enode_chargers.chargers:
             return None
@@ -231,7 +245,7 @@ class FrankEnergieChargerDeadlineEntity(
         )
         if not charger or not charger.charge_settings:
             return None
-        return charger.charge_settings.deadline
+        return charger.charge_settings.calculated_deadline
 
     async def async_set_value(self, value: datetime) -> None:
         """Set the charger charging deadline via EnodeUpdateChargerChargeSettings."""

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
+from typing import Any
 
 from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.config_entries import ConfigEntry
@@ -81,10 +82,10 @@ def _build_charge_settings_input(settings) -> dict:
     }
 
 
-class FrankEnergieVehicleDeadlineEntity(
+class FrankEnergieEnodeDeadlineEntity(
     CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity
 ):
-    """Editable charging deadline / departure time for an Enode EV vehicle."""
+    """Base class for Enode charging deadline entities."""
 
     _attr_has_entity_name = True
     _attr_icon = "mdi:clock-end"
@@ -94,21 +95,86 @@ class FrankEnergieVehicleDeadlineEntity(
         self,
         coordinator: FrankEnergieCoordinator,
         config_entry: ConfigEntry,
-        vehicle_id: str,
+        device_id: str,
+        unique_id_suffix: str,
     ) -> None:
         """Initialize the datetime entity."""
         super().__init__(coordinator)
         self._config_entry = config_entry
-        self._vehicle_id = vehicle_id
-        self._attr_unique_id = f"{DOMAIN}_{vehicle_id}_charging_deadline"
+        self._device_id = device_id
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_{unique_id_suffix}"
+
+    @property
+    def _device_data_key(self) -> str:
+        """Return the key in coordinator data for this device type."""
+        raise NotImplementedError
+
+    def _get_device_list(self) -> list:
+        """Return the list of devices from coordinator data."""
+        raise NotImplementedError
+
+    def _get_device(self) -> Any:
+        """Find and return the device matching self._device_id."""
+        return next(
+            (d for d in self._get_device_list() if d.id == self._device_id), None
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the next calculated charging deadline from Frank.
+
+        Uses ``calculated_deadline`` (Frank's computed next target based on the
+        per-weekday hour schedule) rather than the nullable ``deadline`` field
+        which is a one-time override and can be a stale past date.
+        """
+        device = self._get_device()
+        if not device or not device.charge_settings:
+            return None
+        return device.charge_settings.calculated_deadline
+
+    async def _update_charge_settings(self, input_data: dict) -> bool:
+        """Call the appropriate API update settings mutation."""
+        raise NotImplementedError
+
+    async def async_set_value(self, value: datetime) -> None:
+        """Set the charging deadline via API mutation."""
+        device = self._get_device()
+        if not device or not device.charge_settings:
+            _LOGGER.error(
+                "Cannot set deadline: device %s not found or has no charge settings",
+                self._device_id,
+            )
+            return
+
+        input_data = _build_charge_settings_input(device.charge_settings)
+        input_data["deadline"] = value.isoformat()
+
+        _LOGGER.debug(
+            "Setting charging deadline for device %s to %s", self._device_id, value
+        )
+        success = await self._update_charge_settings(input_data)
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(
+                "Failed to set charging deadline for device %s", self._device_id
+            )
+
+
+class FrankEnergieVehicleDeadlineEntity(FrankEnergieEnodeDeadlineEntity):
+    """Editable charging deadline / departure time for an Enode EV vehicle."""
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        vehicle_id: str,
+    ) -> None:
+        """Initialize the datetime entity."""
+        super().__init__(coordinator, config_entry, vehicle_id, "charging_deadline")
 
         # Find vehicle to get info for device registration
-        enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
-        vehicle = None
-        if enode_vehicles and enode_vehicles.vehicles:
-            vehicle = next(
-                (v for v in enode_vehicles.vehicles if v.id == vehicle_id), None
-            )
+        vehicle = self._get_device()
 
         brand = (
             vehicle.information.brand
@@ -132,65 +198,21 @@ class FrankEnergieVehicleDeadlineEntity(
         )
 
     @property
-    def native_value(self) -> datetime | None:
-        """Return the next calculated charging deadline from Frank.
+    def _device_data_key(self) -> str:
+        return DATA_ENODE_VEHICLES
 
-        Uses ``calculated_deadline`` (Frank's computed next target based on the
-        per-weekday hour schedule) rather than the nullable ``deadline`` field
-        which is a one-time override and can be a stale past date.
-        """
+    def _get_device_list(self) -> list:
         enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
-        if not enode_vehicles or not enode_vehicles.vehicles:
-            return None
-        vehicle = next(
-            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
-        )
-        if not vehicle or not vehicle.charge_settings:
-            return None
-        return vehicle.charge_settings.calculated_deadline
+        return enode_vehicles.vehicles if enode_vehicles else []
 
-    async def async_set_value(self, value: datetime) -> None:
-        """Set the EV charging deadline via EnodeUpdateVehicleChargeSettings."""
-        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
-        if not enode_vehicles or not enode_vehicles.vehicles:
-            _LOGGER.error("Cannot set deadline: no vehicle data available")
-            return
-
-        vehicle = next(
-            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
-        )
-        if not vehicle or not vehicle.charge_settings:
-            _LOGGER.error(
-                "Cannot set deadline: vehicle %s not found or has no charge settings",
-                self._vehicle_id,
-            )
-            return
-
-        input_data = _build_charge_settings_input(vehicle.charge_settings)
-        input_data["deadline"] = value.isoformat()
-
-        _LOGGER.debug(
-            "Setting charging deadline for vehicle %s to %s", self._vehicle_id, value
-        )
-        success = await self.coordinator.api.enode_update_vehicle_charge_settings(
+    async def _update_charge_settings(self, input_data: dict) -> bool:
+        return await self.coordinator.api.enode_update_vehicle_charge_settings(
             input_data
         )
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error(
-                "Failed to set charging deadline for vehicle %s", self._vehicle_id
-            )
 
 
-class FrankEnergieChargerDeadlineEntity(
-    CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity
-):
+class FrankEnergieChargerDeadlineEntity(FrankEnergieEnodeDeadlineEntity):
     """Editable charging deadline / departure time for an Enode wall charger."""
-
-    _attr_has_entity_name = True
-    _attr_icon = "mdi:clock-end"
-    _attr_translation_key = "charging_deadline"
 
     def __init__(
         self,
@@ -199,18 +221,10 @@ class FrankEnergieChargerDeadlineEntity(
         charger_id: str,
     ) -> None:
         """Initialize the datetime entity."""
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-        self._charger_id = charger_id
-        self._attr_unique_id = f"{DOMAIN}_{charger_id}_charging_deadline"
+        super().__init__(coordinator, config_entry, charger_id, "charging_deadline")
 
         # Find charger for device info
-        enode_chargers = coordinator.data.get(DATA_ENODE_CHARGERS)
-        charger = None
-        if enode_chargers and enode_chargers.chargers:
-            charger = next(
-                (c for c in enode_chargers.chargers if c.id == charger_id), None
-            )
+        charger = self._get_device()
 
         # Charger information is a plain dict (not a dataclass like vehicle)
         info = charger.information if charger else {}
@@ -232,52 +246,14 @@ class FrankEnergieChargerDeadlineEntity(
         )
 
     @property
-    def native_value(self) -> datetime | None:
-        """Return the next calculated charging deadline from Frank.
+    def _device_data_key(self) -> str:
+        return DATA_ENODE_CHARGERS
 
-        Uses ``calculated_deadline`` (Frank's computed next target based on the
-        per-weekday hour schedule) rather than the nullable ``deadline`` field
-        which is a one-time override and can be a stale past date.
-        """
+    def _get_device_list(self) -> list:
         enode_chargers = self.coordinator.data.get(DATA_ENODE_CHARGERS)
-        if not enode_chargers or not enode_chargers.chargers:
-            return None
-        charger = next(
-            (c for c in enode_chargers.chargers if c.id == self._charger_id), None
-        )
-        if not charger or not charger.charge_settings:
-            return None
-        return charger.charge_settings.calculated_deadline
+        return enode_chargers.chargers if enode_chargers else []
 
-    async def async_set_value(self, value: datetime) -> None:
-        """Set the charger charging deadline via EnodeUpdateChargerChargeSettings."""
-        enode_chargers = self.coordinator.data.get(DATA_ENODE_CHARGERS)
-        if not enode_chargers or not enode_chargers.chargers:
-            _LOGGER.error("Cannot set deadline: no charger data available")
-            return
-
-        charger = next(
-            (c for c in enode_chargers.chargers if c.id == self._charger_id), None
-        )
-        if not charger or not charger.charge_settings:
-            _LOGGER.error(
-                "Cannot set deadline: charger %s not found or has no charge settings",
-                self._charger_id,
-            )
-            return
-
-        input_data = _build_charge_settings_input(charger.charge_settings)
-        input_data["deadline"] = value.isoformat()
-
-        _LOGGER.debug(
-            "Setting charging deadline for charger %s to %s", self._charger_id, value
-        )
-        success = await self.coordinator.api.enode_update_charger_charge_settings(
+    async def _update_charge_settings(self, input_data: dict) -> bool:
+        return await self.coordinator.api.enode_update_charger_charge_settings(
             input_data
         )
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error(
-                "Failed to set charging deadline for charger %s", self._charger_id
-            )

--- a/custom_components/frank_energie/datetime.py
+++ b/custom_components/frank_energie/datetime.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
+    DATA_ENODE_CHARGERS,
     DATA_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
@@ -33,6 +34,7 @@ async def async_setup_entry(
     entities: list[DateTimeEntity] = []
 
     if coordinator.api.is_authenticated:
+        # EV vehicle charging deadlines
         enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
         if enode_vehicles and enode_vehicles.vehicles:
             for vehicle in enode_vehicles.vehicles:
@@ -42,17 +44,51 @@ async def async_setup_entry(
                     )
                 )
 
+        # Wall charger charging deadlines
+        enode_chargers = coordinator.data.get(DATA_ENODE_CHARGERS)
+        if enode_chargers and enode_chargers.chargers:
+            for charger in enode_chargers.chargers:
+                entities.append(
+                    FrankEnergieChargerDeadlineEntity(
+                        coordinator, config_entry, charger.id
+                    )
+                )
+
     if entities:
         async_add_entities(entities)
+
+
+def _build_charge_settings_input(settings) -> dict:
+    """Build the full charge settings dict required by the mutation.
+
+    All 13 fields must be present — the API does not support partial updates.
+    We read the current values from the coordinator and only override what
+    the user explicitly changed (deadline in this case).
+    """
+    return {
+        "id": settings.id,
+        "isSmartChargingEnabled": settings.is_smart_charging_enabled,
+        "isSolarChargingEnabled": settings.is_solar_charging_enabled,
+        "minChargeLimit": settings.min_charge_limit,
+        "maxChargeLimit": settings.max_charge_limit,
+        "hourMonday": settings.hour_monday,
+        "hourTuesday": settings.hour_tuesday,
+        "hourWednesday": settings.hour_wednesday,
+        "hourThursday": settings.hour_thursday,
+        "hourFriday": settings.hour_friday,
+        "hourSaturday": settings.hour_saturday,
+        "hourSunday": settings.hour_sunday,
+    }
 
 
 class FrankEnergieVehicleDeadlineEntity(
     CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity
 ):
-    """Representation of an editable EV charging deadline/departure time."""
+    """Editable charging deadline / departure time for an Enode EV vehicle."""
 
     _attr_has_entity_name = True
     _attr_icon = "mdi:clock-end"
+    _attr_translation_key = "charging_deadline"
 
     def __init__(
         self,
@@ -64,8 +100,6 @@ class FrankEnergieVehicleDeadlineEntity(
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._vehicle_id = vehicle_id
-        self._attr_name = "Charging deadline"
-        self._attr_translation_key = "charging_deadline"
         self._attr_unique_id = f"{DOMAIN}_{vehicle_id}_charging_deadline"
 
         # Find vehicle to get info for device registration
@@ -99,7 +133,7 @@ class FrankEnergieVehicleDeadlineEntity(
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the current datetime setting."""
+        """Return the current charging deadline."""
         enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
         if not enode_vehicles or not enode_vehicles.vehicles:
             return None
@@ -111,8 +145,123 @@ class FrankEnergieVehicleDeadlineEntity(
         return vehicle.charge_settings.deadline
 
     async def async_set_value(self, value: datetime) -> None:
-        """Set the charging deadline datetime."""
-        _LOGGER.warning(
-            "Changing the EV charging deadline to %s is currently unverified. Captured GraphQL mutations are required.",
-            value,
+        """Set the EV charging deadline via EnodeUpdateVehicleChargeSettings."""
+        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
+        if not enode_vehicles or not enode_vehicles.vehicles:
+            _LOGGER.error("Cannot set deadline: no vehicle data available")
+            return
+
+        vehicle = next(
+            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
         )
+        if not vehicle or not vehicle.charge_settings:
+            _LOGGER.error(
+                "Cannot set deadline: vehicle %s not found or has no charge settings",
+                self._vehicle_id,
+            )
+            return
+
+        input_data = _build_charge_settings_input(vehicle.charge_settings)
+        input_data["deadline"] = value.isoformat()
+
+        _LOGGER.debug(
+            "Setting charging deadline for vehicle %s to %s", self._vehicle_id, value
+        )
+        success = await self.coordinator.api.enode_update_vehicle_charge_settings(
+            input_data
+        )
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(
+                "Failed to set charging deadline for vehicle %s", self._vehicle_id
+            )
+
+
+class FrankEnergieChargerDeadlineEntity(
+    CoordinatorEntity[FrankEnergieCoordinator], DateTimeEntity
+):
+    """Editable charging deadline / departure time for an Enode wall charger."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:clock-end"
+    _attr_translation_key = "charging_deadline"
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        config_entry: ConfigEntry,
+        charger_id: str,
+    ) -> None:
+        """Initialize the datetime entity."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._charger_id = charger_id
+        self._attr_unique_id = f"{DOMAIN}_{charger_id}_charging_deadline"
+
+        # Find charger for device info
+        enode_chargers = coordinator.data.get(DATA_ENODE_CHARGERS)
+        charger = None
+        if enode_chargers and enode_chargers.chargers:
+            charger = next(
+                (c for c in enode_chargers.chargers if c.id == charger_id), None
+            )
+
+        # Charger information is a plain dict (not a dataclass like vehicle)
+        info = charger.information if charger else {}
+        brand = info.get("brand", "Frank Energie") if isinstance(info, dict) else "Frank Energie"
+        model = info.get("model", "Charger") if isinstance(info, dict) else "Charger"
+        name = f"{brand} {model}".strip() if (brand or model) else f"Charger {charger_id}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, charger_id)},
+            manufacturer=brand,
+            model=model,
+            name=name,
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the current charging deadline."""
+        enode_chargers = self.coordinator.data.get(DATA_ENODE_CHARGERS)
+        if not enode_chargers or not enode_chargers.chargers:
+            return None
+        charger = next(
+            (c for c in enode_chargers.chargers if c.id == self._charger_id), None
+        )
+        if not charger or not charger.charge_settings:
+            return None
+        return charger.charge_settings.deadline
+
+    async def async_set_value(self, value: datetime) -> None:
+        """Set the charger charging deadline via EnodeUpdateChargerChargeSettings."""
+        enode_chargers = self.coordinator.data.get(DATA_ENODE_CHARGERS)
+        if not enode_chargers or not enode_chargers.chargers:
+            _LOGGER.error("Cannot set deadline: no charger data available")
+            return
+
+        charger = next(
+            (c for c in enode_chargers.chargers if c.id == self._charger_id), None
+        )
+        if not charger or not charger.charge_settings:
+            _LOGGER.error(
+                "Cannot set deadline: charger %s not found or has no charge settings",
+                self._charger_id,
+            )
+            return
+
+        input_data = _build_charge_settings_input(charger.charge_settings)
+        input_data["deadline"] = value.isoformat()
+
+        _LOGGER.debug(
+            "Setting charging deadline for charger %s to %s", self._charger_id, value
+        )
+        success = await self.coordinator.api.enode_update_charger_charge_settings(
+            input_data
+        )
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(
+                "Failed to set charging deadline for charger %s", self._charger_id
+            )

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -1,0 +1,25 @@
+"""Helper functions for the Frank Energie integration."""
+
+from __future__ import annotations
+
+
+def build_charge_settings_input(settings) -> dict:
+    """Build the full charge settings dict required by the mutation.
+
+    All 13 fields must be present — the API does not support partial updates.
+    """
+    return {
+        "id": settings.id,
+        "deadline": settings.deadline.isoformat() if settings.deadline else None,
+        "isSmartChargingEnabled": settings.is_smart_charging_enabled,
+        "isSolarChargingEnabled": settings.is_solar_charging_enabled,
+        "minChargeLimit": settings.min_charge_limit,
+        "maxChargeLimit": settings.max_charge_limit,
+        "hourMonday": settings.hour_monday,
+        "hourTuesday": settings.hour_tuesday,
+        "hourWednesday": settings.hour_wednesday,
+        "hourThursday": settings.hour_thursday,
+        "hourFriday": settings.hour_friday,
+        "hourSaturday": settings.hour_saturday,
+        "hourSunday": settings.hour_sunday,
+    }

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -515,6 +515,7 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
             serial_number=info.get("vin", None),
             name=vehicle_name,
             hw_version=str(info.get("year")),
+            via_device=(DOMAIN, f"{coordinator.config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -515,7 +515,6 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
             serial_number=info.get("vin", None),
             name=vehicle_name,
             hw_version=str(info.get("year")),
-            via_device=(DOMAIN, f"{coordinator.config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -45,6 +45,31 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "smart_charging": {
+        "name": "Smart Charging"
+      },
+      "smart_trading": {
+        "name": "Smart Trading"
+      },
+      "smart_feed_in": {
+        "name": "Smart Feed-In"
+      },
+      "smart_hvac": {
+        "name": "Smart HVAC"
+      }
+    },
+    "button": {
+      "disable_smart_trading": {
+        "name": "Disable Smart Trading"
+      },
+      "disable_smart_feed_in": {
+        "name": "Disable Smart Feed-In"
+      },
+      "disable_smart_hvac": {
+        "name": "Disable Smart HVAC"
+      }
+    },
     "sensor": {
       "pv_total_bonus": {
         "name": "Total bonus"
@@ -57,20 +82,8 @@
       }
     },
     "switch": {
-      "smart_charging": {
-        "name": "Smart charging"
-      },
-      "smart_trading": {
-        "name": "Smart trading"
-      },
-      "smart_feed_in": {
-        "name": "Smart feed-in"
-      },
-      "self_consumption_trading_allowed": {
-        "name": "Self consumption trading allowed"
-      },
-      "pv_steering_enabled": {
-        "name": "Steering enabled"
+      "enode_smart_charging": {
+        "name": "Smart Charging"
       }
     },
     "datetime": {

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -48,14 +48,32 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
+def _build_charge_settings_input(settings) -> dict:
+    """Build the full charge settings dict required by the mutation."""
+    return {
+        "id": settings.id,
+        "deadline": settings.deadline.isoformat() if settings.deadline else None,
+        "isSmartChargingEnabled": settings.is_smart_charging_enabled,
+        "isSolarChargingEnabled": settings.is_solar_charging_enabled,
+        "minChargeLimit": settings.min_charge_limit,
+        "maxChargeLimit": settings.max_charge_limit,
+        "hourMonday": settings.hour_monday,
+        "hourTuesday": settings.hour_tuesday,
+        "hourWednesday": settings.hour_wednesday,
+        "hourThursday": settings.hour_thursday,
+        "hourFriday": settings.hour_friday,
+        "hourSaturday": settings.hour_saturday,
+        "hourSunday": settings.hour_sunday,
+    }
+
+
 class FrankEnergieEnodeSmartChargingSwitch(
     CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
 ):
     """Switch to enable/disable Enode smart charging for a vehicle.
 
-    This is the only bidirectional switch in the integration — both
-    EnodeEnableSmartCharging and EnodeDisableSmartCharging are confirmed
-    direct mutations in the Frank app API.
+    This is the only bidirectional switch in the integration — toggled
+    via the vehicle-scoped EnodeUpdateVehicleChargeSettings mutation.
     """
 
     _attr_has_entity_name = True
@@ -118,8 +136,28 @@ class FrankEnergieEnodeSmartChargingSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable Enode smart charging."""
+        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
+        if not enode_vehicles or not enode_vehicles.vehicles:
+            _LOGGER.error("Cannot enable smart charging: no vehicle data available")
+            return
+
+        vehicle = next(
+            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
+        )
+        if not vehicle or not vehicle.charge_settings:
+            _LOGGER.error(
+                "Cannot enable smart charging: vehicle %s not found or has no charge settings",
+                self._vehicle_id,
+            )
+            return
+
+        input_data = _build_charge_settings_input(vehicle.charge_settings)
+        input_data["isSmartChargingEnabled"] = True
+
         _LOGGER.debug("Enabling Enode smart charging for vehicle %s", self._vehicle_id)
-        success = await self.coordinator.api.enode_enable_smart_charging()
+        success = await self.coordinator.api.enode_update_vehicle_charge_settings(
+            input_data
+        )
         if success:
             await self.coordinator.async_request_refresh()
         else:
@@ -130,8 +168,28 @@ class FrankEnergieEnodeSmartChargingSwitch(
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable Enode smart charging."""
+        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
+        if not enode_vehicles or not enode_vehicles.vehicles:
+            _LOGGER.error("Cannot disable smart charging: no vehicle data available")
+            return
+
+        vehicle = next(
+            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
+        )
+        if not vehicle or not vehicle.charge_settings:
+            _LOGGER.error(
+                "Cannot disable smart charging: vehicle %s not found or has no charge settings",
+                self._vehicle_id,
+            )
+            return
+
+        input_data = _build_charge_settings_input(vehicle.charge_settings)
+        input_data["isSmartChargingEnabled"] = False
+
         _LOGGER.debug("Disabling Enode smart charging for vehicle %s", self._vehicle_id)
-        success = await self.coordinator.api.enode_disable_smart_charging()
+        success = await self.coordinator.api.enode_update_vehicle_charge_settings(
+            input_data
+        )
         if success:
             await self.coordinator.async_request_refresh()
         else:

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -92,7 +92,9 @@ class FrankEnergieEnodeSmartChargingSwitch(
             if (vehicle and vehicle.information)
             else "Vehicle"
         )
-        name = f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+        name = (
+            f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+        )
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vehicle_id)},

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     DATA_ENODE_VEHICLES,
+    SERVICE_NAME_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
 
@@ -99,6 +100,7 @@ class FrankEnergieEnodeSmartChargingSwitch(
             manufacturer=brand,
             model=model,
             name=name,
+            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -17,6 +17,7 @@ from .const import (
     DATA_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
+from .helpers import build_charge_settings_input
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,25 +47,6 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
-
-
-def _build_charge_settings_input(settings) -> dict:
-    """Build the full charge settings dict required by the mutation."""
-    return {
-        "id": settings.id,
-        "deadline": settings.deadline.isoformat() if settings.deadline else None,
-        "isSmartChargingEnabled": settings.is_smart_charging_enabled,
-        "isSolarChargingEnabled": settings.is_solar_charging_enabled,
-        "minChargeLimit": settings.min_charge_limit,
-        "maxChargeLimit": settings.max_charge_limit,
-        "hourMonday": settings.hour_monday,
-        "hourTuesday": settings.hour_tuesday,
-        "hourWednesday": settings.hour_wednesday,
-        "hourThursday": settings.hour_thursday,
-        "hourFriday": settings.hour_friday,
-        "hourSaturday": settings.hour_saturday,
-        "hourSunday": settings.hour_sunday,
-    }
 
 
 class FrankEnergieEnodeSmartChargingSwitch(
@@ -151,7 +133,7 @@ class FrankEnergieEnodeSmartChargingSwitch(
             )
             return
 
-        input_data = _build_charge_settings_input(vehicle.charge_settings)
+        input_data = build_charge_settings_input(vehicle.charge_settings)
         input_data["isSmartChargingEnabled"] = True
 
         _LOGGER.debug("Enabling Enode smart charging for vehicle %s", self._vehicle_id)
@@ -183,7 +165,7 @@ class FrankEnergieEnodeSmartChargingSwitch(
             )
             return
 
-        input_data = _build_charge_settings_input(vehicle.charge_settings)
+        input_data = build_charge_settings_input(vehicle.charge_settings)
         input_data["isSmartChargingEnabled"] = False
 
         _LOGGER.debug("Disabling Enode smart charging for vehicle %s", self._vehicle_id)

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -14,12 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
-    DATA_USER,
-    DATA_BATTERIES,
-    DATA_BATTERY_DETAILS,
-    DATA_USER_SMART_FEED_IN,
-    DATA_PV_SYSTEMS,
-    DATA_PV_SUMMARY,
+    DATA_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
 
@@ -37,307 +32,108 @@ async def async_setup_entry(
     ]
     entities: list[SwitchEntity] = []
 
-    # If the user is authenticated, set up user-level smart charging & trading switches
     if coordinator.api.is_authenticated:
-        entities.append(FrankEnergieSmartChargingSwitch(coordinator, config_entry))
-        entities.append(FrankEnergieSmartTradingSwitch(coordinator, config_entry))
-        entities.append(FrankEnergieSmartFeedInSwitch(coordinator, config_entry))
-
-        # Check for batteries
-        batteries = coordinator.data.get(DATA_BATTERIES)
-        if batteries and batteries.batteries:
-            for battery in batteries.batteries:
-                entities.append(
-                    FrankEnergieBatteryTradingSwitch(
-                        coordinator, config_entry, battery.id
+        # Enode smart charging: true bidirectional switch (both mutations confirmed)
+        enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
+        if enode_vehicles and enode_vehicles.vehicles:
+            for vehicle in enode_vehicles.vehicles:
+                if vehicle.can_smart_charge:
+                    entities.append(
+                        FrankEnergieEnodeSmartChargingSwitch(
+                            coordinator, config_entry, vehicle.id
+                        )
                     )
-                )
-
-        # Check for PV systems
-        pv_systems = coordinator.data.get(DATA_PV_SYSTEMS)
-        if pv_systems and pv_systems.systems:
-            for system in pv_systems.systems:
-                entities.append(
-                    FrankEnergiePvSteeringSwitch(coordinator, config_entry, system.id)
-                )
 
     if entities:
         async_add_entities(entities)
 
 
-class FrankEnergieSmartChargingSwitch(
+class FrankEnergieEnodeSmartChargingSwitch(
     CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
 ):
-    """Switch to toggle smart charging on/off."""
+    """Switch to enable/disable Enode smart charging for a vehicle.
+
+    This is the only bidirectional switch in the integration — both
+    EnodeEnableSmartCharging and EnodeDisableSmartCharging are confirmed
+    direct mutations in the Frank app API.
+    """
 
     _attr_has_entity_name = True
-    _attr_icon = "mdi:car-electric"
+    _attr_icon = "mdi:car-electric-outline"
+    _attr_translation_key = "enode_smart_charging"
 
     def __init__(
         self,
         coordinator: FrankEnergieCoordinator,
         config_entry: ConfigEntry,
+        vehicle_id: str,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
         self._config_entry = config_entry
-        self._attr_name = "Smart charging"
-        self._attr_translation_key = "smart_charging"
-        self._attr_unique_id = f"{config_entry.entry_id}_smart_charging"
+        self._vehicle_id = vehicle_id
+        self._attr_unique_id = f"{DOMAIN}_{vehicle_id}_enode_smart_charging"
+
+        # Build device info from vehicle data
+        enode_vehicles = coordinator.data.get(DATA_ENODE_VEHICLES)
+        vehicle = None
+        if enode_vehicles and enode_vehicles.vehicles:
+            vehicle = next(
+                (v for v in enode_vehicles.vehicles if v.id == vehicle_id), None
+            )
+
+        brand = (
+            vehicle.information.brand
+            if (vehicle and vehicle.information)
+            else "Frank Energie"
+        )
+        model = (
+            vehicle.information.model
+            if (vehicle and vehicle.information)
+            else "Vehicle"
+        )
+        name = f"{brand} {model}".strip() if (brand or model) else f"Vehicle {vehicle_id}"
+
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
-            name="Frank Energie - User",
-            manufacturer="Frank Energie",
-            model="User",
+            identifiers={(DOMAIN, vehicle_id)},
+            manufacturer=brand,
+            model=model,
+            name=name,
         )
 
     @property
     def is_on(self) -> bool | None:
-        """Return true if switch is on."""
-        user_data = self.coordinator.data.get(DATA_USER)
-        if not user_data:
+        """Return True if Enode smart charging is enabled for this vehicle."""
+        enode_vehicles = self.coordinator.data.get(DATA_ENODE_VEHICLES)
+        if not enode_vehicles or not enode_vehicles.vehicles:
             return None
-        smart_charging = user_data.smartCharging
-        if isinstance(smart_charging, dict):
-            return smart_charging.get("isActivated", False)
-        return getattr(smart_charging, "isActivated", False)
+        vehicle = next(
+            (v for v in enode_vehicles.vehicles if v.id == self._vehicle_id), None
+        )
+        if not vehicle or not vehicle.charge_settings:
+            return None
+        return vehicle.charge_settings.is_smart_charging_enabled
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        _LOGGER.warning(
-            "Turning on Smart Charging is currently unverified. Captured GraphQL mutations are required."
-        )
+        """Enable Enode smart charging."""
+        _LOGGER.debug("Enabling Enode smart charging for vehicle %s", self._vehicle_id)
+        success = await self.coordinator.api.enode_enable_smart_charging()
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(
+                "Failed to enable Enode smart charging for vehicle %s",
+                self._vehicle_id,
+            )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        _LOGGER.warning(
-            "Turning off Smart Charging is currently unverified. Captured GraphQL mutations are required."
-        )
-
-
-class FrankEnergieSmartTradingSwitch(
-    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
-):
-    """Switch to toggle smart trading on/off."""
-
-    _attr_has_entity_name = True
-    _attr_icon = "mdi:battery-sync"
-
-    def __init__(
-        self,
-        coordinator: FrankEnergieCoordinator,
-        config_entry: ConfigEntry,
-    ) -> None:
-        """Initialize the switch."""
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-        self._attr_name = "Smart trading"
-        self._attr_translation_key = "smart_trading"
-        self._attr_unique_id = f"{config_entry.entry_id}_smart_trading"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
-            name="Frank Energie - User",
-            manufacturer="Frank Energie",
-            model="User",
-        )
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if switch is on."""
-        user_data = self.coordinator.data.get(DATA_USER)
-        if not user_data:
-            return None
-        smart_trading = user_data.smartTrading
-        if isinstance(smart_trading, dict):
-            return smart_trading.get("isActivated", False)
-        return getattr(smart_trading, "isActivated", False)
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        _LOGGER.warning(
-            "Turning on Smart Trading is currently unverified. Captured GraphQL mutations are required."
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        _LOGGER.warning(
-            "Turning off Smart Trading is currently unverified. Captured GraphQL mutations are required."
-        )
-
-
-class FrankEnergieSmartFeedInSwitch(
-    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
-):
-    """Switch to toggle smart feed-in on/off."""
-
-    _attr_has_entity_name = True
-    _attr_icon = "mdi:solar-power-variant"
-
-    def __init__(
-        self,
-        coordinator: FrankEnergieCoordinator,
-        config_entry: ConfigEntry,
-    ) -> None:
-        """Initialize the switch."""
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-        self._attr_name = "Smart feed-in"
-        self._attr_translation_key = "smart_feed_in"
-        self._attr_unique_id = f"{config_entry.entry_id}_smart_feed_in"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{config_entry.entry_id}_User")},
-            name="Frank Energie - User",
-            manufacturer="Frank Energie",
-            model="User",
-        )
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if switch is on."""
-        feed_in_status = self.coordinator.data.get(DATA_USER_SMART_FEED_IN)
-        if not feed_in_status:
-            return None
-        if isinstance(feed_in_status, dict):
-            return feed_in_status.get("isActivated", False)
-        return getattr(feed_in_status, "is_activated", False)
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        _LOGGER.warning(
-            "Turning on Smart Feed-in is currently unverified. Captured GraphQL mutations are required."
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        _LOGGER.warning(
-            "Turning off Smart Feed-in is currently unverified. Captured GraphQL mutations are required."
-        )
-
-
-class FrankEnergieBatteryTradingSwitch(
-    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
-):
-    """Switch to toggle self consumption battery trading on/off."""
-
-    _attr_has_entity_name = True
-    _attr_icon = "mdi:home-battery"
-
-    def __init__(
-        self,
-        coordinator: FrankEnergieCoordinator,
-        config_entry: ConfigEntry,
-        battery_id: str,
-    ) -> None:
-        """Initialize the switch."""
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-        self._battery_id = battery_id
-        self._attr_name = "Self consumption trading allowed"
-        self._attr_translation_key = "self_consumption_trading_allowed"
-        self._attr_unique_id = f"{DOMAIN}_{battery_id}_self_consumption_trading_allowed"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, battery_id)},
-            name=f"Smart Battery {battery_id}",
-            manufacturer="Frank Energie",
-            model="SmartBattery",
-        )
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if switch is on."""
-        details_list = self.coordinator.data.get(DATA_BATTERY_DETAILS)
-        if not details_list:
-            return None
-        for detail in details_list:
-            if (
-                detail
-                and getattr(detail, "smart_battery", None)
-                and getattr(detail.smart_battery, "id", None) == self._battery_id
-            ):
-                settings = getattr(detail.smart_battery, "settings", None)
-                if settings:
-                    return getattr(settings, "self_consumption_trading_allowed", None)
-        return None
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        _LOGGER.warning(
-            "Turning on Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required."
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        _LOGGER.warning(
-            "Turning off Battery Self Consumption Trading is currently unverified. Captured GraphQL mutations are required."
-        )
-
-
-class FrankEnergiePvSteeringSwitch(
-    CoordinatorEntity[FrankEnergieCoordinator], SwitchEntity
-):
-    """Switch to toggle PV export steering on/off."""
-
-    _attr_has_entity_name = True
-    _attr_icon = "mdi:solar-power"
-
-    def __init__(
-        self,
-        coordinator: FrankEnergieCoordinator,
-        config_entry: ConfigEntry,
-        system_id: str,
-    ) -> None:
-        """Initialize the switch."""
-        super().__init__(coordinator)
-        self._config_entry = config_entry
-        self._system_id = system_id
-        self._attr_name = "Steering enabled"
-        self._attr_translation_key = "pv_steering_enabled"
-        self._attr_unique_id = f"{DOMAIN}_{system_id}_steering_enabled"
-
-        # Get PV system metadata (brand, model, name, serial_number)
-        metadata = coordinator.get_pv_system_metadata(system_id)
-
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, system_id)},
-            manufacturer=metadata["brand"],
-            model=metadata["model"],
-            name=metadata["display_name"],
-            serial_number=metadata["serial_number"],
-        )
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if switch is on."""
-        summary_dict = self.coordinator.data.get(DATA_PV_SUMMARY)
-        status = None
-        if summary_dict:
-            summary = summary_dict.get(self._system_id)
-            if summary:
-                status = getattr(summary, "steering_status", None)
-
-        if status is None:
-            systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
-            if systems_obj and systems_obj.systems:
-                pv_system = next(
-                    (s for s in systems_obj.systems if s.id == self._system_id), None
-                )
-                if pv_system:
-                    status = getattr(pv_system, "steering_status", None)
-
-        if status is None:
-            return None
-
-        # Return True if active/steering
-        return str(status).upper() in {"ACTIVE", "STEERING"}
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        _LOGGER.warning(
-            "Turning on PV Steering is currently unverified. Captured GraphQL mutations are required."
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        _LOGGER.warning(
-            "Turning off PV Steering is currently unverified. Captured GraphQL mutations are required."
-        )
+        """Disable Enode smart charging."""
+        _LOGGER.debug("Disabling Enode smart charging for vehicle %s", self._vehicle_id)
+        success = await self.coordinator.api.enode_disable_smart_charging()
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(
+                "Failed to disable Enode smart charging for vehicle %s",
+                self._vehicle_id,
+            )

--- a/custom_components/frank_energie/switch.py
+++ b/custom_components/frank_energie/switch.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     DATA_ENODE_VEHICLES,
-    SERVICE_NAME_ENODE_VEHICLES,
 )
 from .coordinator import FrankEnergieCoordinator
 
@@ -100,7 +99,6 @@ class FrankEnergieEnodeSmartChargingSwitch(
             manufacturer=brand,
             model=model,
             name=name,
-            via_device=(DOMAIN, f"{config_entry.entry_id}_{SERVICE_NAME_ENODE_VEHICLES}"),
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,7 @@ flake8 = "^7.3"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=HiDiHo01_home-assistant-frank_energie
+sonar.organization=hidiho01
+sonar.sources=custom_components
+sonar.tests=tests
+sonar.cpd.exclusions=tests/**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,3 +131,24 @@ def aioclient_responses(aioclient_mock, socket_enabled):
     )
 
     return responses
+
+
+@pytest.fixture
+def mock_coordinator():
+    from unittest.mock import AsyncMock, MagicMock
+
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.api = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    from unittest.mock import MagicMock
+    from homeassistant.config_entries import ConfigEntry
+
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    return entry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,3 +152,103 @@ def mock_config_entry():
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     return entry
+
+
+@pytest.fixture
+def create_mock_charge_settings():
+    """Fixture returning a function to create mock charge settings."""
+    from unittest.mock import MagicMock
+
+    def _create(
+        id="set_123",
+        deadline=None,
+        is_smart_charging_enabled=False,
+        is_solar_charging_enabled=False,
+        min_charge_limit=20,
+        max_charge_limit=80,
+        hour_monday=420,
+        hour_tuesday=420,
+        hour_wednesday=420,
+        hour_thursday=420,
+        hour_friday=420,
+        hour_saturday=420,
+        hour_sunday=420,
+    ):
+        settings = MagicMock()
+        settings.id = id
+        settings.deadline = deadline
+        settings.is_smart_charging_enabled = is_smart_charging_enabled
+        settings.is_solar_charging_enabled = is_solar_charging_enabled
+        settings.min_charge_limit = min_charge_limit
+        settings.max_charge_limit = max_charge_limit
+        settings.hour_monday = hour_monday
+        settings.hour_tuesday = hour_tuesday
+        settings.hour_wednesday = hour_wednesday
+        settings.hour_thursday = hour_thursday
+        settings.hour_friday = hour_friday
+        settings.hour_saturday = hour_saturday
+        settings.hour_sunday = hour_sunday
+        settings.calculated_deadline = None
+        return settings
+
+    return _create
+
+
+@pytest.fixture
+def create_mock_vehicle(create_mock_charge_settings):
+    """Fixture returning a function to create a mock Enode vehicle."""
+    from unittest.mock import MagicMock
+
+    def _create(
+        vehicle_id="veh_123",
+        brand="Tesla",
+        model="Model 3",
+        charge_settings_kwargs=None,
+    ):
+        vehicle = MagicMock()
+        vehicle.id = vehicle_id
+        if brand or model:
+            vehicle.information = MagicMock()
+            vehicle.information.brand = brand
+            vehicle.information.model = model
+        else:
+            vehicle.information = None
+
+        if charge_settings_kwargs is not None:
+            vehicle.charge_settings = create_mock_charge_settings(
+                **charge_settings_kwargs
+            )
+        else:
+            vehicle.charge_settings = create_mock_charge_settings()
+        return vehicle
+
+    return _create
+
+
+@pytest.fixture
+def create_mock_charger(create_mock_charge_settings):
+    """Fixture returning a function to create a mock Enode charger."""
+    from unittest.mock import MagicMock
+
+    def _create(
+        charger_id="chg_123",
+        brand="Wallbox",
+        model="Copper",
+        charge_settings_kwargs=None,
+    ):
+        charger = MagicMock()
+        charger.id = charger_id
+        if brand or model:
+            charger.information = {"brand": brand, "model": model}
+        else:
+            charger.information = None
+
+        if charge_settings_kwargs is not None:
+            charger.charge_settings = create_mock_charge_settings(
+                **charge_settings_kwargs
+            )
+        else:
+            charger.charge_settings = create_mock_charge_settings()
+        return charger
+
+    return _create

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,157 @@
+import pytest
+from unittest.mock import MagicMock
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.frank_energie.const import (
+    DATA_USER,
+    DATA_USER_SMART_FEED_IN,
+)
+from custom_components.frank_energie.binary_sensor import (
+    FrankEnergieSmartChargingBinarySensor,
+    FrankEnergieSmartTradingBinarySensor,
+    FrankEnergieSmartFeedInBinarySensor,
+    FrankEnergieSmartHvacBinarySensor,
+    _build_dynamic_smart_batteries_descriptions,
+    FrankEnergieBinarySensor,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    coordinator = MagicMock()
+    coordinator.data = {}
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def test_smart_charging_binary_sensor(mock_coordinator, mock_config_entry):
+    """Test the smart charging binary sensor."""
+    sensor = FrankEnergieSmartChargingBinarySensor(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert sensor.is_on is None
+
+    # Test when active (dict payload inside mock object)
+    mock_user = MagicMock()
+    mock_user.smartCharging = {"isActivated": True}
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert sensor.is_on is True
+
+    # Test when inactive (dict payload inside mock object)
+    mock_user.smartCharging = {"isActivated": False}
+    assert sensor.is_on is False
+
+    # Test with object attributes
+    mock_user.smartCharging = MagicMock()
+    mock_user.smartCharging.isActivated = True
+    assert sensor.is_on is True
+
+    mock_user.smartCharging.isActivated = False
+    assert sensor.is_on is False
+
+
+def test_smart_trading_binary_sensor(mock_coordinator, mock_config_entry):
+    """Test the smart trading binary sensor."""
+    sensor = FrankEnergieSmartTradingBinarySensor(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert sensor.is_on is None
+
+    # Test when active (dict payload inside mock object)
+    mock_user = MagicMock()
+    mock_user.smartTrading = {"isActivated": True}
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert sensor.is_on is True
+
+    # Test when inactive (dict payload inside mock object)
+    mock_user.smartTrading = {"isActivated": False}
+    assert sensor.is_on is False
+
+    # Test with object attributes
+    mock_user.smartTrading = MagicMock()
+    mock_user.smartTrading.isActivated = True
+    assert sensor.is_on is True
+
+
+def test_smart_feed_in_binary_sensor(mock_coordinator, mock_config_entry):
+    """Test the smart feed-in binary sensor."""
+    sensor = FrankEnergieSmartFeedInBinarySensor(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert sensor.is_on is None
+
+    # Test when active (dict payload)
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": True}}
+    assert sensor.is_on is True
+
+    # Test when inactive (dict payload)
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": False}}
+    assert sensor.is_on is False
+
+    # Test with object attributes
+    mock_feed_in = MagicMock()
+    mock_feed_in.is_activated = True
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: mock_feed_in}
+    assert sensor.is_on is True
+
+    mock_feed_in.is_activated = False
+    assert sensor.is_on is False
+
+
+def test_smart_hvac_binary_sensor(mock_coordinator, mock_config_entry):
+    """Test the smart HVAC binary sensor."""
+    sensor = FrankEnergieSmartHvacBinarySensor(mock_coordinator, mock_config_entry)
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    assert sensor.is_on is None
+
+    # Test when active (dict payload inside mock object)
+    mock_user = MagicMock()
+    mock_user.smartHvac = {"isActivated": True}
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert sensor.is_on is True
+
+    # Test when inactive (dict payload inside mock object)
+    mock_user.smartHvac = {"isActivated": False}
+    assert sensor.is_on is False
+
+    # Test with object attributes
+    mock_user.smartHvac = MagicMock()
+    mock_user.smartHvac.isActivated = True
+    assert sensor.is_on is True
+
+    # Test when smartHvac is None
+    mock_user.smartHvac = None
+    assert sensor.is_on is None
+
+
+def test_battery_self_consumption_trading_binary_sensor(mock_coordinator, mock_config_entry):
+    """Test battery self-consumption trading binary sensor builds and evaluates properly."""
+    mock_battery = MagicMock()
+    mock_battery.id = "bat_123"
+    mock_battery.brand = "Sunsynk"
+    mock_battery.settings = MagicMock()
+    mock_battery.settings.self_consumption_trading_allowed = True
+
+    descriptions = _build_dynamic_smart_batteries_descriptions([mock_battery])
+    assert len(descriptions) == 1
+    desc = descriptions[0]
+
+    assert desc.child_device_id == "bat_123"
+    assert desc.child_device_name == "Sunsynk Battery"
+    assert desc.child_device_manufacturer == "Sunsynk"
+
+    sensor = FrankEnergieBinarySensor(mock_coordinator, desc, mock_config_entry)
+    # Test value_fn evaluation
+    mock_coordinator.data = {}
+    assert sensor.is_on is True

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -135,7 +135,9 @@ def test_smart_hvac_binary_sensor(mock_coordinator, mock_config_entry):
     assert sensor.is_on is None
 
 
-def test_battery_self_consumption_trading_binary_sensor(mock_coordinator, mock_config_entry):
+def test_battery_self_consumption_trading_binary_sensor(
+    mock_coordinator, mock_config_entry
+):
     """Test battery self-consumption trading binary sensor builds and evaluates properly."""
     mock_battery = MagicMock()
     mock_battery.id = "bat_123"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,6 +1,4 @@
-import pytest
 from unittest.mock import MagicMock
-from homeassistant.config_entries import ConfigEntry
 
 from custom_components.frank_energie.const import (
     DATA_USER,
@@ -14,20 +12,6 @@ from custom_components.frank_energie.binary_sensor import (
     _build_dynamic_smart_batteries_descriptions,
     FrankEnergieBinarySensor,
 )
-
-
-@pytest.fixture
-def mock_coordinator():
-    coordinator = MagicMock()
-    coordinator.data = {}
-    return coordinator
-
-
-@pytest.fixture
-def mock_config_entry():
-    entry = MagicMock(spec=ConfigEntry)
-    entry.entry_id = "test_entry_id"
-    return entry
 
 
 def test_smart_charging_binary_sensor(mock_coordinator, mock_config_entry):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
-from homeassistant.config_entries import ConfigEntry
+from unittest.mock import MagicMock
 
 from custom_components.frank_energie.const import (
     DATA_USER,
@@ -12,22 +11,6 @@ from custom_components.frank_energie.button import (
     FrankEnergieDisableSmartFeedInButton,
     FrankEnergieDisableSmartHvacButton,
 )
-
-
-@pytest.fixture
-def mock_coordinator():
-    coordinator = MagicMock()
-    coordinator.data = {}
-    coordinator.api = AsyncMock()
-    coordinator.async_request_refresh = AsyncMock()
-    return coordinator
-
-
-@pytest.fixture
-def mock_config_entry():
-    entry = MagicMock(spec=ConfigEntry)
-    entry.entry_id = "test_entry_id"
-    return entry
 
 
 @pytest.mark.asyncio

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,127 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.frank_energie.const import (
+    DATA_USER,
+    DATA_USER_SMART_FEED_IN,
+)
+from custom_components.frank_energie.button import (
+    FrankEnergieRefreshButton,
+    FrankEnergieDisableSmartTradingButton,
+    FrankEnergieDisableSmartFeedInButton,
+    FrankEnergieDisableSmartHvacButton,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.api = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_refresh_button(mock_coordinator):
+    """Test manual refresh button press."""
+    button = FrankEnergieRefreshButton(
+        entry_id="test_entry",
+        coordinator=mock_coordinator,
+        name="Refresh prices",
+    )
+    assert button.name == "Refresh prices"
+    assert button.unique_id == "test_entry_refresh_prices"
+
+    await button.async_press()
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_disable_smart_trading_button(mock_coordinator, mock_config_entry):
+    """Test disable smart trading button availability and action."""
+    button = FrankEnergieDisableSmartTradingButton(mock_coordinator, mock_config_entry)
+
+    # Test unavailable when no data
+    mock_coordinator.data = {}
+    assert button.available is False
+
+    # Test available when active (dict payload)
+    mock_user = MagicMock()
+    mock_user.smartTrading = {"isActivated": True}
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert button.available is True
+
+    # Test unavailable when inactive (dict payload)
+    mock_user.smartTrading = {"isActivated": False}
+    assert button.available is False
+
+    # Test action
+    mock_user.smartTrading = {"isActivated": True}
+    mock_coordinator.api.disable_smart_trading.return_value = True
+
+    await button.async_press()
+    mock_coordinator.api.disable_smart_trading.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_disable_smart_feed_in_button(mock_coordinator, mock_config_entry):
+    """Test disable smart feed-in button availability and action."""
+    button = FrankEnergieDisableSmartFeedInButton(mock_coordinator, mock_config_entry)
+
+    # Test unavailable when no data
+    mock_coordinator.data = {}
+    assert button.available is False
+
+    # Test available when active (dict payload)
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": True}}
+    assert button.available is True
+
+    # Test unavailable when inactive (dict payload)
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": False}}
+    assert button.available is False
+
+    # Test action
+    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": True}}
+    mock_coordinator.api.disable_smart_feed_in.return_value = True
+
+    await button.async_press()
+    mock_coordinator.api.disable_smart_feed_in.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_disable_smart_hvac_button(mock_coordinator, mock_config_entry):
+    """Test disable smart HVAC button availability and action."""
+    button = FrankEnergieDisableSmartHvacButton(mock_coordinator, mock_config_entry)
+
+    # Test unavailable when no data
+    mock_coordinator.data = {}
+    assert button.available is False
+
+    # Test available when active
+    mock_user = MagicMock()
+    mock_user.smartHvac = {"isActivated": True}
+    mock_coordinator.data = {DATA_USER: mock_user}
+    assert button.available is True
+
+    # Test unavailable when inactive
+    mock_user.smartHvac = {"isActivated": False}
+    assert button.available is False
+
+    # Test action
+    mock_user.smartHvac = {"isActivated": True}
+    mock_coordinator.api.disable_smart_hvac.return_value = True
+
+    await button.async_press()
+    mock_coordinator.api.disable_smart_hvac.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -46,7 +46,7 @@ def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):
     mock_vehicle.information.brand = "Audi"
     mock_vehicle.information.model = "e-tron"
     mock_vehicle.charge_settings = MagicMock()
-    
+
     test_dt = datetime(2026, 5, 28, 7, 0, tzinfo=timezone.utc)
     mock_vehicle.charge_settings.calculated_deadline = test_dt
 
@@ -134,7 +134,7 @@ def test_charger_deadline_properties(mock_coordinator, mock_config_entry):
     mock_charger.id = charger_id
     mock_charger.information = {"brand": "Wallbox", "model": "Copper"}
     mock_charger.charge_settings = MagicMock()
-    
+
     test_dt = datetime(2026, 5, 28, 13, 15, tzinfo=timezone.utc)
     mock_charger.charge_settings.calculated_deadline = test_dt
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 import pytest
-from unittest.mock import AsyncMock, MagicMock
-from homeassistant.config_entries import ConfigEntry
+from unittest.mock import MagicMock
 
 from custom_components.frank_energie.const import (
     DATA_ENODE_CHARGERS,
@@ -11,22 +10,6 @@ from custom_components.frank_energie.datetime import (
     FrankEnergieVehicleDeadlineEntity,
     FrankEnergieChargerDeadlineEntity,
 )
-
-
-@pytest.fixture
-def mock_coordinator():
-    coordinator = MagicMock()
-    coordinator.data = {}
-    coordinator.api = AsyncMock()
-    coordinator.async_request_refresh = AsyncMock()
-    return coordinator
-
-
-@pytest.fixture
-def mock_config_entry():
-    entry = MagicMock(spec=ConfigEntry)
-    entry.entry_id = "test_entry_id"
-    return entry
 
 
 def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,206 @@
+from datetime import datetime, timezone
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.frank_energie.const import (
+    DATA_ENODE_CHARGERS,
+    DATA_ENODE_VEHICLES,
+)
+from custom_components.frank_energie.datetime import (
+    FrankEnergieVehicleDeadlineEntity,
+    FrankEnergieChargerDeadlineEntity,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.api = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):
+    """Test properties of the vehicle deadline entity."""
+    vehicle_id = "veh_123"
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    entity = FrankEnergieVehicleDeadlineEntity(
+        mock_coordinator, mock_config_entry, vehicle_id
+    )
+    assert entity.native_value is None
+
+    # Test when vehicle exists with settings
+    mock_vehicle = MagicMock()
+    mock_vehicle.id = vehicle_id
+    mock_vehicle.information.brand = "Audi"
+    mock_vehicle.information.model = "e-tron"
+    mock_vehicle.charge_settings = MagicMock()
+    
+    test_dt = datetime(2026, 5, 28, 7, 0, tzinfo=timezone.utc)
+    mock_vehicle.charge_settings.calculated_deadline = test_dt
+
+    mock_vehicles = MagicMock()
+    mock_vehicles.vehicles = [mock_vehicle]
+    mock_coordinator.data = {DATA_ENODE_VEHICLES: mock_vehicles}
+
+    entity = FrankEnergieVehicleDeadlineEntity(
+        mock_coordinator, mock_config_entry, vehicle_id
+    )
+    assert entity.native_value == test_dt
+    assert entity.device_info["manufacturer"] == "Audi"
+    assert entity.device_info["model"] == "e-tron"
+
+
+@pytest.mark.asyncio
+async def test_vehicle_deadline_set_value(mock_coordinator, mock_config_entry):
+    """Test setting value for the vehicle deadline entity."""
+    vehicle_id = "veh_123"
+    mock_vehicle = MagicMock()
+    mock_vehicle.id = vehicle_id
+    mock_vehicle.information = None
+    mock_vehicle.charge_settings = MagicMock()
+    mock_vehicle.charge_settings.id = "set_123"
+    mock_vehicle.charge_settings.is_smart_charging_enabled = True
+    mock_vehicle.charge_settings.is_solar_charging_enabled = False
+    mock_vehicle.charge_settings.min_charge_limit = 20
+    mock_vehicle.charge_settings.max_charge_limit = 80
+    mock_vehicle.charge_settings.hour_monday = 420
+    mock_vehicle.charge_settings.hour_tuesday = 420
+    mock_vehicle.charge_settings.hour_wednesday = 420
+    mock_vehicle.charge_settings.hour_thursday = 420
+    mock_vehicle.charge_settings.hour_friday = 420
+    mock_vehicle.charge_settings.hour_saturday = 420
+    mock_vehicle.charge_settings.hour_sunday = 420
+
+    mock_vehicles = MagicMock()
+    mock_vehicles.vehicles = [mock_vehicle]
+    mock_coordinator.data = {DATA_ENODE_VEHICLES: mock_vehicles}
+
+    entity = FrankEnergieVehicleDeadlineEntity(
+        mock_coordinator, mock_config_entry, vehicle_id
+    )
+
+    mock_coordinator.api.enode_update_vehicle_charge_settings.return_value = True
+
+    new_deadline = datetime(2026, 5, 29, 8, 30, tzinfo=timezone.utc)
+    await entity.async_set_value(new_deadline)
+
+    expected_payload = {
+        "id": "set_123",
+        "deadline": new_deadline.isoformat(),
+        "isSmartChargingEnabled": True,
+        "isSolarChargingEnabled": False,
+        "minChargeLimit": 20,
+        "maxChargeLimit": 80,
+        "hourMonday": 420,
+        "hourTuesday": 420,
+        "hourWednesday": 420,
+        "hourThursday": 420,
+        "hourFriday": 420,
+        "hourSaturday": 420,
+        "hourSunday": 420,
+    }
+
+    mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once_with(
+        expected_payload
+    )
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+def test_charger_deadline_properties(mock_coordinator, mock_config_entry):
+    """Test properties of the charger deadline entity."""
+    charger_id = "chg_123"
+
+    # Test when data is missing
+    mock_coordinator.data = {}
+    entity = FrankEnergieChargerDeadlineEntity(
+        mock_coordinator, mock_config_entry, charger_id
+    )
+    assert entity.native_value is None
+
+    # Test when charger exists with settings
+    mock_charger = MagicMock()
+    mock_charger.id = charger_id
+    mock_charger.information = {"brand": "Wallbox", "model": "Copper"}
+    mock_charger.charge_settings = MagicMock()
+    
+    test_dt = datetime(2026, 5, 28, 13, 15, tzinfo=timezone.utc)
+    mock_charger.charge_settings.calculated_deadline = test_dt
+
+    mock_chargers = MagicMock()
+    mock_chargers.chargers = [mock_charger]
+    mock_coordinator.data = {DATA_ENODE_CHARGERS: mock_chargers}
+
+    entity = FrankEnergieChargerDeadlineEntity(
+        mock_coordinator, mock_config_entry, charger_id
+    )
+    assert entity.native_value == test_dt
+    assert entity.device_info["manufacturer"] == "Wallbox"
+    assert entity.device_info["model"] == "Copper"
+
+
+@pytest.mark.asyncio
+async def test_charger_deadline_set_value(mock_coordinator, mock_config_entry):
+    """Test setting value for the charger deadline entity."""
+    charger_id = "chg_123"
+    mock_charger = MagicMock()
+    mock_charger.id = charger_id
+    mock_charger.information = None
+    mock_charger.charge_settings = MagicMock()
+    mock_charger.charge_settings.id = "set_456"
+    mock_charger.charge_settings.is_smart_charging_enabled = False
+    mock_charger.charge_settings.is_solar_charging_enabled = True
+    mock_charger.charge_settings.min_charge_limit = 10
+    mock_charger.charge_settings.max_charge_limit = 90
+    mock_charger.charge_settings.hour_monday = 480
+    mock_charger.charge_settings.hour_tuesday = 480
+    mock_charger.charge_settings.hour_wednesday = 480
+    mock_charger.charge_settings.hour_thursday = 480
+    mock_charger.charge_settings.hour_friday = 480
+    mock_charger.charge_settings.hour_saturday = 480
+    mock_charger.charge_settings.hour_sunday = 480
+
+    mock_chargers = MagicMock()
+    mock_chargers.chargers = [mock_charger]
+    mock_coordinator.data = {DATA_ENODE_CHARGERS: mock_chargers}
+
+    entity = FrankEnergieChargerDeadlineEntity(
+        mock_coordinator, mock_config_entry, charger_id
+    )
+
+    mock_coordinator.api.enode_update_charger_charge_settings.return_value = True
+
+    new_deadline = datetime(2026, 5, 29, 7, 0, tzinfo=timezone.utc)
+    await entity.async_set_value(new_deadline)
+
+    expected_payload = {
+        "id": "set_456",
+        "deadline": new_deadline.isoformat(),
+        "isSmartChargingEnabled": False,
+        "isSolarChargingEnabled": True,
+        "minChargeLimit": 10,
+        "maxChargeLimit": 90,
+        "hourMonday": 480,
+        "hourTuesday": 480,
+        "hourWednesday": 480,
+        "hourThursday": 480,
+        "hourFriday": 480,
+        "hourSaturday": 480,
+        "hourSunday": 480,
+    }
+
+    mock_coordinator.api.enode_update_charger_charge_settings.assert_called_once_with(
+        expected_payload
+    )
+    mock_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -187,3 +187,93 @@ async def test_charger_deadline_set_value(mock_coordinator, mock_config_entry):
         expected_payload
     )
     mock_coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_vehicle_deadline_set_value_failure(mock_coordinator, mock_config_entry):
+    """Test vehicle deadline set_value handles API failure by not refreshing."""
+    from unittest.mock import MagicMock
+    from datetime import datetime, timezone
+    from custom_components.frank_energie.datetime import (
+        FrankEnergieVehicleDeadlineEntity,
+    )
+
+    vehicle_id = "veh_123"
+    mock_vehicle = MagicMock()
+    mock_vehicle.id = vehicle_id
+    mock_vehicle.information = None
+    mock_vehicle.charge_settings = MagicMock()
+    mock_vehicle.charge_settings.id = "set_123"
+    mock_vehicle.charge_settings.deadline = None
+    mock_vehicle.charge_settings.is_smart_charging_enabled = True
+    mock_vehicle.charge_settings.is_solar_charging_enabled = False
+    mock_vehicle.charge_settings.min_charge_limit = 20
+    mock_vehicle.charge_settings.max_charge_limit = 80
+    mock_vehicle.charge_settings.hour_monday = 420
+    mock_vehicle.charge_settings.hour_tuesday = 420
+    mock_vehicle.charge_settings.hour_wednesday = 420
+    mock_vehicle.charge_settings.hour_thursday = 420
+    mock_vehicle.charge_settings.hour_friday = 420
+    mock_vehicle.charge_settings.hour_saturday = 420
+    mock_vehicle.charge_settings.hour_sunday = 420
+
+    mock_vehicles = MagicMock()
+    mock_vehicles.vehicles = [mock_vehicle]
+    mock_coordinator.data = {DATA_ENODE_VEHICLES: mock_vehicles}
+
+    entity = FrankEnergieVehicleDeadlineEntity(
+        mock_coordinator, mock_config_entry, vehicle_id
+    )
+
+    mock_coordinator.api.enode_update_vehicle_charge_settings.return_value = False
+
+    new_deadline = datetime(2026, 5, 29, 7, 0, tzinfo=timezone.utc)
+    await entity.async_set_value(new_deadline)
+
+    mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_charger_deadline_set_value_failure(mock_coordinator, mock_config_entry):
+    """Test charger deadline set_value handles API failure by not refreshing."""
+    from unittest.mock import MagicMock
+    from datetime import datetime, timezone
+    from custom_components.frank_energie.datetime import (
+        FrankEnergieChargerDeadlineEntity,
+    )
+
+    charger_id = "chg_123"
+    mock_charger = MagicMock()
+    mock_charger.id = charger_id
+    mock_charger.information = None
+    mock_charger.charge_settings = MagicMock()
+    mock_charger.charge_settings.id = "set_456"
+    mock_charger.charge_settings.deadline = None
+    mock_charger.charge_settings.is_smart_charging_enabled = False
+    mock_charger.charge_settings.is_solar_charging_enabled = True
+    mock_charger.charge_settings.min_charge_limit = 10
+    mock_charger.charge_settings.max_charge_limit = 90
+    mock_charger.charge_settings.hour_monday = 480
+    mock_charger.charge_settings.hour_tuesday = 480
+    mock_charger.charge_settings.hour_wednesday = 480
+    mock_charger.charge_settings.hour_thursday = 480
+    mock_charger.charge_settings.hour_friday = 480
+    mock_charger.charge_settings.hour_saturday = 480
+    mock_charger.charge_settings.hour_sunday = 480
+
+    mock_chargers = MagicMock()
+    mock_chargers.chargers = [mock_charger]
+    mock_coordinator.data = {DATA_ENODE_CHARGERS: mock_chargers}
+
+    entity = FrankEnergieChargerDeadlineEntity(
+        mock_coordinator, mock_config_entry, charger_id
+    )
+
+    mock_coordinator.api.enode_update_charger_charge_settings.return_value = False
+
+    new_deadline = datetime(2026, 5, 29, 7, 0, tzinfo=timezone.utc)
+    await entity.async_set_value(new_deadline)
+
+    mock_coordinator.api.enode_update_charger_charge_settings.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_not_called()

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -12,7 +12,9 @@ from custom_components.frank_energie.datetime import (
 )
 
 
-def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):
+def test_vehicle_deadline_properties(
+    mock_coordinator, mock_config_entry, create_mock_vehicle
+):
     """Test properties of the vehicle deadline entity."""
     vehicle_id = "veh_123"
 
@@ -24,13 +26,10 @@ def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):
     assert entity.native_value is None
 
     # Test when vehicle exists with settings
-    mock_vehicle = MagicMock()
-    mock_vehicle.id = vehicle_id
-    mock_vehicle.information.brand = "Audi"
-    mock_vehicle.information.model = "e-tron"
-    mock_vehicle.charge_settings = MagicMock()
-
     test_dt = datetime(2026, 5, 28, 7, 0, tzinfo=timezone.utc)
+    mock_vehicle = create_mock_vehicle(
+        vehicle_id=vehicle_id, brand="Audi", model="e-tron"
+    )
     mock_vehicle.charge_settings.calculated_deadline = test_dt
 
     mock_vehicles = MagicMock()
@@ -46,25 +45,17 @@ def test_vehicle_deadline_properties(mock_coordinator, mock_config_entry):
 
 
 @pytest.mark.asyncio
-async def test_vehicle_deadline_set_value(mock_coordinator, mock_config_entry):
+async def test_vehicle_deadline_set_value(
+    mock_coordinator, mock_config_entry, create_mock_vehicle
+):
     """Test setting value for the vehicle deadline entity."""
     vehicle_id = "veh_123"
-    mock_vehicle = MagicMock()
-    mock_vehicle.id = vehicle_id
-    mock_vehicle.information = None
-    mock_vehicle.charge_settings = MagicMock()
-    mock_vehicle.charge_settings.id = "set_123"
-    mock_vehicle.charge_settings.is_smart_charging_enabled = True
-    mock_vehicle.charge_settings.is_solar_charging_enabled = False
-    mock_vehicle.charge_settings.min_charge_limit = 20
-    mock_vehicle.charge_settings.max_charge_limit = 80
-    mock_vehicle.charge_settings.hour_monday = 420
-    mock_vehicle.charge_settings.hour_tuesday = 420
-    mock_vehicle.charge_settings.hour_wednesday = 420
-    mock_vehicle.charge_settings.hour_thursday = 420
-    mock_vehicle.charge_settings.hour_friday = 420
-    mock_vehicle.charge_settings.hour_saturday = 420
-    mock_vehicle.charge_settings.hour_sunday = 420
+    mock_vehicle = create_mock_vehicle(
+        vehicle_id=vehicle_id,
+        brand=None,
+        model=None,
+        charge_settings_kwargs={"is_smart_charging_enabled": True},
+    )
 
     mock_vehicles = MagicMock()
     mock_vehicles.vehicles = [mock_vehicle]
@@ -101,7 +92,9 @@ async def test_vehicle_deadline_set_value(mock_coordinator, mock_config_entry):
     mock_coordinator.async_request_refresh.assert_called_once()
 
 
-def test_charger_deadline_properties(mock_coordinator, mock_config_entry):
+def test_charger_deadline_properties(
+    mock_coordinator, mock_config_entry, create_mock_charger
+):
     """Test properties of the charger deadline entity."""
     charger_id = "chg_123"
 
@@ -113,12 +106,10 @@ def test_charger_deadline_properties(mock_coordinator, mock_config_entry):
     assert entity.native_value is None
 
     # Test when charger exists with settings
-    mock_charger = MagicMock()
-    mock_charger.id = charger_id
-    mock_charger.information = {"brand": "Wallbox", "model": "Copper"}
-    mock_charger.charge_settings = MagicMock()
-
     test_dt = datetime(2026, 5, 28, 13, 15, tzinfo=timezone.utc)
+    mock_charger = create_mock_charger(
+        charger_id=charger_id, brand="Wallbox", model="Copper"
+    )
     mock_charger.charge_settings.calculated_deadline = test_dt
 
     mock_chargers = MagicMock()
@@ -134,25 +125,29 @@ def test_charger_deadline_properties(mock_coordinator, mock_config_entry):
 
 
 @pytest.mark.asyncio
-async def test_charger_deadline_set_value(mock_coordinator, mock_config_entry):
+async def test_charger_deadline_set_value(
+    mock_coordinator, mock_config_entry, create_mock_charger
+):
     """Test setting value for the charger deadline entity."""
     charger_id = "chg_123"
-    mock_charger = MagicMock()
-    mock_charger.id = charger_id
-    mock_charger.information = None
-    mock_charger.charge_settings = MagicMock()
-    mock_charger.charge_settings.id = "set_456"
-    mock_charger.charge_settings.is_smart_charging_enabled = False
-    mock_charger.charge_settings.is_solar_charging_enabled = True
-    mock_charger.charge_settings.min_charge_limit = 10
-    mock_charger.charge_settings.max_charge_limit = 90
-    mock_charger.charge_settings.hour_monday = 480
-    mock_charger.charge_settings.hour_tuesday = 480
-    mock_charger.charge_settings.hour_wednesday = 480
-    mock_charger.charge_settings.hour_thursday = 480
-    mock_charger.charge_settings.hour_friday = 480
-    mock_charger.charge_settings.hour_saturday = 480
-    mock_charger.charge_settings.hour_sunday = 480
+    mock_charger = create_mock_charger(
+        charger_id=charger_id,
+        brand=None,
+        model=None,
+        charge_settings_kwargs={
+            "id": "set_456",
+            "is_solar_charging_enabled": True,
+            "min_charge_limit": 10,
+            "max_charge_limit": 90,
+            "hour_monday": 480,
+            "hour_tuesday": 480,
+            "hour_wednesday": 480,
+            "hour_thursday": 480,
+            "hour_friday": 480,
+            "hour_saturday": 480,
+            "hour_sunday": 480,
+        },
+    )
 
     mock_chargers = MagicMock()
     mock_chargers.chargers = [mock_charger]
@@ -190,32 +185,17 @@ async def test_charger_deadline_set_value(mock_coordinator, mock_config_entry):
 
 
 @pytest.mark.asyncio
-async def test_vehicle_deadline_set_value_failure(mock_coordinator, mock_config_entry):
+async def test_vehicle_deadline_set_value_failure(
+    mock_coordinator, mock_config_entry, create_mock_vehicle
+):
     """Test vehicle deadline set_value handles API failure by not refreshing."""
-    from unittest.mock import MagicMock
-    from datetime import datetime, timezone
-    from custom_components.frank_energie.datetime import (
-        FrankEnergieVehicleDeadlineEntity,
-    )
-
     vehicle_id = "veh_123"
-    mock_vehicle = MagicMock()
-    mock_vehicle.id = vehicle_id
-    mock_vehicle.information = None
-    mock_vehicle.charge_settings = MagicMock()
-    mock_vehicle.charge_settings.id = "set_123"
-    mock_vehicle.charge_settings.deadline = None
-    mock_vehicle.charge_settings.is_smart_charging_enabled = True
-    mock_vehicle.charge_settings.is_solar_charging_enabled = False
-    mock_vehicle.charge_settings.min_charge_limit = 20
-    mock_vehicle.charge_settings.max_charge_limit = 80
-    mock_vehicle.charge_settings.hour_monday = 420
-    mock_vehicle.charge_settings.hour_tuesday = 420
-    mock_vehicle.charge_settings.hour_wednesday = 420
-    mock_vehicle.charge_settings.hour_thursday = 420
-    mock_vehicle.charge_settings.hour_friday = 420
-    mock_vehicle.charge_settings.hour_saturday = 420
-    mock_vehicle.charge_settings.hour_sunday = 420
+    mock_vehicle = create_mock_vehicle(
+        vehicle_id=vehicle_id,
+        brand=None,
+        model=None,
+        charge_settings_kwargs={"is_smart_charging_enabled": True},
+    )
 
     mock_vehicles = MagicMock()
     mock_vehicles.vehicles = [mock_vehicle]
@@ -235,32 +215,29 @@ async def test_vehicle_deadline_set_value_failure(mock_coordinator, mock_config_
 
 
 @pytest.mark.asyncio
-async def test_charger_deadline_set_value_failure(mock_coordinator, mock_config_entry):
+async def test_charger_deadline_set_value_failure(
+    mock_coordinator, mock_config_entry, create_mock_charger
+):
     """Test charger deadline set_value handles API failure by not refreshing."""
-    from unittest.mock import MagicMock
-    from datetime import datetime, timezone
-    from custom_components.frank_energie.datetime import (
-        FrankEnergieChargerDeadlineEntity,
-    )
-
     charger_id = "chg_123"
-    mock_charger = MagicMock()
-    mock_charger.id = charger_id
-    mock_charger.information = None
-    mock_charger.charge_settings = MagicMock()
-    mock_charger.charge_settings.id = "set_456"
-    mock_charger.charge_settings.deadline = None
-    mock_charger.charge_settings.is_smart_charging_enabled = False
-    mock_charger.charge_settings.is_solar_charging_enabled = True
-    mock_charger.charge_settings.min_charge_limit = 10
-    mock_charger.charge_settings.max_charge_limit = 90
-    mock_charger.charge_settings.hour_monday = 480
-    mock_charger.charge_settings.hour_tuesday = 480
-    mock_charger.charge_settings.hour_wednesday = 480
-    mock_charger.charge_settings.hour_thursday = 480
-    mock_charger.charge_settings.hour_friday = 480
-    mock_charger.charge_settings.hour_saturday = 480
-    mock_charger.charge_settings.hour_sunday = 480
+    mock_charger = create_mock_charger(
+        charger_id=charger_id,
+        brand=None,
+        model=None,
+        charge_settings_kwargs={
+            "id": "set_456",
+            "is_solar_charging_enabled": True,
+            "min_charge_limit": 10,
+            "max_charge_limit": 90,
+            "hour_monday": 480,
+            "hour_tuesday": 480,
+            "hour_wednesday": 480,
+            "hour_thursday": 480,
+            "hour_friday": 480,
+            "hour_saturday": 480,
+            "hour_sunday": 480,
+        },
+    )
 
     mock_chargers = MagicMock()
     mock_chargers.chargers = [mock_charger]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,27 +1,13 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from homeassistant.config_entries import ConfigEntry
 
 from custom_components.frank_energie.const import (
-    DATA_USER,
-    DATA_USER_SMART_FEED_IN,
-    DATA_BATTERY_DETAILS,
-    DATA_PV_SYSTEMS,
-    DATA_PV_SUMMARY,
+    DOMAIN,
+    DATA_ENODE_VEHICLES,
 )
 from custom_components.frank_energie.switch import (
-    FrankEnergieSmartChargingSwitch,
-    FrankEnergieSmartTradingSwitch,
-    FrankEnergieSmartFeedInSwitch,
-    FrankEnergieBatteryTradingSwitch,
-    FrankEnergiePvSteeringSwitch,
-)
-from python_frank_energie.models import (
-    UserSmartFeedInStatus,
-    SmartBatteryDetails,
-    SmartPvSystems,
-    SmartPvSystem,
-    SmartPvSystemSummary,
+    FrankEnergieEnodeSmartChargingSwitch,
 )
 
 
@@ -29,6 +15,8 @@ from python_frank_energie.models import (
 def mock_coordinator():
     coordinator = MagicMock()
     coordinator.data = {}
+    coordinator.api = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
     return coordinator
 
 
@@ -39,146 +27,77 @@ def mock_config_entry():
     return entry
 
 
-def test_smart_charging_switch(mock_coordinator, mock_config_entry):
-    """Test the smart charging switch is_on property."""
-    switch = FrankEnergieSmartChargingSwitch(mock_coordinator, mock_config_entry)
+def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_entry):
+    """Test properties of the Enode smart charging switch."""
+    vehicle_id = "vehicle_1"
 
     # Test when data is missing
     mock_coordinator.data = {}
-    assert switch.is_on is None
-
-    # Test when active (dict payload)
-    mock_coordinator.data = {DATA_USER: MagicMock(smartCharging={"isActivated": True})}
-    assert switch.is_on is True
-
-    # Test when inactive (dict payload)
-    mock_coordinator.data = {DATA_USER: MagicMock(smartCharging={"isActivated": False})}
-    assert switch.is_on is False
-
-    # Test with object attribute
-    mock_user = MagicMock()
-    mock_user.smartCharging = MagicMock()
-    mock_user.smartCharging.isActivated = True
-    mock_coordinator.data = {DATA_USER: mock_user}
-    assert switch.is_on is True
-
-
-def test_smart_trading_switch(mock_coordinator, mock_config_entry):
-    """Test the smart trading switch is_on property."""
-    switch = FrankEnergieSmartTradingSwitch(mock_coordinator, mock_config_entry)
-
-    # Test when data is missing
-    mock_coordinator.data = {}
-    assert switch.is_on is None
-
-    # Test when active (dict payload)
-    mock_coordinator.data = {DATA_USER: MagicMock(smartTrading={"isActivated": True})}
-    assert switch.is_on is True
-
-    # Test when inactive (dict payload)
-    mock_coordinator.data = {DATA_USER: MagicMock(smartTrading={"isActivated": False})}
-    assert switch.is_on is False
-
-
-def test_smart_feed_in_switch(mock_coordinator, mock_config_entry):
-    """Test the smart feed-in switch is_on property."""
-    switch = FrankEnergieSmartFeedInSwitch(mock_coordinator, mock_config_entry)
-
-    # Test when data is missing
-    mock_coordinator.data = {}
-    assert switch.is_on is None
-
-    # Test when active (dict payload)
-    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: {"isActivated": True}}
-    assert switch.is_on is True
-
-    # Test when inactive (object payload)
-    mock_feed_in = MagicMock(spec=UserSmartFeedInStatus)
-    mock_feed_in.is_activated = False
-    mock_coordinator.data = {DATA_USER_SMART_FEED_IN: mock_feed_in}
-    assert switch.is_on is False
-
-
-def test_battery_trading_switch(mock_coordinator, mock_config_entry):
-    """Test the battery self-consumption trading switch is_on property."""
-    battery_id = "test_battery_id"
-    switch = FrankEnergieBatteryTradingSwitch(
-        mock_coordinator, mock_config_entry, battery_id
+    switch = FrankEnergieEnodeSmartChargingSwitch(
+        mock_coordinator, mock_config_entry, vehicle_id
     )
-
-    # Test when details are missing
-    mock_coordinator.data = {}
     assert switch.is_on is None
+    assert switch.unique_id == f"{DOMAIN}_{vehicle_id}_enode_smart_charging"
 
-    # Test when details have our battery, with setting active
-    mock_detail = MagicMock(spec=SmartBatteryDetails)
-    mock_detail.smart_battery = MagicMock()
-    mock_detail.smart_battery.id = battery_id
-    mock_detail.smart_battery.settings = MagicMock()
-    mock_detail.smart_battery.settings.self_consumption_trading_allowed = True
+    # Test with vehicle matching ID but without charge settings
+    mock_vehicle = MagicMock()
+    mock_vehicle.id = vehicle_id
+    mock_vehicle.charge_settings = None
+    mock_vehicle.information = MagicMock()
+    mock_vehicle.information.brand = "Tesla"
+    mock_vehicle.information.model = "Model 3"
 
-    mock_coordinator.data = {DATA_BATTERY_DETAILS: [mock_detail]}
-    assert switch.is_on is True
+    mock_vehicles = MagicMock()
+    mock_vehicles.vehicles = [mock_vehicle]
+    mock_coordinator.data = {DATA_ENODE_VEHICLES: mock_vehicles}
 
-    # Test when details have a different battery id
-    mock_detail.smart_battery.id = "other_battery"
-    assert switch.is_on is None
-
-
-def test_pv_steering_switch(mock_coordinator, mock_config_entry):
-    """Test the PV steering switch is_on property."""
-    system_id = "pv_sys_1"
-
-    # Mock systems_obj for constructor
-    mock_system = MagicMock(spec=SmartPvSystem)
-    mock_system.id = system_id
-    mock_system.brand = "SolarEdge"
-    mock_system.model = "SE3000"
-    mock_system.display_name = "Tuin PV"
-    mock_system.inverter_serial_numbers = ["SE123456"]
-
-    mock_systems = MagicMock(spec=SmartPvSystems)
-    mock_systems.systems = [mock_system]
-    mock_coordinator.data = {DATA_PV_SYSTEMS: mock_systems}
-
-    switch = FrankEnergiePvSteeringSwitch(
-        mock_coordinator, mock_config_entry, system_id
+    switch = FrankEnergieEnodeSmartChargingSwitch(
+        mock_coordinator, mock_config_entry, vehicle_id
     )
+    assert switch.is_on is None
+    assert switch.device_info["identifiers"] == {(DOMAIN, vehicle_id)}
+    assert switch.device_info["manufacturer"] == "Tesla"
+    assert switch.device_info["model"] == "Model 3"
+    assert switch.device_info["name"] == "Tesla Model 3"
 
-    # Test when summary says active
-    mock_summary = MagicMock(spec=SmartPvSystemSummary)
-    mock_summary.steering_status = "ACTIVE"
-    mock_coordinator.data = {
-        DATA_PV_SYSTEMS: mock_systems,
-        DATA_PV_SUMMARY: {system_id: mock_summary},
-    }
+    # Test with vehicle matching ID and with charge settings
+    mock_settings = MagicMock()
+    mock_settings.is_smart_charging_enabled = True
+    mock_vehicle.charge_settings = mock_settings
     assert switch.is_on is True
 
-    # Test when summary says stopped, but system list says active
-    mock_summary.steering_status = "STOPPED"
-    mock_system.steering_status = "ACTIVE"
-    assert switch.is_on is False
-
-    # Test fallback to systems_obj when summary has no steering_status
-    mock_summary.steering_status = None
-    mock_system.steering_status = "STEERING"
-    assert switch.is_on is True
-
-    mock_system.steering_status = "INACTIVE"
+    # Test when disabled
+    mock_settings.is_smart_charging_enabled = False
     assert switch.is_on is False
 
 
 @pytest.mark.asyncio
-async def test_switch_actions(mock_coordinator, mock_config_entry):
-    """Test that turn_on and turn_off methods run without exceptions (logging warnings)."""
-    switches = [
-        FrankEnergieSmartChargingSwitch(mock_coordinator, mock_config_entry),
-        FrankEnergieSmartTradingSwitch(mock_coordinator, mock_config_entry),
-        FrankEnergieSmartFeedInSwitch(mock_coordinator, mock_config_entry),
-        FrankEnergieBatteryTradingSwitch(mock_coordinator, mock_config_entry, "bat1"),
-        FrankEnergiePvSteeringSwitch(mock_coordinator, mock_config_entry, "pv1"),
-    ]
+async def test_enode_smart_charging_switch_actions(
+    mock_coordinator, mock_config_entry
+):
+    """Test turn_on and turn_off actions."""
+    vehicle_id = "vehicle_1"
+    mock_vehicle = MagicMock()
+    mock_vehicle.id = vehicle_id
+    mock_vehicle.information = None
+    mock_vehicle.charge_settings = MagicMock()
 
-    for switch in switches:
-        await switch.async_turn_on()
-        await switch.async_turn_off()
+    mock_vehicles = MagicMock()
+    mock_vehicles.vehicles = [mock_vehicle]
+    mock_coordinator.data = {DATA_ENODE_VEHICLES: mock_vehicles}
+
+    switch = FrankEnergieEnodeSmartChargingSwitch(
+        mock_coordinator, mock_config_entry, vehicle_id
+    )
+
+    # Test turn on success
+    mock_coordinator.api.enode_enable_smart_charging.return_value = True
+    await switch.async_turn_on()
+    mock_coordinator.api.enode_enable_smart_charging.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+    # Test turn off success
+    mock_coordinator.api.enode_disable_smart_charging.return_value = True
+    await switch.async_turn_off()
+    mock_coordinator.api.enode_disable_smart_charging.assert_called_once()
+    assert mock_coordinator.async_request_refresh.call_count == 2

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
-from homeassistant.config_entries import ConfigEntry
+from unittest.mock import MagicMock
 
 from custom_components.frank_energie.const import (
     DOMAIN,
@@ -9,22 +8,6 @@ from custom_components.frank_energie.const import (
 from custom_components.frank_energie.switch import (
     FrankEnergieEnodeSmartChargingSwitch,
 )
-
-
-@pytest.fixture
-def mock_coordinator():
-    coordinator = MagicMock()
-    coordinator.data = {}
-    coordinator.api = AsyncMock()
-    coordinator.async_request_refresh = AsyncMock()
-    return coordinator
-
-
-@pytest.fixture
-def mock_config_entry():
-    entry = MagicMock(spec=ConfigEntry)
-    entry.entry_id = "test_entry_id"
-    return entry
 
 
 def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_entry):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -72,9 +72,7 @@ def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_en
 
 
 @pytest.mark.asyncio
-async def test_enode_smart_charging_switch_actions(
-    mock_coordinator, mock_config_entry
-):
+async def test_enode_smart_charging_switch_actions(mock_coordinator, mock_config_entry):
     """Test turn_on and turn_off actions."""
     vehicle_id = "vehicle_1"
     mock_vehicle = MagicMock()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -10,7 +10,9 @@ from custom_components.frank_energie.switch import (
 )
 
 
-def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_entry):
+def test_enode_smart_charging_switch_properties(
+    mock_coordinator, mock_config_entry, create_mock_vehicle
+):
     """Test properties of the Enode smart charging switch."""
     vehicle_id = "vehicle_1"
 
@@ -23,12 +25,10 @@ def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_en
     assert switch.unique_id == f"{DOMAIN}_{vehicle_id}_enode_smart_charging"
 
     # Test with vehicle matching ID but without charge settings
-    mock_vehicle = MagicMock()
-    mock_vehicle.id = vehicle_id
+    mock_vehicle = create_mock_vehicle(
+        vehicle_id=vehicle_id, brand="Tesla", model="Model 3"
+    )
     mock_vehicle.charge_settings = None
-    mock_vehicle.information = MagicMock()
-    mock_vehicle.information.brand = "Tesla"
-    mock_vehicle.information.model = "Model 3"
 
     mock_vehicles = MagicMock()
     mock_vehicles.vehicles = [mock_vehicle]
@@ -55,28 +55,17 @@ def test_enode_smart_charging_switch_properties(mock_coordinator, mock_config_en
 
 
 @pytest.mark.asyncio
-async def test_enode_smart_charging_switch_actions(mock_coordinator, mock_config_entry):
+async def test_enode_smart_charging_switch_actions(
+    mock_coordinator, mock_config_entry, create_mock_vehicle
+):
     """Test turn_on and turn_off actions."""
     vehicle_id = "vehicle_1"
-    mock_vehicle = MagicMock()
-    mock_vehicle.id = vehicle_id
-    mock_vehicle.information = None
-
-    mock_settings = MagicMock()
-    mock_settings.id = "set_123"
-    mock_settings.deadline = None
-    mock_settings.is_smart_charging_enabled = False
-    mock_settings.is_solar_charging_enabled = False
-    mock_settings.min_charge_limit = 20
-    mock_settings.max_charge_limit = 80
-    mock_settings.hour_monday = 420
-    mock_settings.hour_tuesday = 420
-    mock_settings.hour_wednesday = 420
-    mock_settings.hour_thursday = 420
-    mock_settings.hour_friday = 420
-    mock_settings.hour_saturday = 420
-    mock_settings.hour_sunday = 420
-    mock_vehicle.charge_settings = mock_settings
+    mock_vehicle = create_mock_vehicle(
+        vehicle_id=vehicle_id,
+        brand=None,
+        model=None,
+        charge_settings_kwargs={"is_smart_charging_enabled": False},
+    )
 
     mock_vehicles = MagicMock()
     mock_vehicles.vehicles = [mock_vehicle]
@@ -102,7 +91,9 @@ async def test_enode_smart_charging_switch_actions(mock_coordinator, mock_config
     mock_coordinator.async_request_refresh.reset_mock()
 
     # Test turn off success
-    mock_settings.is_smart_charging_enabled = True  # Simulate switch state change
+    mock_vehicle.charge_settings.is_smart_charging_enabled = (
+        True  # Simulate switch state change
+    )
     await switch.async_turn_off()
     mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once()
     mock_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -61,7 +61,22 @@ async def test_enode_smart_charging_switch_actions(mock_coordinator, mock_config
     mock_vehicle = MagicMock()
     mock_vehicle.id = vehicle_id
     mock_vehicle.information = None
-    mock_vehicle.charge_settings = MagicMock()
+
+    mock_settings = MagicMock()
+    mock_settings.id = "set_123"
+    mock_settings.deadline = None
+    mock_settings.is_smart_charging_enabled = False
+    mock_settings.is_solar_charging_enabled = False
+    mock_settings.min_charge_limit = 20
+    mock_settings.max_charge_limit = 80
+    mock_settings.hour_monday = 420
+    mock_settings.hour_tuesday = 420
+    mock_settings.hour_wednesday = 420
+    mock_settings.hour_thursday = 420
+    mock_settings.hour_friday = 420
+    mock_settings.hour_saturday = 420
+    mock_settings.hour_sunday = 420
+    mock_vehicle.charge_settings = mock_settings
 
     mock_vehicles = MagicMock()
     mock_vehicles.vehicles = [mock_vehicle]
@@ -72,13 +87,35 @@ async def test_enode_smart_charging_switch_actions(mock_coordinator, mock_config
     )
 
     # Test turn on success
-    mock_coordinator.api.enode_enable_smart_charging.return_value = True
+    mock_coordinator.api.enode_update_vehicle_charge_settings.return_value = True
     await switch.async_turn_on()
-    mock_coordinator.api.enode_enable_smart_charging.assert_called_once()
+    mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once()
     mock_coordinator.async_request_refresh.assert_called_once()
 
+    # Verify input_data had isSmartChargingEnabled = True
+    call_arg = mock_coordinator.api.enode_update_vehicle_charge_settings.call_args[0][0]
+    assert call_arg["isSmartChargingEnabled"] is True
+    assert call_arg["id"] == "set_123"
+
+    # Reset mock
+    mock_coordinator.api.enode_update_vehicle_charge_settings.reset_mock()
+    mock_coordinator.async_request_refresh.reset_mock()
+
     # Test turn off success
-    mock_coordinator.api.enode_disable_smart_charging.return_value = True
+    mock_settings.is_smart_charging_enabled = True  # Simulate switch state change
     await switch.async_turn_off()
-    mock_coordinator.api.enode_disable_smart_charging.assert_called_once()
-    assert mock_coordinator.async_request_refresh.call_count == 2
+    mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+    call_arg = mock_coordinator.api.enode_update_vehicle_charge_settings.call_args[0][0]
+    assert call_arg["isSmartChargingEnabled"] is False
+
+    # Reset mock
+    mock_coordinator.api.enode_update_vehicle_charge_settings.reset_mock()
+    mock_coordinator.async_request_refresh.reset_mock()
+
+    # Test turn on failure
+    mock_coordinator.api.enode_update_vehicle_charge_settings.return_value = False
+    await switch.async_turn_on()
+    mock_coordinator.api.enode_update_vehicle_charge_settings.assert_called_once()
+    mock_coordinator.async_request_refresh.assert_not_called()


### PR DESCRIPTION
# Summary
This pull request refactors the entity architecture for Frank Energie smart controls in Home Assistant as a follow-up to #139. It removes the previous stub switch entities, replacing them with a combination of read-only binary sensors, disable-action buttons, and writable entities (a bidirectional switch for Enode EV smart charging and datetime entities for charging deadlines).

# Why this is needed
1. **Reverted Switch Entities**: The original design used simple switches to enable/disable features like Smart Charging, Smart Trading, and Smart Feed-In. However, the Frank Energie API requires multi-step subscription, authentication, and terms-of-service agreement flows to *enable* these features. Since these complex interactive flows cannot be cleanly or securely completed within Home Assistant, we cannot support enabling them. However, disabling them is a single, direct API call. Therefore:
   - Enabling these features remains a read-only state, monitored via **binary sensors**.
   - Disabling these features is exposed as a single-press **button** entity.
2. **Bidirectional Control for Enode**: Enode smart charging for vehicles is a fully supported bidirectional switch because both `EnodeEnableSmartCharging` and `EnodeDisableSmartCharging` are direct mutations.
3. **EV/Charger Departure Deadlines**: Writable datetime entities allow users to set charging deadlines, which require serialization of all 13 settings fields to the API.
4. **API Dependency**: This pull request depends on the GraphQL mutation changes implemented in the accompanying API library PR (referenced below).

# Key Changes
- **Switch Refactor**:
  - Removed old stub switches (`FrankEnergieSmartChargingSwitch`, `FrankEnergieSmartTradingSwitch`, `FrankEnergieSmartFeedInSwitch`, `FrankEnergieBatteryTradingSwitch`, `FrankEnergiePvSteeringSwitch`).
  - Added bidirectional `FrankEnergieEnodeSmartChargingSwitch` (vehicle-specific, only if `can_smart_charge` is true).
- **Binary Sensors**:
  - Added read-only binary sensors: `Smart Charging`, `Smart Trading`, `Smart Feed-In`, and `Smart HVAC` representing their activation state.
  - Kept battery self-consumption trading binary sensor.
- **Buttons**:
  - Added disable-action buttons: `Disable Smart Trading`, `Disable Smart Feed-In`, and `Disable Smart HVAC`. These are marked unavailable when the feature is already off.
- **Datetime Entities**:
  - Added `FrankEnergieVehicleDeadlineEntity` (EV charging deadline) and `FrankEnergieChargerDeadlineEntity` (wall charger deadline).
  - Extracted helper `_build_charge_settings_input()` to build the full 13-field setting input required by the API.
- **Testing**:
  - Added complete test coverage in `tests/test_binary_sensor.py`, `tests/test_button.py`, and `tests/test_datetime.py`.
  - Updated `tests/test_switch.py` for Enode switches.
  - Added `asyncio_mode = "auto"` to `pyproject.toml` to streamline developer testing.

# References
- API Library Mutations PR: https://github.com/HiDiHo01/python-frank-energie/pull/80

## Summary by Sourcery

Refactor de Frank Energie Home Assistant-integratie om slimme feature-statussen te modelleren als alleen-lezen sensoren, eenrichtings-uitschakelbediening toe te voegen en EV-laaddeadline-entiteiten te introduceren, en breid de coördinator uit met Smart PV-gegevens en verbeteringen voor Enode-ondersteuning.

Nieuwe functionaliteit:
- Stel alleen-lezen binaire sensoren bloot voor Smart Charging, Smart Trading, Smart Feed-In, Smart HVAC en per-batterij zelfconsumptie-handelsstatus.
- Voeg uitschakelknoppen toe voor Smart Trading, Smart Feed-In en Smart HVAC, en een bidirectionele Enode smart charging-schakelaar per in aanmerking komend voertuig.
- Introduceer datetime-entiteiten voor het configureren van Enode EV- en wall charger-laaddeadlines op basis van payloads voor volledig opladen.
- Voeg Smart PV-systeemsensoren per systeem toe voor totale bonus, operationele status en stuur-/regelingstatus.

Verbeteringen:
- Breid de datacoördinator uit om Smart PV-systemen, PV-samenvattingen, Enode-voertuigen en de slimme feed-in-status van de gebruiker op te halen en te aggregeren, en om helper-metadata voor PV-apparaten beschikbaar te maken.
- Verbetert apparaatmodellering door per-batterij- en per-apparaat-hardware te registreren in het apparatenregister met rijkere metadata en door de platformsetup te sequentiëren zodat sensoren worden geregistreerd vóór afhankelijke entiteiten.
- Pas de afhandeling van binaire sensoren en knoppen aan om de authenticatiestatus te respecteren en de beschikbaarheid in lijn te brengen met de daadwerkelijke feature-activatie.

Tests:
- Voeg speciale test-suites toe voor binaire sensoren, knoppen, datetime-entiteiten en de Enode smart charging-schakelaar, en breid coördinatortests uit voor de nieuwe gegevensvelden.
- Stel de pytest asyncio-modus in op `auto` om de uitvoering van async tests te vereenvoudigen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Frank Energie Home Assistant integration to model smart feature states as read-only sensors, add one-way disable controls and EV charging deadline entities, and extend the coordinator with smart PV data and Enode support improvements.

New Features:
- Expose read-only binary sensors for Smart Charging, Smart Trading, Smart Feed-In, Smart HVAC, and per-battery self-consumption trading state.
- Add disable-action buttons for Smart Trading, Smart Feed-In, and Smart HVAC, and a bidirectional Enode smart charging switch per eligible vehicle.
- Introduce datetime entities for configuring Enode EV and wall charger charging deadlines based on full charge settings payloads.
- Add Smart PV system sensors per system for total bonus, operational status, and steering status.

Enhancements:
- Extend the data coordinator to fetch and aggregate Smart PV systems, PV summaries, Enode vehicles, and user smart feed-in status, and to expose helper metadata for PV devices.
- Improve device modelling by registering per-battery and per-device hardware in the device registry with richer metadata and by sequencing platform setup so sensors register before dependent entities.
- Adjust binary sensor and button handling to respect authentication state and align availability with actual feature activation.

Tests:
- Add dedicated test suites for binary sensors, buttons, datetime entities, and the Enode smart charging switch, and extend coordinator tests for the new data fields.
- Configure pytest asyncio mode to auto to simplify async test execution.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smart charging switch for vehicles to toggle smart charging capability.
  * Added disable buttons for Smart Trading, Smart Feed-In, and Smart HVAC features.
  * Added charging deadline setting for vehicles and wall chargers.
  * Added solar system monitoring with sensors for total bonus, operational status, and steering status.
  * Enhanced smart feature detection with new binary sensors for charging, trading, feed-in, and HVAC activation states.

* **Tests**
  * Comprehensive unit tests for binary sensors, buttons, datetime, and switch entities.

* **Chores**
  * Updated translations and configuration strings.
  * Added test infrastructure and fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HiDiHo01/home-assistant-frank_energie/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->