### PR TITLE
chore: synchronize translations and clean up config flow steps

### DIFF
--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -3,23 +3,26 @@
     "step": {
       "user": {
         "title": "Frank Energie configureren",
-        "description": "[%key:common::config_flow::description::confirm_setup%]"
-      },
-      "confirm": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",
-        "title": "Frank Energie configureren"
+        "data": {
+          "authentication": "Gebruik Frank Energie-accountgegevens"
+        }
       },
-      "options": {
-        "title": "Opties configureren",
-        "description": "Configureer de opties voor Frank Energie."
+      "login": {
+        "title": "Inloggen bij Frank Energie",
+        "description": "Voer je Frank Energie inloggegevens in.",
+        "data": {
+          "username": "E-mailadres",
+          "password": "Wachtwoord"
+        }
       },
-      "import": {
-        "title": "Importeer configuratie",
-        "description": "Importeer een bestaande configuratie voor Frank Energie."
-      },
-      "reauth_confirm": {
-        "title": "Her-authenticatie vereist",
-        "description": "Her-authenticatie is vereist voor Frank Energie."
+      "reconfigure": {
+        "title": "Inloggen bij Frank Energie",
+        "description": "Voer de inloggegevens voor Frank Energie in om je account opnieuw te configureren.",
+        "data": {
+          "username": "E-mailadres",
+          "password": "Wachtwoord"
+        }
       },
       "reauth": {
         "title": "Her-authenticatie vereist",

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -2,48 +2,50 @@
   "config": {
     "step": {
       "user": {
-        "title": "Frank Energie configureren",
-        "description": "[%key:common::config_flow::description::confirm_setup%]",
+        "title": "Configure Frank Energie",
+        "description": "Signing in is not required for obtaining energy price data but will add additional sensors specific to your account.",
         "data": {
-          "authentication": "Gebruik Frank Energie-accountgegevens"
+          "authentication": "Use Frank Energie account credentials"
         }
       },
       "login": {
-        "title": "Inloggen bij Frank Energie",
-        "description": "Voer je Frank Energie inloggegevens in.",
+        "title": "Enter your Frank Energie account credentials",
+        "description": "Enter your Frank Energie account credentials.",
         "data": {
-          "username": "E-mailadres",
-          "password": "Wachtwoord"
+          "username": "Username / e-mail",
+          "password": "Password"
         }
       },
       "reconfigure": {
-        "title": "Inloggen bij Frank Energie",
-        "description": "Voer de inloggegevens voor Frank Energie in om je account opnieuw te configureren.",
+        "title": "Reconfigure account",
+        "description": "Enter your Frank Energie credentials to reconfigure your account.",
         "data": {
-          "username": "E-mailadres",
-          "password": "Wachtwoord"
+          "username": "Username / e-mail",
+          "password": "Password"
         }
       },
       "reauth": {
-        "title": "Her-authenticatie vereist",
-        "description": "Her-authenticatie is vereist voor Frank Energie."
+        "title": "Re-authentication required",
+        "description": "Re-authentication is required for Frank Energie."
       },
       "site": {
-        "title": "Selecteer leveringslocatie",
-        "description": "Kies de leveringslocatie die je toe wilt voegen.",
+        "title": "Select delivery location",
+        "description": "Choose the delivery location you want to add.",
         "data": {
-          "site_reference": "Leveringslocatie"
+          "site_reference": "Delivery location"
         }
       }
     },
     "error": {
-      "invalid_auth": "Ongeldige gebruikersnaam of wachtwoord.",
-      "connection_error": "Verbindingsfout met Frank Energie API.",
-      "no_delivery_sites": "Geen leveringslocaties gevonden voor dit account.",
-      "no_suitable_sites": "Geen geschikte leveringslocaties gevonden. Controleer of je account actieve leveringscontracten heeft.",
-      "site_retrieval_failed": "Fout bij het ophalen van leveringslocaties. Probeer het later opnieuw."
+      "invalid_auth": "Credentials rejected, please check your username and password.",
+      "connection_error": "Connection error with Frank Energie API.",
+      "no_delivery_sites": "No delivery sites found for this account.",
+      "no_suitable_sites": "No suitable delivery sites found. Please check if your account has active delivery contracts.",
+      "site_retrieval_failed": "Error retrieving delivery sites. Please try again later."
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -14,18 +14,31 @@
         },
         "step": {
             "login": {
+                "title": "Enter your Frank Energie account credentials",
+                "description": "Enter your Frank Energie account credentials.",
                 "data": {
-                    "password": "Password",
-                    "username": "Username / e-mail"
-                },
-                "title": "Enter your Frank Energie account credentials"
+                    "username": "Username / e-mail",
+                    "password": "Password"
+                }
             },
             "user": {
+                "title": "Do you want to sign in to Frank Energie?",
+                "description": "Signing in is not required for obtaining energy price data but will add additional sensors specific to your account.",
                 "data": {
                     "authentication": "Use Frank Energie account credentials"
-                },
-                "title": "Do you want to sign in to Frank Energie?",
-                "description": "Signing in is not required for obtaining energy price data but will add additional sensors specific to your account."
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure account",
+                "description": "Enter your Frank Energie credentials to reconfigure your account.",
+                "data": {
+                    "username": "Username / e-mail",
+                    "password": "Password"
+                }
+            },
+            "reauth": {
+                "title": "Re-authentication required",
+                "description": "Re-authentication is required for Frank Energie."
             },
             "site": {
                 "title": "Select delivery location",
@@ -37,6 +50,31 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "smart_charging": {
+                "name": "Smart charging"
+            },
+            "smart_trading": {
+                "name": "Smart trading"
+            },
+            "smart_feed_in": {
+                "name": "Smart feed-in"
+            },
+            "smart_hvac": {
+                "name": "Smart HVAC"
+            }
+        },
+        "button": {
+            "disable_smart_trading": {
+                "name": "Disable smart trading"
+            },
+            "disable_smart_feed_in": {
+                "name": "Disable smart feed-in"
+            },
+            "disable_smart_hvac": {
+                "name": "Disable smart HVAC"
+            }
+        },
         "sensor": {
             "pv_total_bonus": {
                 "name": "Total bonus"
@@ -49,20 +87,8 @@
             }
         },
         "switch": {
-            "smart_charging": {
+            "enode_smart_charging": {
                 "name": "Smart charging"
-            },
-            "smart_trading": {
-                "name": "Smart trading"
-            },
-            "smart_feed_in": {
-                "name": "Smart feed-in"
-            },
-            "self_consumption_trading_allowed": {
-                "name": "Self consumption trading allowed"
-            },
-            "pv_steering_enabled": {
-                "name": "Steering enabled"
             }
         },
         "datetime": {

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -17,6 +17,7 @@
         "step": {
             "login": {
                 "title": "Inloggen bij Frank Energie",
+                "description": "Voer je Frank Energie inloggegevens in.",
                 "data": {
                     "username": "Email",
                     "password": "Wachtwoord"
@@ -34,22 +35,23 @@
                     "authentication": "Gebruik Frank Energie-accountgegevens"
                 }
             },
+            "reconfigure": {
+                "title": "Inloggen bij Frank Energie",
+                "description": "Voer de inloggegevens voor Frank Energie in om je account opnieuw te configureren.",
+                "data": {
+                    "username": "Email",
+                    "password": "Wachtwoord"
+                }
+            },
+            "reauth": {
+                "title": "Her-authenticatie vereist",
+                "description": "Her-authenticatie is vereist voor Frank Energie."
+            },
             "site": {
                 "title": "Kies leveringslocatie",
                 "description": "Selecteer de leveringslocatie die je toe wilt voegen",
                 "data": {
                     "site_reference": "Leveringslocaties:"
-                }
-            },
-            "confirm": {
-                "title": "Frank Energie",
-                "description": "Wil je deze integratie toevoegen?"
-            },
-            "reconfigure": {
-                "title": "Inloggen bij Frank Energie",
-                "data": {
-                    "username": "Email",
-                    "password": "Wachtwoord"
                 }
             }
         }
@@ -116,6 +118,31 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "smart_charging": {
+                "name": "Slim laden"
+            },
+            "smart_trading": {
+                "name": "Slim handelen"
+            },
+            "smart_feed_in": {
+                "name": "Slim terugleveren"
+            },
+            "smart_hvac": {
+                "name": "Slimme HVAC"
+            }
+        },
+        "button": {
+            "disable_smart_trading": {
+                "name": "Slim handelen uitschakelen"
+            },
+            "disable_smart_feed_in": {
+                "name": "Slim terugleveren uitschakelen"
+            },
+            "disable_smart_hvac": {
+                "name": "Slimme HVAC uitschakelen"
+            }
+        },
         "sensor": {
             "current_electricity_price": {
                 "name": "Huidige elektriciteitsprijs (All-in)",
@@ -586,20 +613,8 @@
             }
         },
         "switch": {
-            "smart_charging": {
+            "enode_smart_charging": {
                 "name": "Slim laden"
-            },
-            "smart_trading": {
-                "name": "Slim handelen"
-            },
-            "smart_feed_in": {
-                "name": "Slim terugleveren"
-            },
-            "self_consumption_trading_allowed": {
-                "name": "Handelen op eigen verbruik toegestaan"
-            },
-            "pv_steering_enabled": {
-                "name": "Sturing ingeschakeld"
             }
         },
         "datetime": {

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -51,7 +51,7 @@
                 "title": "Kies leveringslocatie",
                 "description": "Selecteer de leveringslocatie die je toe wilt voegen",
                 "data": {
-                    "site_reference": "Leveringslocaties:"
+                    "site_reference": "Leveringslocatie"
                 }
             }
         }


### PR DESCRIPTION
## Summary
This pull request synchronizes the translation files (`en.json` and `nl.json`) with the source of truth (`strings.json`), removing legacy/stale configuration steps and switches, adding translations for newly added entity platforms, and standardizing the base strings to resolve review comments.

## Key Changes
- **strings.json**: Converted all configuration step and error strings to English, establishing it as the correct English source of truth according to Home Assistant custom integration standards and fixing the source-of-truth mismatch. Removed unused steps (`confirm`, `options`, `import`, `reauth_confirm`).
- **en.json**: Added translations for `binary_sensor` and `button` platforms; added `login` (description), `reconfigure`, and `reauth` step translations; removed stale legacy switches (`smart_charging`, `smart_trading`, `smart_feed_in`, etc.) in favor of `enode_smart_charging`.
- **nl.json**: Added translations for `binary_sensor` and `button` platforms; added `login` (description), `reconfigure` (description), and `reauth` step translations; removed unused `confirm` step and stale legacy switches. Converted the Dutch string `"Leveringslocaties:"` to `"Leveringslocatie"` (singular, no colon) per review comments.
- **Verification**: Validated JSON syntax across all modified files and verified that all unit tests pass successfully.

## Why this is needed
Maintaining up-to-date, properly structured English base translation files (`strings.json`) and synchronized localization files ensures that the custom integration adheres to Home Assistant's translation design guidelines, avoids validation mismatches with `hassfest`, and operates correctly without displaying raw localization reference keys.


# Code Review: Translation Sync & Cleanup

### 1. Verification of Removed Config Flow Steps (`confirm`, `options`, `import`, `reauth_confirm`)
A full search across [config_flow.py] was performed to ensure that none of the removed step IDs are active:
- **`confirm`**: No longer referenced. The config flow currently uses the `user` and `login` steps.
- **`options`**: The options flow handler ([FrankEnergieOptionsFlowHandler]) utilizes the `init` and `user` step IDs. The step ID `options` is not used.
- **`import`**: Not referenced. No YAML import configuration exists in the codebase.
- **`reauth_confirm`**: The `reauth` step redirects directly to the `login` step.

**Conclusion:** Removing these steps from `strings.json` and the localized translation files has zero impact on active config flows and will not break existing integrations.

---

### 2. Verification of Stale Switch Keys (`smart_charging`, `smart_trading`, `smart_feed_in`, `self_consumption_trading_allowed`, `pv_steering_enabled`)
We verified that the removal of these keys from the `switch` translation block does not break any entity IDs or internal options:
- [switch.py] only registers a single switch: `FrankEnergieEnodeSmartChargingSwitch`, which uses the translation key `enode_smart_charging`.
- The legacy terms are active in the codebase but exist **only under other entity platforms**:
  - `smart_charging`, `smart_trading`, and `smart_feed_in` are registered as read-only binary sensors in [binary_sensor.py] (with their translations preserved under the `binary_sensor` block).
  - `disable_smart_trading` and `disable_smart_feed_in` are registered as buttons in [button.py] (with translations preserved under the `button` block).
  - `self_consumption_trading_allowed` is used as a suffix for battery binary sensor keys, but does not use a localized translation key.
  - `pv_steering_enabled` is completely absent from the Python codebase.

**Conclusion:** No active switch entities depend on the old translation keys. Removing them from the `switch` translation section in `en.json` and `nl.json` is perfectly safe and backwards-compatible.


## Samenvatting door Sourcery

Synchroniseer Home Assistant-vertaalstrings met de huidige config flow en entity-platforms, verwijder verouderde stappen en switches en voeg vertalingen toe voor nieuwe flows en platforms.

Nieuwe functies:
- Voeg vertaalitems toe voor nieuwe config-flowstappen zoals login, reconfigure en reauth.
- Voeg vertalingen toe voor nieuw ondersteunde `binary_sensor`- en `button`-entity-platforms.

Verbeteringen:
- Verwijder verouderde config-flowstappen en legacy `smart_*`-switches uit de vertaalbestanden om aan te sluiten bij het huidige gedrag van de integratie.
- Breng de vertaalbestanden `en` en `nl` in lijn met `strings.json` als enige bron van waarheid.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize Home Assistant translation strings with the current config flow and entity platforms, removing legacy steps and switches and adding translations for new flows and platforms.

New Features:
- Add translation entries for new config flow steps such as login, reconfigure, and reauth.
- Add translations for newly supported binary_sensor and button entity platforms.

Enhancements:
- Remove obsolete config flow steps and legacy smart_* switches from the translation files to match the current integration behavior.
- Align en and nl translation files with strings.json as the single source of truth.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Dutch and English UI text for Frank Energie setup, login, reauthentication, and account reconfiguration flows for clearer guidance.
  * Added and refined translated names for smart charging, trading, feed‑in, HVAC sensors and related control buttons.
  * Renamed/streamlined smart‑charging switch label for improved consistency in the UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HiDiHo01/home-assistant-frank_energie/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->