### PR TITLE
add: resolution handling in coordinator

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1752,7 +1752,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self._connection_id:
             _LOGGER.warning("Cannot set resolution via API: connection_id not available")
             return
-            raise UpdateFailed("Missing connection id")
 
         if (
             self._api_resolution_state is not None

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -174,22 +174,36 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, hass: HomeAssistant, config_entry: ConfigEntry, api: FrankEnergie
     ) -> None:
         """Initialize the data object."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Frank Energie coordinator",
+            # update_interval=timedelta(seconds=DEFAULT_REFRESH_INTERVAL),
+            update_interval=None,
+            config_entry=config_entry,
+        )
+        from .mutation_queue import MutationQueue
+        self._mutation_queue = MutationQueue()
+        self.api = api
+        self.site_reference: str | None = config_entry.data.get("site_reference")
         self.hass = hass
         self.config_entry = config_entry
         self.api = api
         self._today_prices_logged: bool = False
         self._cache: dict = {}  # <--- hier cache je prijzen
         self.site_reference = config_entry.data.get("site_reference", None)
-        self.country_code: str | None = (
-            self.hass.config.country
-        )  # replaced by hass_country_code
-        self._country_code: str | None = self.hass.config.country
+        self._country_code: str | None = hass.config.country
+        self._user_country: str | None = hass.config.country
         self.hass_country_code: str | None = self.hass.config.country
         self._user_country: str | None = self.country_code
         self._connection_id: str | None = (
             None  # cache voor contractPriceResolutionState
         )
-        self._resolution_state: ContractPriceResolutionState | None = None
+        self._last_lowest_price_event: date | None = None
+        self._last_lowest_4p_event: date | None = None
+        self._last_lowest_16p_event: date | None = None
+        resolution = self.config_entry.options.get("resolution", DEFAULT_RESOLUTION)
+        self._api_resolution_state: ContractPriceResolutionState | None = None
         self.enode_chargers: EnodeChargers | None = None
         self.data: FrankEnergieData = {  # type: ignore[typeddict-unknown-key]
             DATA_ELECTRICITY: None,

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1532,12 +1532,27 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             else None
         )
 
-    @property
-    def resolution(self) -> str:
-        """Effective price resolution used for API queries."""
-        if self.config_entry is None:
-            return DEFAULT_RESOLUTION
-        return self.config_entry.options.get("resolution", DEFAULT_RESOLUTION)
+from .const import (
+    DATA_BATTERIES,
+    DATA_BATTERY_DETAILS,
+    DATA_BATTERY_SESSIONS,
+    DATA_CONTRACT_PRICE_RESOLUTION_STATE,
+    DATA_ELECTRICITY,
+    DATA_ENODE_CHARGERS,
+    DATA_ENODE_VEHICLES,
+    DATA_GAS,
+    DATA_INVOICES,
+    DATA_MONTH_SUMMARY,
+    DATA_USAGE,
+    DATA_USER,
+    DATA_USER_SITES,
+    DATA_PV_SYSTEMS,
+    DATA_PV_SUMMARY,
+    DATA_USER_SMART_FEED_IN,
+    DEFAULT_REFRESH_INTERVAL,
+    DEFAULT_RESOLUTION,
+    EVENT_FRANK_ENERGIE,
+)
     
     def _parse_vehicles(self, data: list[dict]) -> EnodeVehicles:
         vehicles_list = [EnodeVehicle(**vehicle_dict) for vehicle_dict in data]

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1781,10 +1781,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             if self.config_entry is None:
                 return
 
-            if self.config_entry.options.get("resolution") != result.activeOption:
+            if self.config_entry.options.get("resolution") != value:
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
-                    options={**self.config_entry.options, "resolution": result.activeOption},
+                    options={**self.config_entry.options, "resolution": value},
                 )
 
         await self._mutation_queue.add(_mutation)

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1443,9 +1443,88 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     def _should_fire_lowest_4h_event(self, today: date) -> bool:
         return self._last_lowest_4h_event != today
 
-    def _mark_lowest_4h_event_fired(self, today: date) -> None:
-        self._last_lowest_4h_event = today
+    def _mark_lowest_4p_event_fired(self, today: date) -> None:
+        """Mark the lowest-4p event as fired for today."""
+        self._last_lowest_4p_event = today
 
+    def _should_fire_lowest_16p_event(self, today: date) -> bool:
+        """Return True if the lowest-16p event has not yet fired today."""
+        return self._last_lowest_16p_event != today
+
+    def _mark_lowest_16p_event_fired(self, today: date) -> None:
+        """Mark the lowest-16p event as fired for today."""
+        self._last_lowest_16p_event = today
+
+    def _reconcile_resolution(self) -> None:
+        """Ensure config and API state are consistent after refresh."""
+
+        if not self._api_resolution_state:
+            return
+
+        if self.config_entry is None:
+            return
+
+        api_value = self._api_resolution_state.activeOption
+        config_value = self.config_entry.options.get("resolution")
+
+        # Only log drift — do NOT overwrite config automatically
+        if api_value and config_value and api_value != config_value:
+            _LOGGER.warning(
+                "Resolution drift detected (config=%s api=%s)",
+                config_value,
+                api_value,
+            )
+
+    async def async_set_resolution(self, value: str) -> None:
+        """Update resolution safely via mutation queue."""
+
+        async def _mutation() -> None:
+            if not self._connection_id:
+                raise UpdateFailed("Missing connection id")
+
+            result = await self.api.contract_price_resolution_request_change(
+                self._connection_id,
+                value,
+            )
+
+            if result is None or not result.success:
+                raise UpdateFailed(
+                    "Resolution change request failed: %s"
+                    % (result.reason if result else "no response")
+                )
+
+            _LOGGER.info(
+                "Resolution change accepted (effective: %s)",
+                result.data.effectiveDate if result.data else "unknown",
+            )
+
+            if self.config_entry is None:
+                return
+
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={**self.config_entry.options, "resolution": value},
+            )
+
+        await self._mutation_queue.add(_mutation)
+        await self.async_request_refresh()
+
+    @property
+    def api_resolution(self) -> str | None:
+        """Resolution reported by API (read-only)."""
+        return (
+            self._api_resolution_state.activeOption
+            if self._api_resolution_state
+            else None
+        )
+
+    @property
+    def resolution(self) -> str:
+        """Effective price resolution used for API queries."""
+        if self.config_entry is None:
+            return DEFAULT_RESOLUTION
+        return self.config_entry.options.get("resolution", DEFAULT_RESOLUTION)
+    
     def _parse_vehicles(self, data: list[dict]) -> EnodeVehicles:
         vehicles_list = [EnodeVehicle(**vehicle_dict) for vehicle_dict in data]
         return EnodeVehicles(vehicles=vehicles_list)

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -263,8 +263,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         ) = None
         self.last_fetch_tomorrow: datetime | None = None
         self._last_lowest_price_event: date | None = None
-        self._last_lowest_4h_event: date | None = None
-
+        self._last_lowest_4p_event: date | None = None
+        self._last_lowest_16p_event: date | None = None
+    
     def _is_not_in_delivery_site(
         self, data_month_summary, data_invoices, user_sites
     ) -> bool:
@@ -457,82 +458,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             data_contract_price_resolution_state,
         )
 
-        lowest_elec_price = (
-            prices_today.electricity.today_min
-            if prices_today and prices_today.electricity
-            else None
-        )
-
-        if lowest_elec_price and self._should_fire_lowest_price_event(today):
-            start = lowest_elec_price.date_from
-            end = lowest_elec_price.date_till
-            self._price_resolution_minutes = int((end - start).total_seconds() / 60)
-
-            # We gaan ervan uit dat de API altijd UTC-tijden teruggeeft, maar we controleren het voor de zekerheid
-            if start.tzinfo is None:
-                start = start.replace(tzinfo=timezone.utc)
-            if end.tzinfo is None:
-                end = end.replace(tzinfo=timezone.utc)
-
-            if start <= now_utc < end:
-                self.hass.bus.async_fire(
-                    EVENT_FRANK_ENERGIE,
-                    {
-                        "entry_id": self.config_entry.entry_id,
-                        "action": "lowest_price",
-                        "resolution": self._price_resolution_minutes,
-                        "price": lowest_elec_price.total,
-                        "unit": "€/kWh",
-                        "start": start.isoformat(),
-                        "end": end.isoformat(),
-                    },
-                )
-                _LOGGER.debug(
-                    "Firing frank_energie_event (lowest price): %s → %s : %s",
-                    lowest_elec_price.date_from,
-                    lowest_elec_price.date_till,
-                    lowest_elec_price.total,
-                )
-                self._mark_lowest_price_event_fired(today)
-
-        prices = (
-            prices_today.electricity.today
-            if prices_today and prices_today.electricity
-            else None
-        )
-
-        if prices:
-            result = self._find_lowest_consecutive_hours(prices, window=4)
-
-            if result and self._should_fire_lowest_4h_event(today):
-                average_price, start_price, end_price = result
-
-                # Correcte price resolution: verschil tussen eerste 2 entries in prices
-                if len(prices) >= 2:
-                    first_interval = prices[0].date_from
-                    second_interval = prices[1].date_from
-                    self._price_resolution_minutes = int(
-                        (second_interval - first_interval).total_seconds() / 60
-                    )
-                else:
-                    self._price_resolution_minutes = 60  # fallback
-
-                if start_price.date_from <= now_utc < end_price.date_till:
-                    self.hass.bus.async_fire(
-                        EVENT_FRANK_ENERGIE,
-                        {
-                            "entry_id": self.config_entry.entry_id,
-                            "action": "lowest_4p_price",
-                            "periods": 4,
-                            "resolution": self._price_resolution_minutes,
-                            "average_price": round(average_price, 3),
-                            "unit": "€/kWh",
-                            "start": start_price.date_from,
-                            "end": end_price.date_till,
-                        },
-                    )
-
-                    self._mark_lowest_4h_event_fired(today)
+        # ---------------------------------------------------
+        # EVENTS
+        # ---------------------------------------------------
+        self._maybe_fire_lowest_price_event(c.prices_today, today, now_utc)
+        self._maybe_fire_lowest_4p_event(c.prices_today, today, now_utc)
+        self._maybe_fire_lowest_16p_event(c.prices_today, today, now_utc)
 
         return self.cached_prices
 
@@ -957,6 +888,154 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         return details_list, sessions_list
 
+    def _maybe_fire_lowest_price_event(
+        self, prices_today: MarketPrices | None, today: date, now_utc: datetime
+    ) -> None:
+        """Fire the lowest-price event if within the cheapest price slot."""
+        if not self._should_fire_lowest_price_event(today):
+            return
+
+        lowest = (
+            prices_today.electricity.today_min
+            if prices_today and prices_today.electricity
+            else None
+        )
+        if lowest is None:
+            return
+
+        start = self._ensure_utc(lowest.date_from)
+        end = self._ensure_utc(lowest.date_till)
+
+        if not (start <= now_utc < end):
+            return
+
+        self.hass.bus.async_fire(
+            EVENT_FRANK_ENERGIE,
+            {
+                "entry_id": self.config_entry.entry_id,
+                "action": "lowest_price",
+                "resolution": int((end - start).total_seconds() / 60),
+                "price": lowest.total,
+                "unit": "€/kWh",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        _LOGGER.debug(
+            "Fired frank_energie_event (lowest_price): %s → %s @ %s",
+            start, end, lowest.total,
+        )
+        self._mark_lowest_price_event_fired(today)
+
+    def _maybe_fire_lowest_4p_event(
+        self, prices_today: MarketPrices | None, today: date, now_utc: datetime
+    ) -> None:
+        """Fire the lowest-4h-window event if within the cheapest consecutive block."""
+        if not self._should_fire_lowest_4p_event(today):
+            return
+
+        prices = (
+            prices_today.electricity.today
+            if prices_today and prices_today.electricity
+            else None
+        )
+        if not prices:
+            return
+
+        result = self._find_lowest_consecutive_hours(prices, window=4)
+        if result is None:
+            return
+
+        average_price, start_price, end_price = result
+
+        resolution = (
+            int((prices[1].date_from - prices[0].date_from).total_seconds() / 60)
+            if len(prices) >= 2
+            else 60
+        )
+
+        start = self._ensure_utc(start_price.date_from)
+        end = self._ensure_utc(end_price.date_till)
+
+        if not (start <= now_utc < end):
+            return
+
+        self.hass.bus.async_fire(
+            EVENT_FRANK_ENERGIE,
+            {
+                "entry_id": self.config_entry.entry_id,
+                "action": "lowest_4p_price",
+                "periods": 4,
+                "resolution": resolution,
+                "average_price": round(average_price, 3),
+                "unit": "€/kWh",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        _LOGGER.debug(
+            "Fired frank_energie_event (lowest_4p_price): %s → %s @ avg %s",
+            start, end, round(average_price, 3),
+        )
+        self._mark_lowest_4p_event_fired(today)
+
+    def _maybe_fire_lowest_16p_event(
+        self, prices_today: MarketPrices | None, today: date, now_utc: datetime
+    ) -> None:
+        """Fire the lowest-16p-window event if within the cheapest consecutive block."""
+        if not self._should_fire_lowest_16p_event(today):
+            return
+
+        prices = (
+            prices_today.electricity.today
+            if prices_today and prices_today.electricity
+            else None
+        )
+        if not prices:
+            return
+
+        result = self._find_lowest_consecutive_hours(prices, window=16)
+        if result is None:
+            return
+
+        average_price, start_price, end_price = result
+
+        # calculate the resolution by looking at the first two price points. Default to 60 if 2 points are not available
+        resolution = (
+            int((prices[1].date_from - prices[0].date_from).total_seconds() / 60)
+            if len(prices) >= 2
+            else 60
+        )
+
+        # Only fire if the resolution is 15 minutes, else it would fire for 16 hour period.
+        if not resolution == 15:
+            return
+
+        start = self._ensure_utc(start_price.date_from)
+        end = self._ensure_utc(end_price.date_till)
+
+        if not (start <= now_utc < end):
+            return
+
+        self.hass.bus.async_fire(
+            EVENT_FRANK_ENERGIE,
+            {
+                "entry_id": self.config_entry.entry_id,
+                "action": "lowest_16p_price",
+                "periods": 16,
+                "resolution": resolution,
+                "average_price": round(average_price, 3),
+                "unit": "€/kWh",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        _LOGGER.debug(
+            "Fired frank_energie_event (lowest_16p_price): %s → %s @ avg %s",
+            start, end, round(average_price, 3),
+        )
+        self._mark_lowest_16p_event_fired(today)
+    
     async def _fetch_today_data(
         self, today: date, tomorrow: date
     ) -> tuple[

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -173,7 +173,16 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     def __init__(
         self, hass: HomeAssistant, config_entry: ConfigEntry, api: FrankEnergie
     ) -> None:
-        """Initialize the data object."""
+        """
+        Initialize the Frank Energie coordinator and set up internal state, caches, and default update behavior.
+        
+        This constructor prepares the coordinator's data structures, feature flags, cached price slots, resolution state, mutation queue, and timing controls used to fetch and aggregate market, user, device, and billing data.
+        
+        Parameters:
+            hass (HomeAssistant): Home Assistant core instance.
+            config_entry (ConfigEntry): Configuration entry for this integration.
+            api (FrankEnergie): Authenticated Frank Energie API client.
+        """
         super().__init__(
             hass,
             _LOGGER,
@@ -1455,22 +1464,52 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self._last_lowest_price_event = today
 
     def _should_fire_lowest_4h_event(self, today: date) -> bool:
+        """
+        Determine whether the lowest 4-hour price event should be fired for the given date.
+        
+        Parameters:
+            today (date): Date to check for whether the event has already been fired.
+        
+        Returns:
+            true if the lowest 4-hour event has not been fired for `today`, `false` otherwise.
+        """
         return self._last_lowest_4h_event != today
 
     def _mark_lowest_4p_event_fired(self, today: date) -> None:
-        """Mark the lowest-4p event as fired for today."""
+        """
+        Record that the lowest 4-period price event has been fired for the given date.
+        
+        Parameters:
+            today (date): The date to mark as having had the lowest 4-period event fired.
+        """
         self._last_lowest_4p_event = today
 
     def _should_fire_lowest_16p_event(self, today: date) -> bool:
-        """Return True if the lowest-16p event has not yet fired today."""
+        """
+        Determine whether the lowest-16p event has not yet been fired for the given day.
+        
+        Returns:
+            True if the lowest-16p event has not been fired for `today`, False otherwise.
+        """
         return self._last_lowest_16p_event != today
 
     def _mark_lowest_16p_event_fired(self, today: date) -> None:
-        """Mark the lowest-16p event as fired for today."""
+        """
+        Record that the 16-point lowest-price event has been fired for the given day.
+        
+        This stores the provided date in the coordinator's internal marker so the same event is not emitted again for that day.
+        
+        Parameters:
+            today (date): The date for which the 16-point lowest-price event has been fired.
+        """
         self._last_lowest_16p_event = today
 
     def _reconcile_resolution(self) -> None:
-        """Ensure config and API state are consistent after refresh."""
+        """
+        Log a warning when the API's contract price resolution differs from the configured resolution.
+        
+        Does nothing if the coordinator lacks an API resolution state or a config entry. This function only records the discrepancy; it does not modify configuration or state.
+        """
 
         if not self._api_resolution_state:
             return
@@ -1490,9 +1529,26 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
 
     async def async_set_resolution(self, value: str) -> None:
-        """Update resolution safely via mutation queue."""
+        """
+        Request a contract price resolution change and apply it to the config entry when accepted.
+        
+        Enqueues a mutation that asks the API to change the contract price resolution for the current connection, updates the config entry options with the requested `value` when the request is accepted, and triggers a coordinator refresh. If the connection id is missing or the API response indicates failure, the mutation raises UpdateFailed.
+        
+        Parameters:
+            value (str): Desired resolution identifier (e.g. "PT60M").
+        """
 
         async def _mutation() -> None:
+            """
+            Request a contract price resolution change for the current connection and update the config entry options on success.
+            
+            Raises:
+                UpdateFailed: If the coordinator has no connection id or if the API request fails or returns an unsuccessful response.
+            
+            Details:
+                - Calls the API to request a resolution change for `self._connection_id`.
+                - On success, logs the effective date (if available) and updates the config entry's `options["resolution"]` to `value`.
+            """
             if not self._connection_id:
                 raise UpdateFailed("Missing connection id")
 
@@ -1525,7 +1581,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
     @property
     def api_resolution(self) -> str | None:
-        """Resolution reported by API (read-only)."""
+        """
+        Return the active resolution option reported by the API.
+        
+        Returns:
+            The API's active resolution option string (for example, "PT60M") if available, `None` otherwise.
+        """
         return (
             self._api_resolution_state.activeOption
             if self._api_resolution_state
@@ -1555,6 +1616,15 @@ from .const import (
 )
     
     def _parse_vehicles(self, data: list[dict]) -> EnodeVehicles:
+        """
+        Builds an EnodeVehicles container from a list of vehicle dictionaries.
+        
+        Parameters:
+            data (list[dict]): List of mappings with vehicle fields suitable for constructing `EnodeVehicle` objects.
+        
+        Returns:
+            EnodeVehicles: Container object whose `vehicles` list contains `EnodeVehicle` instances parsed from `data`.
+        """
         vehicles_list = [EnodeVehicle(**vehicle_dict) for vehicle_dict in data]
         return EnodeVehicles(vehicles=vehicles_list)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -412,10 +412,28 @@ class TestInitNewAttributes:
         )
         assert coord.site_reference == "ref-xyz"
 
-    def test_site_reference_none_when_not_in_data(self, coordinator):
+    def test_site_reference_none_when_not_in_data(self, mock_frank_energie):
         """site_reference must be None when not present in config_entry.data."""
-        # mock_config_entry fixture uses data without 'site_reference' key
-        assert coordinator.site_reference is None
+        # Create config entry without 'site_reference' key
+        entry_data_without_site_ref = {k: v for k, v in mock_entry_data.items() if k != "site_reference"}
+        entry = MockConfigEntry(
+            version=1,
+            domain="frank_energie",
+            title="Frank Energie",
+            data=entry_data_without_site_ref,
+            options={},
+            source="user",
+            entry_id="no-site-ref",
+            state="loaded",
+            minor_version=1,
+            unique_id="uid-no-site-ref",
+        )
+        coord = FrankEnergieCoordinator(
+            hass=MagicMock(),
+            config_entry=entry,
+            api=mock_frank_energie,
+        )
+        assert coord.site_reference is None
 
 
 class TestMarkLowest4pEventFired:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -359,3 +359,436 @@ async def test_fetch_month_summary_auth_exception(coordinator, mock_frank_energi
     mock_frank_energie.month_summary.side_effect = AuthException("auth error")
     result = await coordinator._fetch_month_summary()
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for code changed/added in this PR
+# ---------------------------------------------------------------------------
+
+
+class TestInitNewAttributes:
+    """Tests for new attributes introduced in __init__ by this PR."""
+
+    def test_last_lowest_4p_event_initialized_to_none(self, coordinator):
+        """_last_lowest_4p_event must start as None."""
+        assert coordinator._last_lowest_4p_event is None
+
+    def test_last_lowest_16p_event_initialized_to_none(self, coordinator):
+        """_last_lowest_16p_event must start as None."""
+        assert coordinator._last_lowest_16p_event is None
+
+    def test_api_resolution_state_initialized_to_none(self, coordinator):
+        """_api_resolution_state must start as None."""
+        assert coordinator._api_resolution_state is None
+
+    def test_mutation_queue_created(self, coordinator):
+        """A MutationQueue instance must be created during init."""
+        from custom_components.frank_energie.mutation_queue import MutationQueue
+
+        assert isinstance(coordinator._mutation_queue, MutationQueue)
+
+    def test_api_set_from_argument(self, coordinator, mock_frank_energie):
+        """The api attribute must equal the api argument passed to __init__."""
+        assert coordinator.api is mock_frank_energie
+
+    def test_site_reference_from_config_entry(self, mock_frank_energie):
+        """site_reference must be read from config_entry.data."""
+        entry = MockConfigEntry(
+            version=1,
+            domain="frank_energie",
+            title="Frank Energie",
+            data={"site_reference": "ref-xyz", "access_token": "tok"},
+            options={},
+            source="user",
+            entry_id="abc",
+            state="loaded",
+            minor_version=1,
+            unique_id="uid-xyz",
+        )
+        coord = FrankEnergieCoordinator(
+            hass=MagicMock(),
+            config_entry=entry,
+            api=mock_frank_energie,
+        )
+        assert coord.site_reference == "ref-xyz"
+
+    def test_site_reference_none_when_not_in_data(self, coordinator):
+        """site_reference must be None when not present in config_entry.data."""
+        # mock_config_entry fixture uses data without 'site_reference' key
+        assert coordinator.site_reference is None
+
+
+class TestMarkLowest4pEventFired:
+    """Tests for the renamed _mark_lowest_4p_event_fired method."""
+
+    def test_sets_last_lowest_4p_event(self, coordinator):
+        """After calling _mark_lowest_4p_event_fired, _last_lowest_4p_event equals today."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._mark_lowest_4p_event_fired(today)
+        assert coordinator._last_lowest_4p_event == today
+
+    def test_overwrites_previous_date(self, coordinator):
+        """Calling _mark_lowest_4p_event_fired twice updates to the latest date."""
+        from datetime import date
+
+        old_date = date(2026, 5, 29)
+        new_date = date(2026, 5, 30)
+        coordinator._mark_lowest_4p_event_fired(old_date)
+        coordinator._mark_lowest_4p_event_fired(new_date)
+        assert coordinator._last_lowest_4p_event == new_date
+
+    def test_does_not_affect_other_event_flags(self, coordinator):
+        """_mark_lowest_4p_event_fired must not modify other event tracking attributes."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._mark_lowest_4p_event_fired(today)
+        assert coordinator._last_lowest_price_event is None
+        assert coordinator._last_lowest_16p_event is None
+
+
+class TestShouldFireLowest16pEvent:
+    """Tests for the new _should_fire_lowest_16p_event method."""
+
+    def test_returns_true_when_never_fired(self, coordinator):
+        """Should return True when _last_lowest_16p_event is None."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        assert coordinator._should_fire_lowest_16p_event(today) is True
+
+    def test_returns_true_when_fired_on_different_day(self, coordinator):
+        """Should return True when last event was fired on a different day."""
+        from datetime import date
+
+        yesterday = date(2026, 5, 29)
+        today = date(2026, 5, 30)
+        coordinator._last_lowest_16p_event = yesterday
+        assert coordinator._should_fire_lowest_16p_event(today) is True
+
+    def test_returns_false_when_already_fired_today(self, coordinator):
+        """Should return False when event was already fired today."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._last_lowest_16p_event = today
+        assert coordinator._should_fire_lowest_16p_event(today) is False
+
+
+class TestMarkLowest16pEventFired:
+    """Tests for the new _mark_lowest_16p_event_fired method."""
+
+    def test_sets_last_lowest_16p_event(self, coordinator):
+        """After calling _mark_lowest_16p_event_fired, _last_lowest_16p_event equals today."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._mark_lowest_16p_event_fired(today)
+        assert coordinator._last_lowest_16p_event == today
+
+    def test_subsequent_should_fire_returns_false(self, coordinator):
+        """After marking fired, _should_fire_lowest_16p_event must return False."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._mark_lowest_16p_event_fired(today)
+        assert coordinator._should_fire_lowest_16p_event(today) is False
+
+    def test_does_not_affect_4p_event_flag(self, coordinator):
+        """_mark_lowest_16p_event_fired must not modify _last_lowest_4p_event."""
+        from datetime import date
+
+        today = date(2026, 5, 30)
+        coordinator._mark_lowest_16p_event_fired(today)
+        assert coordinator._last_lowest_4p_event is None
+
+
+class TestReconcileResolution:
+    """Tests for the new _reconcile_resolution method."""
+
+    def test_returns_early_when_no_api_resolution_state(self, coordinator):
+        """Must return without error when _api_resolution_state is None."""
+        coordinator._api_resolution_state = None
+        # Should not raise
+        coordinator._reconcile_resolution()
+
+    def test_returns_early_when_config_entry_is_none(self, coordinator):
+        """Must return without error when config_entry is None."""
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT15M"
+        coordinator._api_resolution_state = mock_state
+        coordinator.config_entry = None
+        # Should not raise
+        coordinator._reconcile_resolution()
+
+    def test_no_warning_when_values_match(self, coordinator):
+        """Must not log a warning when API and config values are identical."""
+        from unittest.mock import patch
+
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT15M"
+        coordinator._api_resolution_state = mock_state
+        mock_config_entry = MagicMock()
+        mock_config_entry.options = {"resolution": "PT15M"}
+        coordinator.config_entry = mock_config_entry
+
+        with patch(
+            "custom_components.frank_energie.coordinator._LOGGER"
+        ) as mock_logger:
+            coordinator._reconcile_resolution()
+            mock_logger.warning.assert_not_called()
+
+    def test_logs_warning_when_drift_detected(self, coordinator):
+        """Must log a warning when config and API resolution values differ."""
+        from unittest.mock import patch
+
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT60M"
+        coordinator._api_resolution_state = mock_state
+        mock_config_entry = MagicMock()
+        mock_config_entry.options = {"resolution": "PT15M"}
+        coordinator.config_entry = mock_config_entry
+
+        with patch(
+            "custom_components.frank_energie.coordinator._LOGGER"
+        ) as mock_logger:
+            coordinator._reconcile_resolution()
+            mock_logger.warning.assert_called_once()
+            warning_args = mock_logger.warning.call_args[0]
+            assert "drift" in warning_args[0].lower() or "resolution" in warning_args[0].lower()
+
+    def test_no_warning_when_api_value_is_none(self, coordinator):
+        """Must not log a warning when api_value is None."""
+        from unittest.mock import patch
+
+        mock_state = MagicMock()
+        mock_state.activeOption = None
+        coordinator._api_resolution_state = mock_state
+        mock_config_entry = MagicMock()
+        mock_config_entry.options = {"resolution": "PT15M"}
+        coordinator.config_entry = mock_config_entry
+
+        with patch(
+            "custom_components.frank_energie.coordinator._LOGGER"
+        ) as mock_logger:
+            coordinator._reconcile_resolution()
+            mock_logger.warning.assert_not_called()
+
+    def test_no_warning_when_config_value_is_none(self, coordinator):
+        """Must not log a warning when config_value is None (not set)."""
+        from unittest.mock import patch
+
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT15M"
+        coordinator._api_resolution_state = mock_state
+        mock_config_entry = MagicMock()
+        # options dict without 'resolution' key -> get returns None
+        mock_config_entry.options = {}
+        coordinator.config_entry = mock_config_entry
+
+        with patch(
+            "custom_components.frank_energie.coordinator._LOGGER"
+        ) as mock_logger:
+            coordinator._reconcile_resolution()
+            mock_logger.warning.assert_not_called()
+
+
+class TestApiResolutionProperty:
+    """Tests for the new api_resolution property."""
+
+    def test_returns_none_when_no_api_resolution_state(self, coordinator):
+        """api_resolution must return None when _api_resolution_state is None."""
+        coordinator._api_resolution_state = None
+        assert coordinator.api_resolution is None
+
+    def test_returns_active_option_when_state_set(self, coordinator):
+        """api_resolution must return activeOption from _api_resolution_state."""
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT15M"
+        coordinator._api_resolution_state = mock_state
+        assert coordinator.api_resolution == "PT15M"
+
+    def test_returns_none_active_option_when_state_has_none(self, coordinator):
+        """api_resolution must propagate None activeOption from _api_resolution_state."""
+        mock_state = MagicMock()
+        mock_state.activeOption = None
+        coordinator._api_resolution_state = mock_state
+        assert coordinator.api_resolution is None
+
+    def test_property_is_read_only(self, coordinator):
+        """api_resolution must be a read-only property."""
+        import pytest
+
+        with pytest.raises(AttributeError):
+            coordinator.api_resolution = "PT60M"
+
+
+class TestAsyncSetResolution:
+    """Tests for the new async_set_resolution method."""
+
+    @pytest.mark.asyncio
+    async def test_raises_update_failed_when_no_connection_id(self, coordinator):
+        """Must raise UpdateFailed when _connection_id is None."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator._connection_id = None
+        coordinator.async_request_refresh = AsyncMock()
+
+        with pytest.raises(UpdateFailed, match="Missing connection id"):
+            await coordinator.async_set_resolution("PT15M")
+
+    @pytest.mark.asyncio
+    async def test_raises_update_failed_when_api_returns_none(self, coordinator, mock_frank_energie):
+        """Must raise UpdateFailed when API returns None result."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator._connection_id = "conn-123"
+        coordinator.async_request_refresh = AsyncMock()
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=None
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator.async_set_resolution("PT15M")
+
+    @pytest.mark.asyncio
+    async def test_raises_update_failed_when_result_not_success(
+        self, coordinator, mock_frank_energie
+    ):
+        """Must raise UpdateFailed when result.success is False."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator._connection_id = "conn-123"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.reason = "server_error"
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        with pytest.raises(UpdateFailed, match="server_error"):
+            await coordinator.async_set_resolution("PT15M")
+
+    @pytest.mark.asyncio
+    async def test_success_updates_config_entry_and_requests_refresh(
+        self, coordinator, mock_frank_energie
+    ):
+        """On success, config entry must be updated and refresh must be requested."""
+        coordinator._connection_id = "conn-123"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.data = MagicMock()
+        mock_result.data.effectiveDate = "2026-06-01"
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        await coordinator.async_set_resolution("PT60M")
+
+        coordinator.hass.config_entries.async_update_entry.assert_called_once_with(
+            coordinator.config_entry,
+            options={**coordinator.config_entry.options, "resolution": "PT60M"},
+        )
+        coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_api_called_with_connection_id_and_value(
+        self, coordinator, mock_frank_energie
+    ):
+        """The API must be called with correct connection_id and resolution value."""
+        coordinator._connection_id = "conn-abc"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.data = MagicMock()
+        mock_result.data.effectiveDate = "2026-06-01"
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        await coordinator.async_set_resolution("PT15M")
+
+        mock_frank_energie.contract_price_resolution_request_change.assert_called_once_with(
+            "conn-abc", "PT15M"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_config_update_when_config_entry_is_none(
+        self, coordinator, mock_frank_energie
+    ):
+        """If config_entry becomes None inside mutation, update must be skipped without error."""
+        coordinator._connection_id = "conn-123"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.data = MagicMock()
+        mock_result.data.effectiveDate = "2026-06-01"
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Set config_entry to None after coordinator is created
+        coordinator.config_entry = None
+
+        # Should not raise
+        await coordinator.async_set_resolution("PT60M")
+        coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_called_even_after_mutation_success(
+        self, coordinator, mock_frank_energie
+    ):
+        """async_request_refresh must always be called after a successful mutation."""
+        coordinator._connection_id = "conn-999"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.data = None  # effectiveDate path: result.data is None
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        await coordinator.async_set_resolution("PT15M")
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_not_called_when_mutation_raises(self, coordinator):
+        """async_request_refresh must NOT be called when the mutation raises UpdateFailed."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator._connection_id = None  # triggers UpdateFailed inside mutation
+        coordinator.async_request_refresh = AsyncMock()
+
+        with pytest.raises(UpdateFailed):
+            await coordinator.async_set_resolution("PT15M")
+
+        coordinator.async_request_refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_error_message_contains_reason_when_result_fails(
+        self, coordinator, mock_frank_energie
+    ):
+        """UpdateFailed message must include the reason from the API response."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator._connection_id = "conn-123"
+        coordinator.async_request_refresh = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.reason = "contract_locked"
+        mock_frank_energie.contract_price_resolution_request_change = AsyncMock(
+            return_value=mock_result
+        )
+
+        with pytest.raises(UpdateFailed, match="contract_locked"):
+            await coordinator.async_set_resolution("PT15M")


### PR DESCRIPTION
Refactored resolution-related methods in FrankEnergieCoordinator.

- Added None guard on config_entry in resolution property and _reconcile_resolution to satisfy type checker
- Added None guard on config_entry in async_set_resolution
- Logs effectiveDate from ContractPriceResolutionChangeResult so the user knows when the resolution change takes effect
- Removed stale commented-out _resolution_state references from resolution property
- async_set_resolution delegates to contract_price_resolution_request_change mutation (replaces placeholder set_contract_price_resolution_state call)

## Summary by Sourcery

Behandel de resolutiestatus consistent tussen configuratie en API, terwijl het bijhouden van laagste-prijsevenementen wordt uitgebreid.

Verbeteringen:
- Voeg een asynchrone helper voor resolutiewijzigingen toe die een API-mutation aanvraagt, de ingangsdatum logt en de nieuwe resolutie opslaat in configuratieopties.
- Introduceer verzoening en read-only toegangsmethodes om de resolutiestatus van configuratie en API op elkaar afgestemd te houden en afwijkingen te detecteren.
- Breid het bijhouden van laagste-prijsevenementen uit met aparte 4p- en 16p-eventmarkeringen en controles.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle resolution state consistently between configuration and API while extending lowest-price event tracking.

Enhancements:
- Add async resolution change helper that requests API mutation, logs effective date, and persists the new resolution in config options.
- Introduce reconciliation and read-only accessors to keep configuration and API resolution states aligned and detect drift.
- Extend lowest-price event tracking with separate 4p and 16p event markers and checks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits daily "lowest price" events for 1-period, 4-period and 16-period windows with period metadata and resolution info.
  * UI can request a price-resolution change (request persisted on success and triggers a refresh).
  * Exposes a read-only resolution value reported by the API.

* **Bug Fixes**
  * Detects and logs mismatches between configured and API-reported resolution without overwriting user settings.

* **Tests**
  * Adds coordinator tests for event bookkeeping, resolution reconciliation, and resolution-change flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HiDiHo01/home-assistant-frank_energie/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->