### PR TITLE
fix(number): align SmartBatteryUpdateSettings with snake_case method

### DIFF
--- a/custom_components/frank_energie/number.py
+++ b/custom_components/frank_energie/number.py
@@ -150,7 +150,7 @@ class FrankEnergieBatteryThresholdNumber(
             self._battery_id,
             value,
         )
-        success = await self.coordinator.api.SmartBatteryUpdateSettings(
+        success = await self.coordinator.api.smart_battery_update_settings(
             self._battery_id, {"selfConsumptionTradingThresholdPrice": value}
         )
         if success:
@@ -195,7 +195,7 @@ class FrankEnergieBatteryThresholdNumber(
         )
 
         try:
-            success = await self.coordinator.api.SmartBatteryUpdateSettings(
+            success = await self.coordinator.api.smart_battery_update_settings(
                 self._battery_id,
                 {
                     "selfConsumptionTradingThresholdPrice": value,
@@ -210,7 +210,7 @@ class FrankEnergieBatteryThresholdNumber(
 
         if not success:
             message = (
-                "SmartBatteryUpdateSettings returned unsuccessful result "
+                "smart_battery_update_settings returned unsuccessful result "
                 "for smart battery %s"
             )
 


### PR DESCRIPTION
# Summary
Aligns the battery threshold number entity to use the snake_case `smart_battery_update_settings` method instead of the buggy/unsupported PascalCase method.

# Key Changes
- Modified `number.py` to call `coordinator.api.smart_battery_update_settings` instead of `SmartBatteryUpdateSettings`.
- Fixed logs and error message formatting to match the updated method name.

# Why this is needed
Aligns the number platform with PEP 8 naming standards, consistency in the codebase (matching `select.py`), and resolves the failing unit test in `tests/test_number.py`.

## Summary by Sourcery

Breng de battery threshold number entity in lijn met de snake_case-APImethode `smart_battery_update_settings` en de bijbehorende logging.

Bug Fixes:
- Gebruik de ondersteunde snake_case-APImethode `smart_battery_update_settings` in plaats van de PascalCase-variant `SmartBatteryUpdateSettings` om correcte updates te herstellen en falende tests te verhelpen.

Enhancements:
- Werk log- en foutmeldingen bij zodat ze verwijzen naar de snake_case-methode `smart_battery_update_settings` voor consistentie met de API.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align battery threshold number entity with the snake_case smart_battery_update_settings API method and its related logging.

Bug Fixes:
- Use the supported snake_case smart_battery_update_settings API method instead of the PascalCase SmartBatteryUpdateSettings variant to restore correct updates and fix failing tests.

Enhancements:
- Update log and error messages to reference the snake_case smart_battery_update_settings method name for consistency with the API.

</details>