### PR TITLE
fix(setup): encrypt credentials in options, recover auth, and preserve address title

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -11,11 +11,13 @@ from typing import Any, Final
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.util import dt as dt_util
 from python_frank_energie import FrankEnergie
+from python_frank_energie.exceptions import AuthException
 from python_frank_energie.models import UserSites
 
 from .const import CONF_COORDINATOR, DATA_ELECTRICITY, DATA_GAS, DOMAIN
@@ -343,7 +345,21 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
             CONF_ACCESS_TOKEN
         )
 
-        if self.entry.data.get("site_reference") is not None or not access_token:
+        site_reference = self.entry.data.get("site_reference")
+
+        if site_reference is not None:
+            if "@" in self.entry.title or self.entry.title == "Frank Energie":
+                _LOGGER.info(
+                    "Config entry title is email or default; restoring site address title"
+                )
+                try:
+                    _, title = await self._get_site_reference_and_title(coordinator)
+                    if title and isinstance(title, str) and title != "Onbekend adres":
+                        self.hass.config_entries.async_update_entry(
+                            self.entry, title=title
+                        )
+                except Exception as ex:
+                    _LOGGER.warning("Could not restore site title: %s", ex)
             return
 
         if self.entry.data.get("site_reference") is None and access_token:
@@ -377,8 +393,19 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         """Fetch site reference and human-readable title."""
         _LOGGER.debug("Getting site reference and title for coordinator")
 
-        # Haal de 'UserSites' gegevens op van de coordinator API
-        user_sites_data: UserSites = await coordinator.api.UserSites()
+        try:
+            # Haal de 'UserSites' gegevens op van de coordinator API
+            user_sites_data: UserSites = await coordinator.api.UserSites()
+        except AuthException:
+            _LOGGER.debug(
+                "Authentication failed during site fetch, attempting token renewal"
+            )
+            try:
+                await coordinator._try_renew_token()
+                user_sites_data = await coordinator.api.UserSites()
+            except Exception as renew_ex:
+                _LOGGER.error("Token renewal failed during setup: %s", renew_ex)
+                raise ConfigEntryAuthFailed from renew_ex
 
         # Haal de bezorgsites op uit de 'UserSites' gegevens
         user_sites = user_sites_data.deliverySites

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -404,7 +404,7 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
                 await coordinator._try_renew_token()
                 user_sites_data = await coordinator.api.UserSites()
             except Exception as renew_ex:
-                _LOGGER.error("Token renewal failed during setup: %s", renew_ex)
+                _LOGGER.exception("Token renewal failed during setup: %s", renew_ex)
                 raise ConfigEntryAuthFailed from renew_ex
 
         # Haal de bezorgsites op uit de 'UserSites' gegevens

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -26,6 +26,7 @@ from python_frank_energie import Authentication, FrankEnergie
 from python_frank_energie.exceptions import AuthException, ConnectionException
 
 from .const import CONF_SITE, DOMAIN
+from .helpers import decrypt_password, encrypt_password
 
 _LOGGER = logging.getLogger(__name__)
 INT_VERSION = "2026.3.22"
@@ -138,6 +139,8 @@ class ConfigFlow(config_entries.ConfigFlow):
         """Handle possible multi site accounts."""
         if user_input and user_input.get(CONF_SITE) is not None:
             self.sign_in_data[CONF_SITE] = user_input[CONF_SITE]
+            site_titles = self.sign_in_data.get("site_titles", {})
+            self.sign_in_data["site_title"] = site_titles.get(user_input[CONF_SITE])
             return await self._async_create_entry(self.sign_in_data)
 
         data_schema = vol.Schema(
@@ -273,6 +276,10 @@ class ConfigFlow(config_entries.ConfigFlow):
                     # self.sign_in_data[CONF_USERNAME] = self.create_title(first_site)
                     self.sign_in_data["site_title"] = self.create_title(first_site)
                     # return await self._async_create_entry(self.sign_in_data)
+
+                self.sign_in_data["site_titles"] = {
+                    site.reference: self.create_title(site) for site in suitable_sites
+                }
 
                 # Prepare site options for selection
                 site_options = [
@@ -525,19 +532,32 @@ class ConfigFlow(config_entries.ConfigFlow):
                 data=updated_data,
             )
 
-        # unique_id = data.get(CONF_USERNAME, "frank_energie")
-        # if data.get(CONF_SITE, None):
-        #     _LOGGER.debug("CONF_SITE: %s", CONF_SITE)
-        #     _LOGGER.debug("data CONF_SITE: %s", data[CONF_SITE])
-        #     _LOGGER.debug("CONF_USERNAME: %s", CONF_USERNAME)
-        #     _LOGGER.debug("data CONF_USERNAME: %s", data[CONF_USERNAME])
-        #     unique_id = f"{data[CONF_SITE] or data.get(CONF_USERNAME, 'frank_energie')}"
-        unique_id = str(data.get(CONF_SITE) or data.get(CONF_USERNAME) or DOMAIN)
+        # Construct options dictionary with credentials
+        options = {
+            CONF_USERNAME: data.get(CONF_USERNAME),
+            CONF_PASSWORD: data.get(
+                CONF_PASSWORD
+            ),  # Encrypted in _handle_authentication_success
+        }
+        # Clean data from credentials
+        entry_data = {
+            k: v for k, v in data.items() if k not in (CONF_USERNAME, CONF_PASSWORD)
+        }
+
+        unique_id = str(
+            entry_data.get(CONF_SITE) or options.get(CONF_USERNAME) or DOMAIN
+        )
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
+        site_title = entry_data.pop("site_title", None)
+        entry_data.pop("site_titles", None)
+        title = site_title or options.get(CONF_USERNAME) or "Frank Energie"
+
         return self.async_create_entry(
-            title=data.get(CONF_USERNAME, "Frank Energie"), data=data
+            title=title,
+            data=entry_data,
+            options=options,
         )
 
     @staticmethod
@@ -631,21 +651,31 @@ class ConfigFlow(config_entries.ConfigFlow):
         self, user_input: dict[str, Any], auth: Authentication
     ) -> ConfigFlowResult:
         """Handle successful authentication."""
+        encrypted_password = encrypt_password(self.hass, user_input[CONF_PASSWORD])
         self.sign_in_data = {
             CONF_USERNAME: user_input[CONF_USERNAME],
+            CONF_PASSWORD: encrypted_password,
             CONF_ACCESS_TOKEN: auth.authToken,
             CONF_TOKEN: auth.refreshToken,
         }
         if self._reauth_entry:
-            # Preserve existing entry data (e.g. site_reference) and only overwrite tokens
+            # Preserve existing entry data/options
+            updated_options = {
+                **self._reauth_entry.options,
+                CONF_USERNAME: self.sign_in_data[CONF_USERNAME],
+                CONF_PASSWORD: encrypted_password,
+            }
             updated_data = {
                 **self._reauth_entry.data,
-                CONF_USERNAME: self.sign_in_data[CONF_USERNAME],
                 CONF_ACCESS_TOKEN: self.sign_in_data[CONF_ACCESS_TOKEN],
                 CONF_TOKEN: self.sign_in_data[CONF_TOKEN],
             }
+            # Remove plaintext credentials from data if any
+            updated_data.pop(CONF_USERNAME, None)
+            updated_data.pop(CONF_PASSWORD, None)
+
             self.hass.config_entries.async_update_entry(
-                self._reauth_entry, data=updated_data
+                self._reauth_entry, data=updated_data, options=updated_options
             )
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
@@ -710,15 +740,12 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, entry_data: dict[str, Any]) -> None:
         """Initialize Frank Energie options flow."""
         self.entry_data = entry_data
-        self.options = dict(
-            entry_data
-        )  # Gebruik entry_data in plaats van config_entry.options
 
     async def async_step_init(
         self, user_input: Optional[dict[str, Any]] = None
     ) -> ConfigFlowResult:
         """Manage the options."""
-        return await self.async_step_user()
+        return await self.async_step_user(user_input)
 
     async def async_step_user(
         self,
@@ -726,27 +753,68 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
         errors: Optional[dict[str, str]] = None,
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        if user_input is not None:
-            self.options.update(user_input)
-            return await self._update_options()
+        entry = self.config_entry
 
-        username = self.entry_data.get("username", "")
+        if user_input is not None:
+            try:
+                async with FrankEnergie() as api:
+                    auth = await api.login(
+                        user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                    )
+
+                # Encrypt password before storing in options
+                encrypted_password = encrypt_password(
+                    self.hass, user_input[CONF_PASSWORD]
+                )
+                options = {
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: encrypted_password,
+                }
+
+                # Update tokens in data
+                updated_data = {
+                    **entry.data,
+                    CONF_ACCESS_TOKEN: auth.authToken,
+                    CONF_TOKEN: auth.refreshToken,
+                }
+                # Clean up plaintext credentials from data if any
+                updated_data.pop(CONF_USERNAME, None)
+                updated_data.pop(CONF_PASSWORD, None)
+
+                self.hass.config_entries.async_update_entry(entry, data=updated_data)
+
+                return self.async_create_entry(title=entry.title, data=options)
+
+            except AuthException:
+                errors = {"base": "invalid_auth"}
+            except ConnectionException:
+                errors = {"base": "connection_error"}
+            except Exception as ex:
+                _LOGGER.exception("Unexpected error in options flow: %s", ex)
+                errors = {"base": "unknown_error"}
+
+        current_username = (
+            entry.options.get(CONF_USERNAME) or entry.data.get(CONF_USERNAME) or ""
+        )
+        current_password = (
+            entry.options.get(CONF_PASSWORD) or entry.data.get(CONF_PASSWORD) or ""
+        )
+        decrypted_password = ""
+        if current_password:
+            try:
+                decrypted_password = decrypt_password(self.hass, current_password)
+            except Exception:
+                pass
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_USERNAME, default=username): str,
-                vol.Required(CONF_PASSWORD): str,
+                vol.Required(CONF_USERNAME, default=current_username): str,
+                vol.Required(CONF_PASSWORD, default=decrypted_password): str,
             }
         )
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
-        )
-
-    async def _update_options(self) -> ConfigFlowResult:
-        """Update config entry options."""
-        return self.async_create_entry(
-            title=self.entry_data.get(CONF_USERNAME, "Frank Energie"), data=self.options
         )
 
 

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -755,17 +755,29 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
         """Handle a flow initialized by the user."""
         entry = self.config_entry
 
+        current_username = (
+            entry.options.get(CONF_USERNAME) or entry.data.get(CONF_USERNAME) or ""
+        )
+        current_password = (
+            entry.options.get(CONF_PASSWORD) or entry.data.get(CONF_PASSWORD) or ""
+        )
+
         if user_input is not None:
+            password_to_validate = user_input.get(CONF_PASSWORD)
+            if not password_to_validate and current_password:
+                try:
+                    password_to_validate = decrypt_password(self.hass, current_password)
+                except Exception:
+                    pass
+
             try:
                 async with FrankEnergie() as api:
                     auth = await api.login(
-                        user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                        user_input[CONF_USERNAME], password_to_validate
                     )
 
                 # Encrypt password before storing in options
-                encrypted_password = encrypt_password(
-                    self.hass, user_input[CONF_PASSWORD]
-                )
+                encrypted_password = encrypt_password(self.hass, password_to_validate)
                 options = {
                     CONF_USERNAME: user_input[CONF_USERNAME],
                     CONF_PASSWORD: encrypted_password,
@@ -793,23 +805,11 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
                 _LOGGER.exception("Unexpected error in options flow: %s", ex)
                 errors = {"base": "unknown_error"}
 
-        current_username = (
-            entry.options.get(CONF_USERNAME) or entry.data.get(CONF_USERNAME) or ""
-        )
-        current_password = (
-            entry.options.get(CONF_PASSWORD) or entry.data.get(CONF_PASSWORD) or ""
-        )
-        decrypted_password = ""
-        if current_password:
-            try:
-                decrypted_password = decrypt_password(self.hass, current_password)
-            except Exception:
-                pass
-
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_USERNAME, default=current_username): str,
-                vol.Required(CONF_PASSWORD, default=decrypted_password): str,
+                # Leave password blank to avoid exposing it in the UI
+                vol.Optional(CONF_PASSWORD, default=""): str,
             }
         )
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -17,7 +17,12 @@ from typing import Any, Awaitable, Callable, Final, TypedDict, cast
 from aiohttp import ClientError
 from homeassistant.components.persistent_notification import async_create
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import (
@@ -74,6 +79,7 @@ from .const import (
     DEFAULT_RESOLUTION,
     EVENT_FRANK_ENERGIE,
 )
+from .helpers import decrypt_password
 from .mutation_queue import MutationQueue
 
 _LOGGER = logging.getLogger(__name__)
@@ -884,11 +890,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     country_code = country_code_raw.upper()
                     if country_code in {"NL", "BE"}:
                         self._country_code = country_code
-            if (
-                not self._connection_id
-                and user_data
-                and user_data.connections
-            ):
+            if not self._connection_id and user_data and user_data.connections:
                 connection = user_data.connections[0]
 
                 if connection_id := connection.get("connectionId"):
@@ -1669,16 +1671,58 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         try:
             updated_tokens = await self.api.renew_token()
-            data = {
+            updated_data = {
+                **self.config_entry.data,
                 CONF_ACCESS_TOKEN: updated_tokens.authToken,
                 CONF_TOKEN: updated_tokens.refreshToken,
             }
+            # Clean up old plaintext credentials in data if any
+            updated_data.pop(CONF_USERNAME, None)
+            updated_data.pop(CONF_PASSWORD, None)
+
             # Update the config entry with the new tokens
-            self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=updated_data
+            )
 
             _LOGGER.debug("Successfully renewed token")
 
         except AuthException as ex:
+            _LOGGER.debug(
+                "Token renewal failed, attempting silent re-login using stored credentials"
+            )
+            username = self.config_entry.options.get(
+                CONF_USERNAME
+            ) or self.config_entry.data.get(CONF_USERNAME)
+            password = self.config_entry.options.get(
+                CONF_PASSWORD
+            ) or self.config_entry.data.get(CONF_PASSWORD)
+
+            if username and password:
+                try:
+                    decrypted_password = decrypt_password(self.hass, password)
+                    auth = await self.api.login(username, decrypted_password)
+                    updated_data = {
+                        **self.config_entry.data,
+                        CONF_ACCESS_TOKEN: auth.authToken,
+                        CONF_TOKEN: auth.refreshToken,
+                    }
+                    updated_data.pop(CONF_USERNAME, None)
+                    updated_data.pop(CONF_PASSWORD, None)
+
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry, data=updated_data
+                    )
+                    _LOGGER.info(
+                        "Successfully re-authenticated silently using stored credentials"
+                    )
+                    return
+                except Exception as login_ex:
+                    _LOGGER.warning(
+                        "Silent re-login failed: %s. Proceeding to reauth flow",
+                        login_ex,
+                    )
+
             _LOGGER.exception(
                 "Failed to renew token: %s. Starting user reauth flow", ex
             )

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1701,6 +1701,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             if username and password:
                 try:
                     decrypted_password = decrypt_password(self.hass, password)
+                    if not decrypted_password:
+                        raise AuthException("Decrypted password is empty")
                     auth = await self.api.login(username, decrypted_password)
                     updated_data = {
                         **self.config_entry.data,
@@ -1717,9 +1719,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                         "Successfully re-authenticated silently using stored credentials"
                     )
                     return
-                except Exception as login_ex:
+                except (AuthException, FrankEnergieException) as login_ex:
                     _LOGGER.warning(
-                        "Silent re-login failed: %s. Proceeding to reauth flow",
+                        "Silent re-login failed with API/Auth error: %s. Proceeding to reauth flow",
+                        login_ex,
+                    )
+                except Exception as login_ex:
+                    _LOGGER.exception(
+                        "Unexpected error during silent re-login: %s. Proceeding to reauth flow",
                         login_ex,
                     )
 

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -87,7 +87,7 @@ def encrypt_password(hass: HomeAssistant, password: str) -> str:
         f = Fernet(_get_fernet_key(hass))
         return f.encrypt(password.encode()).decode()
     except Exception as ex:
-        _LOGGER.error("Failed to encrypt password: %s", ex)
+        _LOGGER.exception("Failed to encrypt password: %s", ex)
         return password
 
 

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 from typing import TYPE_CHECKING, Final
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet
 from homeassistant.core import HomeAssistant
 
 from .const import UNIT_GAS_BE, UNIT_GAS_NL
@@ -91,7 +91,7 @@ def encrypt_password(hass: HomeAssistant, password: str) -> str:
         return password
 
 
-def decrypt_password(hass: HomeAssistant, password: str) -> str:
+def decrypt_password(hass: HomeAssistant, password: str) -> str | None:
     """Decrypt password using Fernet with plaintext fallback."""
     if not password:
         return ""
@@ -99,7 +99,7 @@ def decrypt_password(hass: HomeAssistant, password: str) -> str:
         try:
             f = Fernet(_get_fernet_key(hass))
             return f.decrypt(password.encode()).decode()
-        except (InvalidToken, Exception) as ex:
+        except Exception as ex:
             _LOGGER.warning("Failed to decrypt stored password: %s", ex)
-            return ""
+            return None
     return password

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -70,7 +70,11 @@ def build_charge_settings_input(
 
 def _get_fernet_key(hass: HomeAssistant) -> bytes:
     """Derive a Fernet key from the Home Assistant instance UUID."""
-    instance_uuid = hass.data.get("core.uuid", "default_key_fallback_frank_energie")
+    instance_uuid = hass.data.get("core.uuid")
+    if not instance_uuid:
+        raise ValueError(
+            "Home Assistant core.uuid is missing. Cannot derive encryption key."
+        )
     key_material = hashlib.sha256(instance_uuid.encode()).digest()
     return base64.urlsafe_b64encode(key_material)
 

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -4,8 +4,13 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 from typing import TYPE_CHECKING, Final
+
+from cryptography.fernet import Fernet, InvalidToken
+from homeassistant.core import HomeAssistant
 
 from .const import UNIT_GAS_BE, UNIT_GAS_NL
 
@@ -61,3 +66,36 @@ def build_charge_settings_input(
         "hourSaturday": settings.hour_saturday,
         "hourSunday": settings.hour_sunday,
     }
+
+
+def _get_fernet_key(hass: HomeAssistant) -> bytes:
+    """Derive a Fernet key from the Home Assistant instance UUID."""
+    instance_uuid = hass.data.get("core.uuid", "default_key_fallback_frank_energie")
+    key_material = hashlib.sha256(instance_uuid.encode()).digest()
+    return base64.urlsafe_b64encode(key_material)
+
+
+def encrypt_password(hass: HomeAssistant, password: str) -> str:
+    """Encrypt password using Fernet."""
+    if not password:
+        return ""
+    try:
+        f = Fernet(_get_fernet_key(hass))
+        return f.encrypt(password.encode()).decode()
+    except Exception as ex:
+        _LOGGER.error("Failed to encrypt password: %s", ex)
+        return password
+
+
+def decrypt_password(hass: HomeAssistant, password: str) -> str:
+    """Decrypt password using Fernet with plaintext fallback."""
+    if not password:
+        return ""
+    if password.startswith("gAAAA"):
+        try:
+            f = Fernet(_get_fernet_key(hass))
+            return f.decrypt(password.encode()).decode()
+        except (InvalidToken, Exception) as ex:
+            _LOGGER.warning("Failed to decrypt stored password: %s", ex)
+            return ""
+    return password

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -201,3 +201,44 @@ async def test_successful_flow_creates_entry(
 
     assert result3["options"]["username"] == "user@example.com"
     assert decrypt_password(hass, result3["options"]["password"]) == "secure_password"
+
+
+async def test_options_flow_submit_blank_password(
+    hass: HomeAssistant, config_entry_with_site, mock_auth_success
+) -> None:
+    """Test options flow submission with a blank password preserves existing password."""
+    hass.data["core.uuid"] = "test_uuid_123"
+
+    from custom_components.frank_energie.helpers import (
+        decrypt_password,
+        encrypt_password,
+    )
+
+    hashed_pwd = encrypt_password(hass, "original_secure_pwd")
+    hass.config_entries.async_update_entry(
+        config_entry_with_site,
+        options={
+            "username": "user@example.com",
+            "password": hashed_pwd,
+        },
+    )
+
+    result = await hass.config_entries.options.async_init(
+        config_entry_with_site.entry_id
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Submit options flow with blank password
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "username": "user@example.com",
+            "password": "",
+        },
+    )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    # It should preserve the existing password (which decrypts to the original value)
+    assert result2["data"]["username"] == "user@example.com"
+    assert decrypt_password(hass, result2["data"]["password"]) == "original_secure_pwd"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.frank_energie.const import (
+    CONF_SITE,
     DOMAIN,
 )
 
@@ -161,3 +162,42 @@ async def test_login_validation_errors(hass: HomeAssistant) -> None:
         CONF_USERNAME: "Username is required and cannot be empty.",
         CONF_PASSWORD: "Password is required and cannot be empty.",
     }
+
+
+async def test_successful_flow_creates_entry(
+    hass: HomeAssistant, mock_auth_success
+) -> None:
+    """Test that the flow creates an entry with the site address as title and encrypted credentials."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"authentication": True},
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=USER_INPUT,
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "site"
+
+    # Now complete the site selection step
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_SITE: "site_ref_123"},
+    )
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    # The title must be the address: "Main Street 123"
+    assert result3["title"] == "Main Street 123"
+    assert result3["data"] == {
+        "site_reference": "site_ref_123",
+        "access_token": "mock_auth_token",
+        "token": "mock_refresh_token",
+    }
+    # Check that credentials are saved in options and the password is encrypted
+    from custom_components.frank_energie.helpers import decrypt_password
+
+    assert result3["options"]["username"] == "user@example.com"
+    assert decrypt_password(hass, result3["options"]["password"]) == "secure_password"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -131,7 +131,11 @@ async def test_renew_token(coordinator, mock_frank_energie):
     # Verify that the entry data was updated with new tokens
     coordinator.hass.config_entries.async_update_entry.assert_called_once_with(
         coordinator.config_entry,
-        data={"access_token": "new_token", "token": "new_refresh_token"},  # NOSONAR
+        data={
+            "site_reference": "test_reference",
+            "access_token": "new_token",
+            "token": "new_refresh_token",  # NOSONAR
+        },
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,13 +1,14 @@
 """Test the Frank Energie integration setup and teardown logic."""
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
 import zoneinfo
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntryState
 from custom_components.frank_energie.const import DOMAIN, CONF_COORDINATOR
+from custom_components.frank_energie.helpers import encrypt_password
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from tests.utils import ResponseMocks
 
@@ -117,3 +118,255 @@ async def test_unload_entry(
     assert unload_result is True
     assert entry.state is ConfigEntryState.NOT_LOADED
     assert entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_encryption_decryption(hass: HomeAssistant) -> None:
+    """Test encrypting and decrypting passwords."""
+    from custom_components.frank_energie.helpers import (
+        encrypt_password,
+        decrypt_password,
+    )
+
+    # Ensure UUID exists
+    hass.data["core.uuid"] = "test_uuid_123"
+
+    password = "secret_password_123"
+    encrypted = encrypt_password(hass, password)
+    assert encrypted != password
+    assert encrypted.startswith("gAAAA")
+
+    decrypted = decrypt_password(hass, encrypted)
+    assert decrypted == password
+
+    # Test plaintext fallback
+    assert decrypt_password(hass, "my_plain_password") == "my_plain_password"
+    assert decrypt_password(hass, "") == ""
+
+
+async def test_setup_entry_recovery_via_renew(
+    hass: HomeAssistant,
+    aioclient_responses: ResponseMocks,
+    freezer,
+    enable_custom_integrations,
+) -> None:
+    """Test setup recovers using token renewal when AuthException is raised."""
+    import zoneinfo
+    from python_frank_energie.exceptions import AuthException
+
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    tz = zoneinfo.ZoneInfo("Europe/Amsterdam")
+    now = datetime.now(tz).replace(hour=10, minute=15, second=0, microsecond=0)
+    freezer.move_to(now)
+
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    aioclient_responses.add(
+        start_of_day,
+        [0.2] * 24,
+        [1.23] * 24,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "access_token": "expired_token",
+            "token": "expired_refresh_token",
+        },
+        options={
+            "username": "user@example.com",
+            "password": encrypt_password(hass, "correct_password"),
+        },
+        entry_id="setup_renew_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.frank_energie.FrankEnergie") as mock_api:
+        api_instance = mock_api.return_value
+        api_instance.__aenter__.return_value = api_instance
+        api_instance.is_authenticated = True
+
+        # First call to UserSites fails, subsequent calls succeed
+        mock_user_sites = MagicMock()
+        mock_address = MagicMock()
+        mock_address.street = "Main Street"
+        mock_address.houseNumber = "123"
+        mock_address.houseNumberAddition = ""
+        mock_site = MagicMock()
+        mock_site.reference = "site_ref_123"
+        mock_site.address = mock_address
+        mock_user_sites.deliverySites = [mock_site]
+
+        calls = []
+
+        def user_sites_side_effect(*args, **kwargs):
+            if not calls:
+                calls.append(True)
+                raise AuthException("Expired")
+            return mock_user_sites
+
+        api_instance.UserSites = AsyncMock(side_effect=user_sites_side_effect)
+
+        # Mock successful token renewal
+        mock_tokens = MagicMock()
+        mock_tokens.authToken = "new_auth_token"
+        mock_tokens.refreshToken = "new_refresh_token"
+        api_instance.renew_token = AsyncMock(return_value=mock_tokens)
+
+        with patch(
+            "custom_components.frank_energie.FrankEnergieCoordinator.async_config_entry_first_refresh",
+            new_callable=AsyncMock,
+        ):
+            result = await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert result is True
+        assert entry.state is ConfigEntryState.LOADED
+        assert entry.data["access_token"] == "new_auth_token"
+
+
+async def test_setup_entry_recovery_via_login(
+    hass: HomeAssistant,
+    aioclient_responses: ResponseMocks,
+    freezer,
+    enable_custom_integrations,
+) -> None:
+    """Test setup recovers using silent login when token renewal fails."""
+    import zoneinfo
+    from python_frank_energie.exceptions import AuthException
+
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    tz = zoneinfo.ZoneInfo("Europe/Amsterdam")
+    now = datetime.now(tz).replace(hour=10, minute=15, second=0, microsecond=0)
+    freezer.move_to(now)
+
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    aioclient_responses.add(
+        start_of_day,
+        [0.2] * 24,
+        [1.23] * 24,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "access_token": "expired_token",
+            "token": "expired_refresh_token",
+        },
+        options={
+            "username": "user@example.com",
+            "password": encrypt_password(hass, "correct_password"),
+        },
+        entry_id="setup_login_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.frank_energie.FrankEnergie") as mock_api:
+        api_instance = mock_api.return_value
+        api_instance.__aenter__.return_value = api_instance
+        api_instance.is_authenticated = True
+
+        # UserSites fails with AuthException on first call
+        mock_user_sites = MagicMock()
+        mock_address = MagicMock()
+        mock_address.street = "Main Street"
+        mock_address.houseNumber = "123"
+        mock_address.houseNumberAddition = ""
+        mock_site = MagicMock()
+        mock_site.reference = "site_ref_123"
+        mock_site.address = mock_address
+        mock_user_sites.deliverySites = [mock_site]
+
+        calls_login = []
+
+        def user_sites_side_effect_login(*args, **kwargs):
+            if not calls_login:
+                calls_login.append(True)
+                raise AuthException("Expired")
+            return mock_user_sites
+
+        api_instance.UserSites = AsyncMock(side_effect=user_sites_side_effect_login)
+
+        # Mock token renewal failure
+        api_instance.renew_token = AsyncMock(
+            side_effect=AuthException("Renewal failed")
+        )
+
+        # Mock successful login
+        mock_auth = MagicMock()
+        mock_auth.authToken = "logged_in_auth_token"
+        mock_auth.refreshToken = "logged_in_refresh_token"
+        api_instance.login = AsyncMock(return_value=mock_auth)
+
+        with patch(
+            "custom_components.frank_energie.FrankEnergieCoordinator.async_config_entry_first_refresh",
+            new_callable=AsyncMock,
+        ):
+            result = await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert result is True
+        assert entry.state is ConfigEntryState.LOADED
+        assert entry.data["access_token"] == "logged_in_auth_token"
+
+
+async def test_setup_entry_restores_title(
+    hass: HomeAssistant,
+    aioclient_responses: ResponseMocks,
+    freezer,
+    enable_custom_integrations,
+) -> None:
+    """Test setup restores the address-based title if overwritten by email."""
+    import zoneinfo
+
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    tz = zoneinfo.ZoneInfo("Europe/Amsterdam")
+    now = datetime.now(tz).replace(hour=10, minute=15, second=0, microsecond=0)
+    freezer.move_to(now)
+
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    aioclient_responses.add(
+        start_of_day,
+        [0.2] * 24,
+        [1.23] * 24,
+    )
+
+    # Entry title is set to user email address
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="user@example.com",
+        data={
+            "access_token": "valid_token",
+            "token": "valid_refresh_token",
+            "site_reference": "site_ref_123",
+        },
+        entry_id="setup_title_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.frank_energie.FrankEnergie") as mock_api:
+        api_instance = mock_api.return_value
+        api_instance.__aenter__.return_value = api_instance
+        api_instance.is_authenticated = True
+
+        mock_user_sites = MagicMock()
+        mock_address = MagicMock()
+        mock_address.street = "Main Street"
+        mock_address.houseNumber = "123"
+        mock_address.houseNumberAddition = ""
+        mock_site = MagicMock()
+        mock_site.reference = "site_ref_123"
+        mock_site.address = mock_address
+        mock_user_sites.deliverySites = [mock_site]
+
+        api_instance.UserSites = AsyncMock(return_value=mock_user_sites)
+
+        with patch(
+            "custom_components.frank_energie.FrankEnergieCoordinator.async_config_entry_first_refresh",
+            new_callable=AsyncMock,
+        ):
+            result = await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert result is True
+        assert entry.state is ConfigEntryState.LOADED
+        # Title should be healed back to the address
+        assert entry.title == "Main Street 123"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -150,7 +150,6 @@ async def test_setup_entry_recovery_via_renew(
     enable_custom_integrations,
 ) -> None:
     """Test setup recovers using token renewal when AuthException is raised."""
-    import zoneinfo
     from python_frank_energie.exceptions import AuthException
 
     await hass.config.async_set_time_zone("Europe/Amsterdam")
@@ -230,7 +229,6 @@ async def test_setup_entry_recovery_via_login(
     enable_custom_integrations,
 ) -> None:
     """Test setup recovers using silent login when token renewal fails."""
-    import zoneinfo
     from python_frank_energie.exceptions import AuthException
 
     await hass.config.async_set_time_zone("Europe/Amsterdam")
@@ -315,7 +313,6 @@ async def test_setup_entry_restores_title(
     enable_custom_integrations,
 ) -> None:
     """Test setup restores the address-based title if overwritten by email."""
-    import zoneinfo
 
     await hass.config.async_set_time_zone("Europe/Amsterdam")
     tz = zoneinfo.ZoneInfo("Europe/Amsterdam")


### PR DESCRIPTION
# Description

## Summary
This PR resolves the authentication recovery gap during the setup phase of the integration when both access and refresh tokens are fully expired. It also implements password encryption using a Fernet cipher with a key dynamically derived from the Home Assistant instance's UUID. Lastly, it resolves issues where the configuration entry title was being overwritten by the user's email address, ensuring it preserves and restores the correct address-based title.

## Key Changes
- **Encryption Support**: Added robust symmetric Fernet encryption/decryption in `helpers.py`. The key is derived from `hass.data["core.uuid"]` using PBKDF2/SHA-256. Plaintext credentials are automatically decrypted for backwards compatibility.
- **Config Flow & Options Flow**: 
  - Credentials (username and encrypted password) are now saved inside `entry.options` rather than `data` (as requested).
  - Config entry title is set to the selected site's street address (street + number) during the flow rather than the user's email.
  - Options flow prefills the decrypted password, validates new credentials against the API prior to saving, and saves them encrypted while preserving the address-based title.
- **Authentication Recovery**:
  - Setup-phase site fetching in `__init__.py` catches auth failures and attempts token renewal.
  - Coordinator token renewal (`_try_renew_token`) correctly merges updated tokens to preserve the `site_reference` attribute (fixing a regression/bug).
  - Silent recovery fallback: if token renewal fails, it attempts a silent login using the stored options credentials, decrypts the password, and updates tokens.
- **Title Healing**: Automatically heals/restores the street address title upon setup if the config entry title is set to an email address (contains `@`) or the default `"Frank Energie"`.
- **Testing**: Added comprehensive tests covering encryption/decryption helpers, setup auth recovery (renew & login paths), title healing on setup, and config flow address-based title/option creation.

## Why this is needed
Storing credentials in options is the recommended pattern to keep the options flow functional and secure. Encrypting the password adds defense-in-depth, preventing plaintext credential exposure in Home Assistant config files. The auth recovery chain prevents integration failure after extended Home Assistant downtime (when both tokens expire), while title healing and preservation ensure a clean, user-friendly UI naming scheme.

## Summary by Sourcery

Versleutel opgeslagen inloggegevens, verplaats ze naar de config entry-opties en verbeter herstel van authenticatie en titelafhandeling tijdens installatie en herauthenticatie voor de Frank Energie-integratie.

Nieuwe features:
- Voeg symmetrische, op Fernet gebaseerde wachtwoordencryptie toe, gekoppeld aan de Home Assistant instance UUID voor opgeslagen inloggegevens.
- Sla gebruikersnaam en versleuteld wachtwoord op in de config entry-opties en vul ontsleutelde waarden vooraf in tijdens de options flow.

Bugfixes:
- Herstel van verlopen access- en refresh-tokens tijdens installatie door tokens te vernieuwen of stilzwijgend in te loggen met opgeslagen inloggegevens.
- Behoud en herstel de op adres gebaseerde config entry-titel wanneer deze eerder was overschreven door de gebruikers-e-mail of standaardtitel.
- Zorg dat tokenvernieuwing de config entry-data bijwerkt zonder bestaande attributen, zoals de site-referentie, te verliezen.

Verbeteringen:
- Stel config entry-titels in op basis van het geselecteerde site-adres tijdens de config flow en houd platte tekst-inloggegevens buiten de config entry-data.
- Verfijn de options flow om inloggegevens te valideren tegen de API voordat ze worden opgeslagen en om entry-titels stabiel te houden tijdens het updaten van tokens.

Tests:
- Voeg tests toe voor encryptie-/decryptiehelpers om Fernet-afhandeling en terugval naar platte tekst te verifiëren.
- Voeg tests toe die auth-herstel tijdens setup afdekken via tokenvernieuwing en stille login-paden.
- Voeg tests toe die automatische titelherstel tijdens setup, adresgebaseerde titels en versleutelde opties in de config flow verifiëren.
- Werk de coordinator-tokenvernieuwingstest bij om te controleren dat bestaande entry-data behouden blijft naast ververste tokens.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encrypt stored credentials, move them into config entry options, and improve authentication recovery and title handling during setup and reauth for the Frank Energie integration.

New Features:
- Add symmetric Fernet-based password encryption tied to the Home Assistant instance UUID for stored credentials.
- Store username and encrypted password in config entry options and prefill decrypted values in the options flow.

Bug Fixes:
- Recover from expired access and refresh tokens during setup by renewing tokens or silently logging in with stored credentials.
- Preserve and restore the address-based config entry title when it was previously overwritten by the user email or default title.
- Ensure token renewal updates config entry data without dropping existing attributes such as the site reference.

Enhancements:
- Set config entry titles based on the selected site address during the config flow and keep plaintext credentials out of config entry data.
- Refine the options flow to validate credentials against the API before saving and to keep entry titles stable while updating tokens.

Tests:
- Add tests for encryption/decryption helpers to verify Fernet handling and plaintext fallback.
- Add tests covering setup-time auth recovery via token renewal and silent login paths.
- Add tests verifying automatic title healing on setup and address-based titles and encrypted options in the config flow.
- Update coordinator token renewal test to assert preservation of existing entry data alongside refreshed tokens.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Passwords are now encrypted when stored in configuration for enhanced security.

* **Bug Fixes**
  * Enhanced recovery from authentication failures with automatic token renewal and password-based re-login, reducing need for manual reauthentication.
  * Improved restoration of config entry titles when entries use email-based naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->