### PR TITLE
fix: propagate dynamic api network errors and update site_reference dynamically

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -279,6 +279,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     @property
     def site_reference(self) -> str | None:
         """Return active site reference."""
+        if self.config_entry and self.config_entry.data:
+            return self.config_entry.data.get("site_reference") or self._site_reference
         return self._site_reference
 
     def _should_skip_api_calls(
@@ -972,6 +974,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug("Network error fetching enode chargers: %s", err)
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:
             _LOGGER.debug("Failed to fetch enode chargers: %s", err)
             return None
@@ -988,6 +1001,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug("Network error fetching smart batteries: %s", err)
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:
             _LOGGER.debug("Failed to fetch smart batteries: %s", err)
             return None
@@ -1013,6 +1037,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug("Network error fetching enode vehicles: %s", err)
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:
             _LOGGER.debug("Failed to fetch enode vehicles: %s", err)
             return None
@@ -1052,6 +1087,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug("Network error fetching smart PV systems: %s", err)
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
             return None
@@ -1073,6 +1119,21 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug(
+                "Network error fetching smart PV system summary for %s: %s",
+                device_id,
+                err,
+            )
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "Failed to fetch smart PV system summary for %s: %s", device_id, err
@@ -1089,6 +1150,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug("Network error fetching user smart feed-in status: %s", err)
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch user smart feed-in status: %s", err)
             return None
@@ -1126,6 +1198,19 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug(
+                "Network error fetching details for battery %s: %s", battery.id, err
+            )
+            if self.last_fetch_today is None:
+                raise
+            return None
         except Exception as err:
             _LOGGER.exception(
                 "Failed to fetch details for battery %s: %s",
@@ -1168,10 +1253,24 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except (
+            NetworkError,
+            RequestException,
+            ClientError,
+            ConnectionError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.debug(
+                "Network error fetching sessions for battery %s: %s", battery.id, err
+            )
+            if self.last_fetch_today is None:
+                raise
+            return None
+        except Exception as err:
             _LOGGER.exception(
-                "Failed to fetch sessions for battery %s",
+                "Failed to fetch sessions for battery %s: %s",
                 battery.id,
+                err,
             )
             return None
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -949,6 +949,35 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             _LOGGER.exception("Error fetching ContractPriceResolutionState: %s", err)
             return None
 
+    def _handle_dynamic_fetch_error(self, method_name: str, err: Exception) -> None:
+        """Handle errors during dynamic fetches, propagating network errors on initial refresh."""
+        if isinstance(
+            err, (AuthException, AuthRequiredException, asyncio.CancelledError)
+        ):
+            raise err
+        if isinstance(
+            err,
+            (
+                NetworkError,
+                RequestException,
+                ClientError,
+                ConnectionError,
+                asyncio.TimeoutError,
+            ),
+        ):
+            _LOGGER.debug("Network error fetching %s: %s", method_name, err)
+            if self.last_fetch_today is None:
+                raise err
+            return
+
+        # Log generic exceptions (other than network errors or cancel/auth)
+        if method_name.startswith("details for battery") or method_name.startswith(
+            "sessions for battery"
+        ):
+            _LOGGER.exception("Failed to fetch %s: %s", method_name, err)
+        else:
+            _LOGGER.debug("Failed to fetch %s: %s", method_name, err)
+
     async def _fetch_enode_chargers(
         self, start_date: date, is_smart_charging: bool
     ) -> dict[str, EnodeChargers] | None:
@@ -970,23 +999,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
         try:
             return await self.api.enode_chargers(self.site_reference, start_date)
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug("Network error fetching enode chargers: %s", err)
-            if self.last_fetch_today is None:
-                raise
-            return None
         except Exception as err:
-            _LOGGER.debug("Failed to fetch enode chargers: %s", err)
+            self._handle_dynamic_fetch_error("enode chargers", err)
             return None
 
     async def _fetch_smart_batteries(
@@ -997,23 +1011,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
         try:
             return await self.api.smart_batteries()
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug("Network error fetching smart batteries: %s", err)
-            if self.last_fetch_today is None:
-                raise
-            return None
         except Exception as err:
-            _LOGGER.debug("Failed to fetch smart batteries: %s", err)
+            self._handle_dynamic_fetch_error("smart batteries", err)
             return None
 
     async def _fetch_enode_vehicles(
@@ -1033,23 +1032,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             vehicles = await self.api.enode_vehicles()
             _LOGGER.debug("Fetched Enode vehicles: %s", vehicles)
             return vehicles
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug("Network error fetching enode vehicles: %s", err)
-            if self.last_fetch_today is None:
-                raise
-            return None
         except Exception as err:
-            _LOGGER.debug("Failed to fetch enode vehicles: %s", err)
+            self._handle_dynamic_fetch_error("enode vehicles", err)
             return None
 
     async def old_fetch_smart_pv_systems(self) -> SmartPvSystems | None:
@@ -1083,23 +1067,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             result = await self.api.smart_pv_systems()
             self._has_pv_systems = bool(result and result.systems)
             return result
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug("Network error fetching smart PV systems: %s", err)
-            if self.last_fetch_today is None:
-                raise
-            return None
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
+        except Exception as err:
+            self._handle_dynamic_fetch_error("smart PV systems", err)
             return None
 
     async def _fetch_smart_pv_summary(
@@ -1115,28 +1084,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
         try:
             return await self.api.smart_pv_system_summary(device_id)
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug(
-                "Network error fetching smart PV system summary for %s: %s",
-                device_id,
-                err,
-            )
-            if self.last_fetch_today is None:
-                raise
-            return None
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Failed to fetch smart PV system summary for %s: %s", device_id, err
+        except Exception as err:
+            self._handle_dynamic_fetch_error(
+                f"smart PV system summary for {device_id}", err
             )
             return None
 
@@ -1146,23 +1096,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
         try:
             return await self.api.user_smart_feed_in()
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug("Network error fetching user smart feed-in status: %s", err)
-            if self.last_fetch_today is None:
-                raise
-            return None
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Failed to fetch user smart feed-in status: %s", err)
+        except Exception as err:
+            self._handle_dynamic_fetch_error("user smart feed-in status", err)
             return None
 
     async def _fetch_battery_details(self, battery) -> SmartBatteryDetails | None:
@@ -1194,29 +1129,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     battery.summary,
                 )
             return details
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug(
-                "Network error fetching details for battery %s: %s", battery.id, err
-            )
-            if self.last_fetch_today is None:
-                raise
-            return None
         except Exception as err:
-            _LOGGER.exception(
-                "Failed to fetch details for battery %s: %s",
-                battery.id,
-                err,
-            )
+            self._handle_dynamic_fetch_error(f"details for battery {battery.id}", err)
             return None
 
     async def _fetch_battery_sessions(
@@ -1249,29 +1163,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     battery.id,
                 )
                 return None
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except (
-            NetworkError,
-            RequestException,
-            ClientError,
-            ConnectionError,
-            asyncio.TimeoutError,
-        ) as err:
-            _LOGGER.debug(
-                "Network error fetching sessions for battery %s: %s", battery.id, err
-            )
-            if self.last_fetch_today is None:
-                raise
-            return None
         except Exception as err:
-            _LOGGER.exception(
-                "Failed to fetch sessions for battery %s: %s",
-                battery.id,
-                err,
-            )
+            self._handle_dynamic_fetch_error(f"sessions for battery {battery.id}", err)
             return None
 
     async def _fetch_battery_details_and_sessions(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from custom_components.frank_energie.const import (
     DATA_ELECTRICITY,
     DATA_GAS,
@@ -424,7 +424,9 @@ class TestInitNewAttributes:
         )
         assert coord.site_reference is None
 
-    def test_site_reference_updates_dynamically(self, mock_frank_energie):
+    def test_site_reference_updates_dynamically(
+        self, mock_frank_energie: AsyncMock
+    ) -> None:
         """site_reference must update dynamically when config_entry.data is updated."""
         entry = MockConfigEntry(
             version=1,
@@ -894,8 +896,8 @@ async def test_fetch_today_data_retry_on_auth_failure(coordinator, mock_frank_en
 
 @pytest.mark.asyncio
 async def test_dynamic_fetch_network_errors_during_first_refresh(
-    coordinator, mock_frank_energie
-):
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
     """Test that transient network errors in dynamic fetch methods propagate only during initial refresh."""
     from python_frank_energie.exceptions import NetworkError
 
@@ -907,20 +909,18 @@ async def test_dynamic_fetch_network_errors_during_first_refresh(
         "transient network issue"
     )
     with pytest.raises(NetworkError):
-        await coordinator._fetch_enode_chargers(datetime.now(timezone.utc).date(), True)
+        await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), True)
 
     # Under subsequent refresh (last_fetch_today is set), it should swallow NetworkError and return None
-    coordinator.last_fetch_today = datetime.now(timezone.utc)
-    result = await coordinator._fetch_enode_chargers(
-        datetime.now(timezone.utc).date(), True
-    )
+    coordinator.last_fetch_today = datetime.now(UTC)
+    result = await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), True)
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_dynamic_fetch_non_network_errors_ignored(
-    coordinator, mock_frank_energie
-):
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
     """Test that non-network errors in dynamic fetch methods are swallowed even during initial refresh."""
     from python_frank_energie.exceptions import SmartTradingNotEnabledException
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -424,6 +424,31 @@ class TestInitNewAttributes:
         )
         assert coord.site_reference is None
 
+    def test_site_reference_updates_dynamically(self, mock_frank_energie):
+        """site_reference must update dynamically when config_entry.data is updated."""
+        entry = MockConfigEntry(
+            version=1,
+            domain="frank_energie",
+            title="Frank Energie",
+            data={"access_token": "tok"},
+            options={},
+            source="user",
+            entry_id="abc",
+            state="loaded",
+            minor_version=1,
+            unique_id="uid-xyz",
+        )
+        coord = FrankEnergieCoordinator(
+            hass=MagicMock(),
+            config_entry=entry,
+            api=mock_frank_energie,
+        )
+        assert coord.site_reference is None
+
+        # Simulate updating config entry data during setup
+        entry.__dict__["data"] = {**entry.data, "site_reference": "ref-xyz"}
+        assert coord.site_reference == "ref-xyz"
+
 
 class TestMarkLowest4pEventFired:
     """Tests for the renamed _mark_lowest_4p_event_fired method."""
@@ -856,3 +881,46 @@ async def test_fetch_today_data_retry_on_auth_failure(coordinator, mock_frank_en
 
     assert call_count == 1
     coordinator._try_renew_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_fetch_network_errors_during_first_refresh(
+    coordinator, mock_frank_energie
+):
+    """Test that transient network errors in dynamic fetch methods propagate only during initial refresh."""
+    from python_frank_energie.exceptions import NetworkError
+
+    coordinator.last_fetch_today = None
+    mock_frank_energie.is_authenticated = True
+
+    # Under initial refresh, it should propagate NetworkError
+    mock_frank_energie.enode_chargers.side_effect = NetworkError(
+        "transient network issue"
+    )
+    with pytest.raises(NetworkError):
+        await coordinator._fetch_enode_chargers(datetime.now(timezone.utc).date(), True)
+
+    # Under subsequent refresh (last_fetch_today is set), it should swallow NetworkError and return None
+    coordinator.last_fetch_today = datetime.now(timezone.utc)
+    result = await coordinator._fetch_enode_chargers(
+        datetime.now(timezone.utc).date(), True
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_dynamic_fetch_non_network_errors_ignored(
+    coordinator, mock_frank_energie
+):
+    """Test that non-network errors in dynamic fetch methods are swallowed even during initial refresh."""
+    from python_frank_energie.exceptions import SmartTradingNotEnabledException
+
+    coordinator.last_fetch_today = None
+    mock_frank_energie.is_authenticated = True
+
+    # SmartTradingNotEnabledException is a subclass of FrankEnergieException, not a network/connection error
+    mock_frank_energie.smart_batteries.side_effect = SmartTradingNotEnabledException(
+        "disabled"
+    )
+    result = await coordinator._fetch_smart_batteries(True)
+    assert result is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -445,8 +445,17 @@ class TestInitNewAttributes:
         )
         assert coord.site_reference is None
 
-        # Simulate updating config entry data during setup
-        entry.__dict__["data"] = {**entry.data, "site_reference": "ref-xyz"}
+        # Setup side effect to simulate async_update_entry behavior on entry.__dict__
+        def mock_update_entry(entry, **kwargs):
+            if "data" in kwargs:
+                entry.__dict__["data"] = kwargs["data"]
+
+        coord.hass.config_entries.async_update_entry.side_effect = mock_update_entry
+
+        # Simulate updating config entry data during setup using the public API
+        coord.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "site_reference": "ref-xyz"}
+        )
         assert coord.site_reference == "ref-xyz"
 
 


### PR DESCRIPTION
# Pull Request: Dynamic site_reference resolution and dynamic API error propagation on boot

## Summary
Resolves two key issues that prevent dynamic entities (EV chargers, batteries, vehicles, PV systems) and monthly summary sensors from registering on the first boot after an update.

## Key Changes
- Modified the `site_reference` property in `coordinator.py` to read dynamically from `self.config_entry.data` rather than relying solely on a one-time cached constructor value. This allows the coordinator to recognize the site reference immediately after `_select_site_reference` populates it during setup.
- Updated dynamic fetch helper methods (`_fetch_enode_chargers`, `_fetch_smart_batteries`, `_fetch_enode_vehicles`, `_fetch_smart_pv_systems`, `_fetch_smart_pv_summary`, `_fetch_user_smart_feed_in`, `_fetch_battery_details`, and `_fetch_battery_sessions`) to catch specific connection exceptions (`NetworkError`, `RequestException`, `ClientError`, `ConnectionError`, and `asyncio.TimeoutError`) and propagate them only during the initial refresh (`self.last_fetch_today is None`).
- Added comprehensive unit tests in `test_coordinator.py` verifying:
  - `site_reference` updates dynamically when `config_entry.data` changes.
  - Connection errors propagate on first refresh but are swallowed during normal operation.
  - Non-network exceptions (like `SmartTradingNotEnabledException`) are swallowed during initial setup.

## Why this is needed
Previously, a fresh config entry update left `coordinator._site_reference` stuck as `None` during the initial update cycle, causing all site-specific calls to log warnings and return empty data. Swallowing these failures meant the integration loaded successfully but left the user's EV charger and battery sensors missing until a manual reload was triggered.

Closes #161

## Summary by Sourcery

Zorg ervoor dat dynamische entiteiten correct worden geregistreerd bij de eerste start door de site-referentie dynamisch te bepalen en de afhandeling van tijdelijke API-netwerkfouten tijdens de initiële refresh te verbeteren.

Bugfixes:
- Laat de coördinator de actieve `site_reference` dynamisch lezen uit de config entry data, zodat sitespecifieke entiteiten meteen na de setup beschikbaar zijn.
- Propager tijdelijke netwerk- en verbindingsfouten van dynamische API-opvragingen tijdens de initiële refresh, maar negeer ze bij latere refreshes om te voorkomen dat entiteiten stilzwijgend ontbreken.
- Zorg ervoor dat niet-netwerk-excepties van dynamische opvragingen worden genegeerd tijdens de initiële setup, zodat ze het laden van de integratie niet breken.

Tests:
- Voeg tests toe die verifiëren dat `site_reference` runtime-wijzigingen in `config_entry.data` weerspiegelt.
- Voeg tests toe die bevestigen dat netwerkfouten van dynamische fetch-methoden alleen bij de eerste refresh worden opgegooid en daarna worden genegeerd.
- Voeg tests toe die bevestigen dat niet-netwerkfouten bij dynamische fetches zelfs tijdens de initiële refresh worden genegeerd.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure dynamic entities register correctly on first boot by dynamically resolving the site reference and improving handling of transient API network errors during initial refresh.

Bug Fixes:
- Make the coordinator read the active site_reference dynamically from the config entry data so site-specific entities are available immediately after setup.
- Propagate transient network and connection errors from dynamic API fetches during the initial refresh while swallowing them on subsequent refreshes to avoid silently missing entities.
- Ensure non-network exceptions from dynamic fetches are ignored during initial setup so they do not break integration loading.

Tests:
- Add tests verifying that site_reference reflects runtime changes to config_entry.data.
- Add tests confirming network errors from dynamic fetch methods are raised only on the first refresh and ignored afterward.
- Add tests confirming non-network dynamic fetch errors are swallowed even during the initial refresh.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience during network connectivity issues—when transient network errors occur and cached data exists, the system now gracefully falls back to cached data instead of failing.

* **Tests**
  * Added test coverage for updated error-handling behavior and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->