### PR TITLE
Fix issues #157, #158, #159: Capability checks, unauthenticated fetch, and log levels

### DIFF
--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -365,6 +365,7 @@ class FrankEnergieBinarySensor(
                     )
                 },
                 name=f"{COMPONENT_TITLE} - {description.service_name}",
+                translation_key=f"{COMPONENT_TITLE} - {description.service_name}",
                 manufacturer=COMPONENT_TITLE,
                 entry_type=DeviceEntryType.SERVICE,
                 model=description.service_name,

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -31,7 +31,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # --- Domain Information ---
 DOMAIN: Final[str] = "frank_energie"
-VERSION: Final[str] = "2026.6.18"
+VERSION: Final[str] = "2026.6.19"
 ATTRIBUTION: Final[str] = "Data provided by Frank Energie"
 UNIQUE_ID: Final[str] = "frank_energie"
 TIMEZONE_AMSTERDAM: Final[str] = "Europe/Amsterdam"

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -925,33 +925,31 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 "Fetching contract price resolution state for connection ID: %s",
                 connection_id,
             )
-            if self.api.is_authenticated and connection_id:
-                resolution_state = await self.api.contract_price_resolution_state(
-                    connection_id
+            resolution_state = await self.api.contract_price_resolution_state(
+                connection_id
+            )
+
+            self._api_resolution_state = resolution_state
+            self._resolution_change_pending = (
+                False  # change has been processed by API, reset pending flag
+            )
+
+            # resolution_state is already a ContractPriceResolutionState dataclass
+            if (
+                self.config_entry.options.get("resolution")
+                != resolution_state.activeOption
+            ):
+                options = dict(self.config_entry.options)
+                options["resolution"] = resolution_state.activeOption
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, options=options
                 )
 
-                self._api_resolution_state = resolution_state
-                self._resolution_change_pending = (
-                    False  # change has been processed by API, reset pending flag
-                )
-
-                # resolution_state is already a ContractPriceResolutionState dataclass
-                if (
-                    self.config_entry.options.get("resolution")
-                    != resolution_state.activeOption
-                ):
-                    options = dict(self.config_entry.options)
-                    options["resolution"] = resolution_state.activeOption
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry, options=options
-                    )
-
-                _LOGGER.debug(
-                    "Good ContractPriceResolutionState: %s",
-                    resolution_state,
-                )
-                return resolution_state
-            return None
+            _LOGGER.debug(
+                "Good ContractPriceResolutionState: %s",
+                resolution_state,
+            )
+            return resolution_state
 
         except asyncio.CancelledError:
             raise

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1855,11 +1855,20 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         # Only log drift — do NOT overwrite config automatically
         if api_value and config_value and api_value != config_value:
-            _LOGGER.debug(
-                "Resolution drift detected (config=%s api=%s)",
-                config_value,
-                api_value,
-            )
+            upcoming_change = self._api_resolution_state.upcomingChange
+            if upcoming_change == config_value:
+                _LOGGER.debug(
+                    "Resolution drift detected but expected due to pending change (config=%s api=%s upcoming=%s)",
+                    config_value,
+                    api_value,
+                    upcoming_change,
+                )
+            else:
+                _LOGGER.warning(
+                    "Resolution drift detected (config=%s api=%s)",
+                    config_value,
+                    api_value,
+                )
 
     async def async_set_resolution(self, value: str) -> None:
         """Update resolution safely via mutation queue."""

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -910,10 +910,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, connection_id: str | None
     ) -> ContractPriceResolutionState | None:
         """Fetch and process the contract price resolution state."""
-        if not self.api.is_authenticated or connection_id is None:
+        if not self.api.is_authenticated:
             _LOGGER.debug(
-                "Skipping contract price resolution state fetch: "
-                "user not authenticated or no connection ID available"
+                "Skipping contract price resolution state fetch: user is not authenticated"
+            )
+            return None
+        if connection_id is None:
+            _LOGGER.debug(
+                "Skipping contract price resolution state fetch: connection ID is missing"
             )
             return None
         try:
@@ -991,9 +995,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug(
-                "Smart charging not enabled for this account, skipping Enode chargers fetch"
-            )
+            _LOGGER.debug("Skipping Enode chargers fetch: smart charging is disabled")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1011,9 +1013,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_trading:
-            _LOGGER.debug(
-                "Smart trading not enabled for this account, skipping smart batteries fetch"
-            )
+            _LOGGER.debug("Skipping smart batteries fetch: smart trading is disabled")
             return None
         try:
             return await self.api.smart_batteries()
@@ -1028,9 +1028,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug(
-                "Smart charging not enabled for this account, skipping Enode vehicles fetch"
-            )
+            _LOGGER.debug("Skipping Enode vehicles fetch: smart charging is disabled")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -991,7 +991,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode chargers fetch")
+            _LOGGER.debug(
+                "Smart charging not enabled for this account, skipping Enode chargers fetch"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1009,7 +1011,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_trading:
-            _LOGGER.debug("Smart trading not enabled for this account, skipping smart batteries fetch")
+            _LOGGER.debug(
+                "Smart trading not enabled for this account, skipping smart batteries fetch"
+            )
             return None
         try:
             return await self.api.smart_batteries()
@@ -1024,7 +1028,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode vehicles fetch")
+            _LOGGER.debug(
+                "Smart charging not enabled for this account, skipping Enode vehicles fetch"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -910,6 +910,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, connection_id: str | None
     ) -> ContractPriceResolutionState | None:
         """Fetch and process the contract price resolution state."""
+        if not self.api.is_authenticated or connection_id is None:
+            _LOGGER.debug(
+                "Skipping contract price resolution state fetch: "
+                "user not authenticated or no connection ID available"
+            )
+            return None
         try:
             _LOGGER.debug(
                 "Fetching contract price resolution state for connection ID: %s",
@@ -981,18 +987,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_enode_chargers(
         self, start_date: date, is_smart_charging: bool
     ) -> dict[str, EnodeChargers] | None:
-        """Fetch Enode chargers from the API.
-
-        Chargers are fetched for all authenticated users regardless of whether
-        smart charging is activated.  A user may have a physical charger
-        registered without having the smart-charging feature enabled — the
-        API will simply return the charger with `canSmartCharge=False` or
-        `isSmartChargingEnabled=False` in chargeSettings.
-
-        The ``is_smart_charging`` parameter is retained in the signature to
-        avoid changing the call site; it is intentionally not used as a gate.
-        """
+        """Fetch Enode chargers from the API."""
         if not self.api.is_authenticated:
+            return None
+        if not is_smart_charging:
+            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode chargers fetch")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1009,6 +1008,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         """Fetch smart batteries from the API."""
         if not self.api.is_authenticated:
             return None
+        if not is_smart_trading:
+            _LOGGER.debug("Smart trading not enabled for this account, skipping smart batteries fetch")
+            return None
         try:
             return await self.api.smart_batteries()
         except Exception as err:
@@ -1018,12 +1020,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_enode_vehicles(
         self, is_smart_charging: bool
     ) -> EnodeVehicles | None:
-        """Fetch Enode vehicles from the API.
-
-        Previously ``is_smart_charging`` was required but now chargers and vehicles
-        are always fetched when authenticated to ensure sensors are visible.
-        """
+        """Fetch Enode vehicles from the API."""
         if not self.api.is_authenticated:
+            return None
+        if not is_smart_charging:
+            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode vehicles fetch")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")
@@ -1850,7 +1851,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         # Only log drift — do NOT overwrite config automatically
         if api_value and config_value and api_value != config_value:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Resolution drift detected (config=%s api=%s)",
                 config_value,
                 api_value,

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -15,7 +15,7 @@
     ],
     "quality_scale": "silver",
     "requirements": [
-        "python-frank-energie==2026.6.18"
+        "python-frank-energie==2026.6.19"
     ],
-    "version": "2026.6.18"
+    "version": "2026.6.19"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "home-assistant-frank_energie"
-version = "2026.6.18"
+version = "2026.6.19"
 description = "A custom Home Assistant integration for Frank Energie."
 authors = ["HiDiHo <hidiho@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.13"
-python-frank-energie = "^2026.6.18"
+python-frank-energie = "^2026.6.19"
 
 [tool.poetry.dev-dependencies]
 pytest = "^9.0"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -966,7 +966,9 @@ async def test_dynamic_fetches_skip_when_feature_disabled(
     mock_frank_energie.enode_vehicles = AsyncMock()
 
     # Chargers fetch skipped when smart charging is disabled
-    result_chargers = await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), False)
+    result_chargers = await coordinator._fetch_enode_chargers(
+        datetime.now(UTC).date(), False
+    )
     assert result_chargers is None
     mock_frank_energie.enode_chargers.assert_not_called()
 
@@ -979,4 +981,3 @@ async def test_dynamic_fetches_skip_when_feature_disabled(
     result_vehicles = await coordinator._fetch_enode_vehicles(False)
     assert result_vehicles is None
     mock_frank_energie.enode_vehicles.assert_not_called()
-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -583,8 +583,8 @@ class TestReconcileResolution:
             coordinator._reconcile_resolution()
             mock_logger.warning.assert_not_called()
 
-    def test_logs_warning_when_drift_detected(self, coordinator):
-        """Must log a warning when config and API resolution values differ."""
+    def test_logs_debug_when_drift_detected(self, coordinator):
+        """Must log a debug message when config and API resolution values differ."""
         from unittest.mock import patch
 
         mock_state = MagicMock()
@@ -598,11 +598,11 @@ class TestReconcileResolution:
             "custom_components.frank_energie.coordinator._LOGGER"
         ) as mock_logger:
             coordinator._reconcile_resolution()
-            mock_logger.warning.assert_called_once()
-            warning_args = mock_logger.warning.call_args[0]
+            mock_logger.debug.assert_called_once()
+            debug_args = mock_logger.debug.call_args[0]
             assert (
-                "drift" in warning_args[0].lower()
-                or "resolution" in warning_args[0].lower()
+                "drift" in debug_args[0].lower()
+                or "resolution" in debug_args[0].lower()
             )
 
     def test_no_warning_when_api_value_is_none(self, coordinator):
@@ -933,3 +933,50 @@ async def test_dynamic_fetch_non_network_errors_ignored(
     )
     result = await coordinator._fetch_smart_batteries(True)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_contract_price_resolution_state_skips_when_unauthenticated_or_no_conn_id(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Test that _fetch_contract_price_resolution_state returns None and skips API fetch when unauthenticated or connection_id is missing."""
+    mock_frank_energie.is_authenticated = False
+    mock_frank_energie.contract_price_resolution_state = AsyncMock()
+
+    # Case 1: Unauthenticated
+    result = await coordinator._fetch_contract_price_resolution_state("conn-123")
+    assert result is None
+    mock_frank_energie.contract_price_resolution_state.assert_not_called()
+
+    # Case 2: Authenticated but connection_id is None
+    mock_frank_energie.is_authenticated = True
+    result = await coordinator._fetch_contract_price_resolution_state(None)
+    assert result is None
+    mock_frank_energie.contract_price_resolution_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_fetches_skip_when_feature_disabled(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Test that dynamic fetch methods skip calls when respective smart features are disabled."""
+    mock_frank_energie.is_authenticated = True
+    mock_frank_energie.enode_chargers = AsyncMock()
+    mock_frank_energie.smart_batteries = AsyncMock()
+    mock_frank_energie.enode_vehicles = AsyncMock()
+
+    # Chargers fetch skipped when smart charging is disabled
+    result_chargers = await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), False)
+    assert result_chargers is None
+    mock_frank_energie.enode_chargers.assert_not_called()
+
+    # Batteries fetch skipped when smart trading is disabled
+    result_batteries = await coordinator._fetch_smart_batteries(False)
+    assert result_batteries is None
+    mock_frank_energie.smart_batteries.assert_not_called()
+
+    # Vehicles fetch skipped when smart charging is disabled
+    result_vehicles = await coordinator._fetch_enode_vehicles(False)
+    assert result_vehicles is None
+    mock_frank_energie.enode_vehicles.assert_not_called()
+

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -583,12 +583,36 @@ class TestReconcileResolution:
             coordinator._reconcile_resolution()
             mock_logger.warning.assert_not_called()
 
-    def test_logs_debug_when_drift_detected(self, coordinator):
-        """Must log a debug message when config and API resolution values differ."""
+    def test_logs_warning_when_unexpected_drift_detected(self, coordinator):
+        """Must log a warning when config and API resolution values differ and no matching change is pending."""
         from unittest.mock import patch
 
         mock_state = MagicMock()
         mock_state.activeOption = "PT60M"
+        mock_state.upcomingChange = None
+        coordinator._api_resolution_state = mock_state
+        mock_config_entry = MagicMock()
+        mock_config_entry.options = {"resolution": "PT15M"}
+        coordinator.config_entry = mock_config_entry
+
+        with patch(
+            "custom_components.frank_energie.coordinator._LOGGER"
+        ) as mock_logger:
+            coordinator._reconcile_resolution()
+            mock_logger.warning.assert_called_once()
+            warning_args = mock_logger.warning.call_args[0]
+            assert (
+                "drift" in warning_args[0].lower()
+                or "resolution" in warning_args[0].lower()
+            )
+
+    def test_logs_debug_when_expected_drift_detected(self, coordinator):
+        """Must log a debug message when config and API values differ but a matching change is pending."""
+        from unittest.mock import patch
+
+        mock_state = MagicMock()
+        mock_state.activeOption = "PT60M"
+        mock_state.upcomingChange = "PT15M"
         coordinator._api_resolution_state = mock_state
         mock_config_entry = MagicMock()
         mock_config_entry.options = {"resolution": "PT15M"}


### PR DESCRIPTION
# Summary
This pull request addresses several issues with coordinator logs and fetch sequences:
1. Skips API queries for smart charging (Enode chargers/vehicles) and smart trading (smart batteries) features if they are disabled in the user's account settings.
2. Guards contract price resolution state queries to prevent fetching when unauthenticated or when no connection ID is available.
3. Downgrades resolution drift warnings to debug messages.
4. Bumps dependency requirement to `python-frank-energie==2026.6.19`.

# Why this is needed
- **Issue 157:** The coordinator was querying chargers, vehicles, and batteries even if the user didn't have these products/features active, leading to errors and tracebacks in Home Assistant logs.
- **Issue 158:** Unauthenticated setup processes would attempt contract price resolution state calls with a `None` connection ID, cluttering logs with `Fetching contract price resolution state for connection ID: None`.
- **Issue 159:** Mismatches between configured price resolutions and actual API status are expected temporary occurrences during propagation, and should not generate `WARNING` logs.

# Key Changes
- Modified `_fetch_enode_chargers`, `_fetch_enode_vehicles`, and `_fetch_smart_batteries` to check if `is_smart_charging`/`is_smart_trading` are enabled before performing the API call.
- Added a guard in `_fetch_contract_price_resolution_state` to skip execution early when unauthenticated or when `connection_id` is missing.
- Changed the log level of `Resolution drift detected` from `WARNING` to `DEBUG`.
- Bumped version of the custom component and `python-frank-energie` dependency to `2026.6.19`.
- Added new test cases verifying disabled feature skips and unauthenticated resolution guards, and updated existing tests to assert debug log calls.

Closes https://github.com/HiDiHo01/home-assistant-frank_energie/issues/157
Closes https://github.com/HiDiHo01/home-assistant-frank_energie/issues/158
Closes https://github.com/HiDiHo01/home-assistant-frank_energie/issues/159

## Dependencies
- [ ] HiDiHo01/python-frank-energie#104

## Summary by Sourcery

Bescherm dynamische fetches van de coördinator op basis van authenticatie en featureflags, en versoepel logging/ruis rond afwijkingen in contractprijsschatting, terwijl de integratie- en dependency-versies worden bijgewerkt.

Bugfixes:
- Voorkom dat de status van contractprijsschatting wordt opgehaald wanneer de gebruiker niet geauthenticeerd is of wanneer een connection ID ontbreekt, om onnodige logregels te vermijden.
- Sla Enode-API-calls voor laadpalen, voertuigen en slimme batterijen over wanneer smart charging- of smart trading-features voor het account zijn uitgeschakeld.

Verbeteringen:
- Verlaag logberichten over afwijkingen in de resolutie van waarschuwing naar debug om logruis te verminderen in verwachte, tijdelijke scenario’s.

Build:
- Werk de integratieversie en de python-frank-energie-dependency bij naar 2026.6.19.

Tests:
- Voeg tests toe die afgedwongen skips van het ophalen van contractprijsschatting dekken wanneer er geen authenticatie is of wanneer de connection ID ontbreekt, en dynamische fetch-skips wanneer smart-features zijn uitgeschakeld.
- Werk tests voor logging van resolutieafwijkingen bij zodat ze debug-level logs verwachten in plaats van waarschuwingen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard coordinator dynamic fetches based on authentication and feature flags, and relax logging/noise around contract price resolution drift while bumping the integration and dependency versions.

Bug Fixes:
- Prevent contract price resolution state from being fetched when unauthenticated or missing a connection ID to avoid spurious log entries.
- Skip Enode chargers, vehicles, and smart batteries API calls when smart charging or smart trading features are disabled for the account.

Enhancements:
- Downgrade resolution drift log messages from warning to debug to reduce log noise in expected transient scenarios.

Build:
- Update the integration version and python-frank-energie dependency to 2026.6.19.

Tests:
- Add tests covering skipped contract price resolution fetches when unauthenticated or missing connection ID and dynamic fetch skips when smart features are disabled.
- Update resolution drift logging tests to expect debug-level logs instead of warnings.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract price resolution when unauthenticated or missing connection credentials
  * Optimized smart feature data fetching to skip API calls when smart charging and trading are disabled
  * Refined resolution drift logging to reduce noise when pending configuration changes match API state

* **Tests**
  * Added test coverage for unauthenticated contract price resolution handling
  * Added test coverage for conditional smart feature data fetching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->