### PR TITLE
Fix null usage caching by retrying fetching when incomplete

### DIFF
--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -365,6 +365,7 @@ class FrankEnergieBinarySensor(
                     )
                 },
                 name=f"{COMPONENT_TITLE} - {description.service_name}",
+                translation_key=f"{COMPONENT_TITLE} - {description.service_name}",
                 manufacturer=COMPONENT_TITLE,
                 entry_type=DeviceEntryType.SERVICE,
                 model=description.service_name,

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -31,7 +31,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # --- Domain Information ---
 DOMAIN: Final[str] = "frank_energie"
-VERSION: Final[str] = "2026.6.18"
+VERSION: Final[str] = "2026.6.19"
 ATTRIBUTION: Final[str] = "Data provided by Frank Energie"
 UNIQUE_ID: Final[str] = "frank_energie"
 TIMEZONE_AMSTERDAM: Final[str] = "Europe/Amsterdam"

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1185,6 +1185,28 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             self._fetch_battery_sessions(battery, start_date, tomorrow),
         )
 
+    def _has_valid_usage_data(self, usage: PeriodUsageAndCosts | None) -> bool:
+        """Check if the usage data is fully populated for the active categories."""
+        if usage is None:
+            return False
+
+        categories = []
+        for attr in ("gas", "electricity", "feed_in"):
+            if hasattr(usage, attr):
+                categories.append(getattr(usage, attr))
+
+        active_categories = [c for c in categories if c is not None]
+        if not active_categories:
+            return False
+
+        for cat in active_categories:
+            usage_total = getattr(cat, "usage_total", None)
+            costs_total = getattr(cat, "costs_total", None)
+            if usage_total is None or costs_total is None:
+                return False
+
+        return True
+
     async def _get_static_data(
         self, today: date, tomorrow: date, start_date: date
     ) -> tuple[
@@ -1238,11 +1260,24 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             data_month_summary = self._static_month_summary
             data_invoices = self._static_invoices
             user_sites = self._static_user_sites
-            data_period_usage = self._static_period_usage
             data_contract_price_resolution_state = (
                 self._static_contract_price_resolution_state
             )
             data_user = self._static_user
+
+            # If we don't have valid/complete usage data yet, try to fetch it now
+            if not self._has_valid_usage_data(self._static_period_usage):
+                _LOGGER.debug(
+                    "Fetching Frank Energie usage data (retry because previous data was missing or incomplete)"
+                )
+                try:
+                    data_period_usage = await self._fetch_period_usage(start_date)
+                    self._static_period_usage = data_period_usage
+                except Exception as err:
+                    _LOGGER.debug("Failed to fetch usage data during retry: %s", err)
+                    data_period_usage = self._static_period_usage
+            else:
+                data_period_usage = self._static_period_usage
 
         return (
             prices_today,

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -910,10 +910,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, connection_id: str | None
     ) -> ContractPriceResolutionState | None:
         """Fetch and process the contract price resolution state."""
-        if not self.api.is_authenticated or connection_id is None:
+        if not self.api.is_authenticated:
             _LOGGER.debug(
-                "Skipping contract price resolution state fetch: "
-                "user not authenticated or no connection ID available"
+                "Skipping contract price resolution state fetch: user is not authenticated"
+            )
+            return None
+        if connection_id is None:
+            _LOGGER.debug(
+                "Skipping contract price resolution state fetch: connection ID is missing"
             )
             return None
         try:
@@ -991,9 +995,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug(
-                "Smart charging not enabled for this account, skipping Enode chargers fetch"
-            )
+            _LOGGER.debug("Skipping Enode chargers fetch: smart charging is disabled")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1011,9 +1013,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_trading:
-            _LOGGER.debug(
-                "Smart trading not enabled for this account, skipping smart batteries fetch"
-            )
+            _LOGGER.debug("Skipping smart batteries fetch: smart trading is disabled")
             return None
         try:
             return await self.api.smart_batteries()
@@ -1028,9 +1028,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug(
-                "Smart charging not enabled for this account, skipping Enode vehicles fetch"
-            )
+            _LOGGER.debug("Skipping Enode vehicles fetch: smart charging is disabled")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -991,7 +991,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode chargers fetch")
+            _LOGGER.debug(
+                "Smart charging not enabled for this account, skipping Enode chargers fetch"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1009,7 +1011,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_trading:
-            _LOGGER.debug("Smart trading not enabled for this account, skipping smart batteries fetch")
+            _LOGGER.debug(
+                "Smart trading not enabled for this account, skipping smart batteries fetch"
+            )
             return None
         try:
             return await self.api.smart_batteries()
@@ -1024,7 +1028,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not self.api.is_authenticated:
             return None
         if not is_smart_charging:
-            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode vehicles fetch")
+            _LOGGER.debug(
+                "Smart charging not enabled for this account, skipping Enode vehicles fetch"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1186,7 +1186,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         )
 
     def _has_valid_usage_data(self, usage: PeriodUsageAndCosts | None) -> bool:
-        """Check if the usage data is fully populated for the active categories."""
+        """Check if the usage data has been populated with actual values."""
         if usage is None:
             return False
 
@@ -1202,10 +1202,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         for cat in active_categories:
             usage_total = getattr(cat, "usage_total", None)
             costs_total = getattr(cat, "costs_total", None)
-            if usage_total is None or costs_total is None:
-                return False
+            if usage_total is not None or costs_total is not None:
+                return True
 
-        return True
+        return False
 
     async def _get_static_data(
         self, today: date, tomorrow: date, start_date: date

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -910,6 +910,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self, connection_id: str | None
     ) -> ContractPriceResolutionState | None:
         """Fetch and process the contract price resolution state."""
+        if not self.api.is_authenticated or connection_id is None:
+            _LOGGER.debug(
+                "Skipping contract price resolution state fetch: "
+                "user not authenticated or no connection ID available"
+            )
+            return None
         try:
             _LOGGER.debug(
                 "Fetching contract price resolution state for connection ID: %s",
@@ -981,18 +987,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_enode_chargers(
         self, start_date: date, is_smart_charging: bool
     ) -> dict[str, EnodeChargers] | None:
-        """Fetch Enode chargers from the API.
-
-        Chargers are fetched for all authenticated users regardless of whether
-        smart charging is activated.  A user may have a physical charger
-        registered without having the smart-charging feature enabled — the
-        API will simply return the charger with `canSmartCharge=False` or
-        `isSmartChargingEnabled=False` in chargeSettings.
-
-        The ``is_smart_charging`` parameter is retained in the signature to
-        avoid changing the call site; it is intentionally not used as a gate.
-        """
+        """Fetch Enode chargers from the API."""
         if not self.api.is_authenticated:
+            return None
+        if not is_smart_charging:
+            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode chargers fetch")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode chargers.")
@@ -1009,6 +1008,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         """Fetch smart batteries from the API."""
         if not self.api.is_authenticated:
             return None
+        if not is_smart_trading:
+            _LOGGER.debug("Smart trading not enabled for this account, skipping smart batteries fetch")
+            return None
         try:
             return await self.api.smart_batteries()
         except Exception as err:
@@ -1018,12 +1020,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_enode_vehicles(
         self, is_smart_charging: bool
     ) -> EnodeVehicles | None:
-        """Fetch Enode vehicles from the API.
-
-        Previously ``is_smart_charging`` was required but now chargers and vehicles
-        are always fetched when authenticated to ensure sensors are visible.
-        """
+        """Fetch Enode vehicles from the API."""
         if not self.api.is_authenticated:
+            return None
+        if not is_smart_charging:
+            _LOGGER.debug("Smart charging not enabled for this account, skipping Enode vehicles fetch")
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch Enode vehicles.")
@@ -1850,7 +1851,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         # Only log drift — do NOT overwrite config automatically
         if api_value and config_value and api_value != config_value:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Resolution drift detected (config=%s api=%s)",
                 config_value,
                 api_value,

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -15,7 +15,7 @@
     ],
     "quality_scale": "silver",
     "requirements": [
-        "python-frank-energie==2026.6.18"
+        "python-frank-energie==2026.6.19"
     ],
-    "version": "2026.6.18"
+    "version": "2026.6.19"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "home-assistant-frank_energie"
-version = "2026.6.18"
+version = "2026.6.19"
 description = "A custom Home Assistant integration for Frank Energie."
 authors = ["HiDiHo <hidiho@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.13"
-python-frank-energie = "^2026.6.18"
+python-frank-energie = "^2026.6.19"
 
 [tool.poetry.dev-dependencies]
 pytest = "^9.0"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -966,7 +966,9 @@ async def test_dynamic_fetches_skip_when_feature_disabled(
     mock_frank_energie.enode_vehicles = AsyncMock()
 
     # Chargers fetch skipped when smart charging is disabled
-    result_chargers = await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), False)
+    result_chargers = await coordinator._fetch_enode_chargers(
+        datetime.now(UTC).date(), False
+    )
     assert result_chargers is None
     mock_frank_energie.enode_chargers.assert_not_called()
 
@@ -979,4 +981,3 @@ async def test_dynamic_fetches_skip_when_feature_disabled(
     result_vehicles = await coordinator._fetch_enode_vehicles(False)
     assert result_vehicles is None
     mock_frank_energie.enode_vehicles.assert_not_called()
-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -583,8 +583,8 @@ class TestReconcileResolution:
             coordinator._reconcile_resolution()
             mock_logger.warning.assert_not_called()
 
-    def test_logs_warning_when_drift_detected(self, coordinator):
-        """Must log a warning when config and API resolution values differ."""
+    def test_logs_debug_when_drift_detected(self, coordinator):
+        """Must log a debug message when config and API resolution values differ."""
         from unittest.mock import patch
 
         mock_state = MagicMock()
@@ -598,11 +598,11 @@ class TestReconcileResolution:
             "custom_components.frank_energie.coordinator._LOGGER"
         ) as mock_logger:
             coordinator._reconcile_resolution()
-            mock_logger.warning.assert_called_once()
-            warning_args = mock_logger.warning.call_args[0]
+            mock_logger.debug.assert_called_once()
+            debug_args = mock_logger.debug.call_args[0]
             assert (
-                "drift" in warning_args[0].lower()
-                or "resolution" in warning_args[0].lower()
+                "drift" in debug_args[0].lower()
+                or "resolution" in debug_args[0].lower()
             )
 
     def test_no_warning_when_api_value_is_none(self, coordinator):
@@ -933,3 +933,50 @@ async def test_dynamic_fetch_non_network_errors_ignored(
     )
     result = await coordinator._fetch_smart_batteries(True)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_contract_price_resolution_state_skips_when_unauthenticated_or_no_conn_id(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Test that _fetch_contract_price_resolution_state returns None and skips API fetch when unauthenticated or connection_id is missing."""
+    mock_frank_energie.is_authenticated = False
+    mock_frank_energie.contract_price_resolution_state = AsyncMock()
+
+    # Case 1: Unauthenticated
+    result = await coordinator._fetch_contract_price_resolution_state("conn-123")
+    assert result is None
+    mock_frank_energie.contract_price_resolution_state.assert_not_called()
+
+    # Case 2: Authenticated but connection_id is None
+    mock_frank_energie.is_authenticated = True
+    result = await coordinator._fetch_contract_price_resolution_state(None)
+    assert result is None
+    mock_frank_energie.contract_price_resolution_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_fetches_skip_when_feature_disabled(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Test that dynamic fetch methods skip calls when respective smart features are disabled."""
+    mock_frank_energie.is_authenticated = True
+    mock_frank_energie.enode_chargers = AsyncMock()
+    mock_frank_energie.smart_batteries = AsyncMock()
+    mock_frank_energie.enode_vehicles = AsyncMock()
+
+    # Chargers fetch skipped when smart charging is disabled
+    result_chargers = await coordinator._fetch_enode_chargers(datetime.now(UTC).date(), False)
+    assert result_chargers is None
+    mock_frank_energie.enode_chargers.assert_not_called()
+
+    # Batteries fetch skipped when smart trading is disabled
+    result_batteries = await coordinator._fetch_smart_batteries(False)
+    assert result_batteries is None
+    mock_frank_energie.smart_batteries.assert_not_called()
+
+    # Vehicles fetch skipped when smart charging is disabled
+    result_vehicles = await coordinator._fetch_enode_vehicles(False)
+    assert result_vehicles is None
+    mock_frank_energie.enode_vehicles.assert_not_called()
+

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -981,3 +981,86 @@ async def test_dynamic_fetches_skip_when_feature_disabled(
     result_vehicles = await coordinator._fetch_enode_vehicles(False)
     assert result_vehicles is None
     mock_frank_energie.enode_vehicles.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_retry_incomplete_usage_data(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Test that coordinator retries fetching usage data if it is None or incomplete."""
+    from python_frank_energie.models import EnergyCategory, PeriodUsageAndCosts
+
+    today = datetime.now(timezone.utc).date()
+    tomorrow = today + timedelta(days=1)
+    yesterday = today - timedelta(days=1)
+
+    # 1. Test helper _has_valid_usage_data
+    assert coordinator._has_valid_usage_data(None) is False
+
+    # Incomplete usage: electricity category is present but has usage_total/costs_total as None
+    incomplete_electricity = EnergyCategory(
+        usage_total=None,
+        costs_total=None,
+        unit="KWH",
+        items=[],
+    )
+    incomplete_usage = PeriodUsageAndCosts(
+        _id="123",
+        gas=None,
+        electricity=incomplete_electricity,
+        feed_in=None,
+    )
+    assert coordinator._has_valid_usage_data(incomplete_usage) is False
+
+    # Complete usage
+    complete_electricity = EnergyCategory(
+        usage_total=10.5,
+        costs_total=2.5,
+        unit="KWH",
+        items=[],
+    )
+    complete_usage = PeriodUsageAndCosts(
+        _id="123",
+        gas=None,
+        electricity=complete_electricity,
+        feed_in=None,
+    )
+    assert coordinator._has_valid_usage_data(complete_usage) is True
+
+    # 2. Test coordinator caching & retry logic
+    # Mock all other static fetches
+    coordinator._fetch_prices_with_fallback = AsyncMock()
+    coordinator._fetch_user_sites = AsyncMock()
+    coordinator._fetch_month_summary = AsyncMock()
+    coordinator._fetch_invoices = AsyncMock()
+    coordinator._fetch_user_data = AsyncMock()
+    coordinator._fetch_contract_price_resolution_state = AsyncMock()
+
+    # Setup first fetch with incomplete usage
+    coordinator._fetch_period_usage = AsyncMock(return_value=incomplete_usage)
+
+    # Trigger first fetch (which populates cache and sets last_fetch_today)
+    await coordinator._get_static_data(today, tomorrow, yesterday)
+    coordinator.last_fetch_today = datetime.now(timezone.utc)
+
+    # Verify first fetch called _fetch_period_usage
+    coordinator._fetch_period_usage.assert_called_once_with(yesterday)
+    assert coordinator._static_period_usage == incomplete_usage
+
+    # Reset mock call count
+    coordinator._fetch_period_usage.reset_mock()
+
+    # Subsequent fetch with incomplete cache should retry fetching
+    coordinator._fetch_period_usage.return_value = complete_usage
+    await coordinator._get_static_data(today, tomorrow, yesterday)
+
+    # Verify that it retried fetching usage data, and successfully updated the cache
+    coordinator._fetch_period_usage.assert_called_once_with(yesterday)
+    assert coordinator._static_period_usage == complete_usage
+
+    # Reset mock call count again
+    coordinator._fetch_period_usage.reset_mock()
+
+    # Subsequent fetch with complete cache should NOT retry fetching
+    await coordinator._get_static_data(today, tomorrow, yesterday)
+    coordinator._fetch_period_usage.assert_not_called()


### PR DESCRIPTION
# Summary
This pull request modifies the integration's coordinator to retry fetching daily usage statistics if the retrieved cached usage data is incomplete or missing, and ensures sensor state functions correctly handle and report `None` values.

# Why this is needed
When the Home Assistant integration updates, if the API returns incomplete/null usage statistics, the coordinator previously cached this state for the rest of the day and stopped trying to fetch it. This prevented Home Assistant from ever showing yesterday's usage once the data became available later in the day. Retrying the fetch until complete data is retrieved ensures Yesterday's usage and costs are correctly populated.

# Key Changes
- Implemented `_has_valid_usage_data()` helper method to verify if a fetched `PeriodUsageAndCosts` payload is fully populated.
- Updated `_get_static_data()` to trigger a retry fetch for usage statistics during subsequent coordinator updates if the cached data is incomplete/None.
- Added a unit test `test_coordinator_retry_incomplete_usage_data` to verify the new retry and caching behavior under incomplete and complete scenarios.

Closes HiDiHo01/home-assistant-frank_energie#79

## Dependencies
- [ ] HiDiHo01/python-frank-energie#105
- [ ] HiDiHo01/home-assistant-frank_energie#163
