### PR TITLE
feat: integrate smartHvac binary sensor with separate status fetching and proper availability

### DIFF
--- a/custom_components/frank_energie/binary_sensor.py
+++ b/custom_components/frank_energie/binary_sensor.py
@@ -163,6 +163,7 @@ def _user_feature_attributes(
                     "available_in_country": feature.get("isAvailableInCountry"),
                     "user_created_at": feature.get("userCreatedAt"),
                     "needs_subscription": feature.get("needsSubscription"),
+                    "user_id": feature.get("userId"),
                 }.items()
                 if value is not None
             }
@@ -190,6 +191,11 @@ def _user_feature_attributes(
                     "needsSubscription",
                     None,
                 ),
+                "user_id": getattr(
+                    feature,
+                    "userId",
+                    None,
+                ),
             }.items()
             if value is not None
         }
@@ -197,9 +203,25 @@ def _user_feature_attributes(
     return attr_fn
 
 
-def _smart_hvac_state(data: FrankEnergieData) -> bool:
+def _smart_hvac_state(data: FrankEnergieData) -> bool | None:
     """Return smart HVAC active state."""
     return _user_feature_state(data, UserFeatureKey.SMART_HVAC)
+
+
+def _smart_hvac_available(data: FrankEnergieData) -> bool:
+    """Return smart HVAC availability."""
+    user = data.get(DATA_USER)
+    if user is None:
+        return False
+
+    feature = getattr(user, "smartHvac", None)
+    if feature is None:
+        return False
+
+    if isinstance(feature, dict):
+        return feature.get("isActivated") is not None
+
+    return getattr(feature, "isActivated", None) is not None
 
 
 def _disabled_haptic_feedback(
@@ -377,9 +399,9 @@ def _battery_attributes(
             "max_charge_power_kw": sb.max_charge_power,
             "max_discharge_power_kw": sb.max_discharge_power,
             "battery_mode": settings.battery_mode if settings else None,
-            "imbalance_trading_strategy": settings.imbalance_trading_strategy
-            if settings
-            else None,
+            "imbalance_trading_strategy": (
+                settings.imbalance_trading_strategy if settings else None
+            ),
             "self_consumption_trading_threshold_price": getattr(
                 settings,
                 "self_consumption_trading_threshold_price",
@@ -547,6 +569,10 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[
         device_class=BinarySensorDeviceClass.RUNNING,
         service_name=SERVICE_NAME_USER,
         value_fn=_smart_hvac_state,
+        available_fn=_smart_hvac_available,
+        attr_fn=_user_feature_attributes(
+            "smartHvac",
+        ),
     ),
     FrankEnergieBinarySensorDescription(
         key="disabled_haptic_feedback",

--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -1,6 +1,7 @@
 """
 Constants used in the Frank Energie integration.
 """
+
 # const.py
 
 import logging
@@ -31,7 +32,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # --- Domain Information ---
 DOMAIN: Final[str] = "frank_energie"
-VERSION: Final[str] = "2026.6.19"
+VERSION: Final[str] = "2026.6.21"
 ATTRIBUTION: Final[str] = "Data provided by Frank Energie"
 UNIQUE_ID: Final[str] = "frank_energie"
 TIMEZONE_AMSTERDAM: Final[str] = "Europe/Amsterdam"

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -421,18 +421,22 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # ---------------------------------------------------
         _LOGGER.debug(
             "Today electricity periods: %s",
-            len(self.cached_prices_today.prices_today.electricity.all)
-            if self.cached_prices_today
-            and self.cached_prices_today.prices_today
-            and self.cached_prices_today.prices_today.electricity
-            else 0,
+            (
+                len(self.cached_prices_today.prices_today.electricity.all)
+                if self.cached_prices_today
+                and self.cached_prices_today.prices_today
+                and self.cached_prices_today.prices_today.electricity
+                else 0
+            ),
         )
 
         _LOGGER.debug(
             "Tomorrow electricity periods: %s",
-            len(prices_tomorrow.electricity.all)
-            if prices_tomorrow and prices_tomorrow.electricity
-            else 0,
+            (
+                len(prices_tomorrow.electricity.all)
+                if prices_tomorrow and prices_tomorrow.electricity
+                else 0
+            ),
         )
         result = self._aggregate_data(self.cached_prices_today, prices_tomorrow)
         self.cached_prices = result
@@ -604,9 +608,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 "[%s][%s] Tomorrow electricity periods: %s",
                 self.config_entry.title,
                 self.site_reference,
-                len(prices_tomorrow.electricity.all)
-                if prices_tomorrow and prices_tomorrow.electricity
-                else 0,
+                (
+                    len(prices_tomorrow.electricity.all)
+                    if prices_tomorrow and prices_tomorrow.electricity
+                    else 0
+                ),
             )
             _LOGGER.debug(
                 "Listeners: %s",
@@ -614,9 +620,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             _LOGGER.debug(
                 "Coordinator electricity periods: %s",
-                len(self.data[DATA_ELECTRICITY].all)
-                if self.data[DATA_ELECTRICITY]
-                else 0,
+                (
+                    len(self.data[DATA_ELECTRICITY].all)
+                    if self.data[DATA_ELECTRICITY]
+                    else 0
+                ),
             )
 
         return self.cached_prices_tomorrow
@@ -886,7 +894,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
         try:
             user_data = await self.api.user(self.site_reference)
-            if not self._country_code:
+            if user_data is not None:
+                try:
+                    smart_hvac = await self.api.smart_hvac_status()
+                    if smart_hvac:
+                        user_data.smartHvac = smart_hvac
+                except (RequestException, FrankEnergieException, ClientError) as ex:
+                    _LOGGER.debug(
+                        "Smart HVAC feature is not supported or accessible on this account: %s",
+                        ex,
+                    )
+            if not self._country_code and user_data:
                 country_code_raw = user_data.countryCode
                 if isinstance(country_code_raw, str) and country_code_raw:
                     country_code = country_code_raw.upper()

--- a/custom_components/frank_energie/manifest.json
+++ b/custom_components/frank_energie/manifest.json
@@ -15,7 +15,7 @@
     ],
     "quality_scale": "silver",
     "requirements": [
-        "python-frank-energie==2026.6.19"
+        "python-frank-energie==2026.6.21"
     ],
-    "version": "2026.6.19"
+    "version": "2026.6.21"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "home-assistant-frank_energie"
-version = "2026.6.19"
+version = "2026.6.21"
 description = "A custom Home Assistant integration for Frank Energie."
 authors = ["HiDiHo <hidiho@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.13"
-python-frank-energie = "^2026.6.19"
+python-frank-energie = "^2026.6.21"
 
 [tool.poetry.dev-dependencies]
 pytest = "^9.0"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -109,26 +109,55 @@ def test_smart_hvac_binary_sensor(mock_coordinator, mock_config_entry):
     # Test when data is missing
     mock_coordinator.data = {}
     assert sensor.is_on is None
+    assert sensor.available is False
 
     # Test when active (dict payload inside mock object)
     mock_user = MagicMock()
     mock_user.smartHvac = {"isActivated": True}
     mock_coordinator.data = {DATA_USER: mock_user}
     assert sensor.is_on is True
+    assert sensor.available is True
 
     # Test when inactive (dict payload inside mock object)
     mock_user.smartHvac = {"isActivated": False}
     mock_coordinator.data = {DATA_USER: mock_user}
     assert sensor.is_on is False
+    assert sensor.available is True
 
     # Test with object attributes
     mock_user.smartHvac = MagicMock()
     mock_user.smartHvac.isActivated = True
     assert sensor.is_on is True
+    assert sensor.available is True
 
     # Test when smartHvac is None
     mock_user.smartHvac = None
     assert sensor.is_on is None
+    assert sensor.available is False
+
+    # Test attributes (dict payload)
+    mock_user.smartHvac = {
+        "isActivated": True,
+        "isAvailableInCountry": True,
+        "userCreatedAt": "2026-06-20T17:00:00Z",
+        "userId": "test-user-id",
+    }
+    mock_coordinator.data = {DATA_USER: mock_user}
+    attrs = sensor.extra_state_attributes
+    assert attrs["available_in_country"] is True
+    assert attrs["user_created_at"] == "2026-06-20T17:00:00Z"
+    assert attrs["user_id"] == "test-user-id"
+
+    # Test attributes (object payload)
+    mock_user.smartHvac = MagicMock()
+    mock_user.smartHvac.isAvailableInCountry = True
+    mock_user.smartHvac.userCreatedAt = "2026-06-20T17:00:00Z"
+    mock_user.smartHvac.userId = "test-user-id"
+    mock_coordinator.data = {DATA_USER: mock_user}
+    attrs = sensor.extra_state_attributes
+    assert attrs["available_in_country"] is True
+    assert attrs["user_created_at"] == "2026-06-20T17:00:00Z"
+    assert attrs["user_id"] == "test-user-id"
 
 
 def test_battery_self_consumption_trading_binary_sensor(


### PR DESCRIPTION
#### Summary
Integrates `smartHvac` binary sensor support using the updated client library.

#### Dependencies
-  [x] Requires [python-frank-energie PR #107](https://github.com/HiDiHo01/python-frank-energie/pull/107) (releasing `python-frank-energie==2026.6.21`) to be merged and published first.
- [x] Depends on #172

#### Key Changes
- Updated the dependency requirement to `python-frank-energie==2026.6.21`.
- Updated the coordinator to fetch `smartHvac` separately and gracefully handle client/network/validation errors without failing the overall refresh.
- Wired the `available_fn` for the `smart_hvac` binary sensor to reflect entity availability, avoiding an `unknown` state on unsupported accounts.
- Bound the `attr_fn` on `smart_hvac` to expose user attributes (`available_in_country`, `user_created_at`, and `user_id`).
- Added binary sensor tests.
- Bumped component version to `2026.6.21`.

#### Why this is needed
To support the Smart HVAC binary sensor cleanly without causing integration setup failure for users whose accounts lack the feature, and to ensure Home Assistant handles the missing feature by setting the state to `Unavailable` rather than `unknown`.
Closes #176

## Summary by Sourcery

Integreer ondersteuning voor slimme HVAC in de gebruikersdataflow en de binaire sensor, terwijl niet-ondersteunde accounts netjes als niet-beschikbaar worden behandeld.

Nieuwe functionaliteit:
- Stel de slimme HVAC-gebruikersfunctie bloot als een Home Assistant-binaire sensor met correcte beschikbaarheid en attributen voor gebruikersmetadata.

Verbeteringen:
- Haal de status van de slimme HVAC afzonderlijk op tijdens het vernieuwen van gebruikersdata en negeer client-/netwerkfouten zodat deze de algemene updates niet verstoren.
- Verbeter de beschikbaarheidshandling van de slimme HVAC-binaire sensor om onbekende statussen te vermijden wanneer de functie ontbreekt of niet wordt ondersteund.
- Breid de attributen van de slimme HVAC-binaire sensor uit om gebruikersidentificatie-metadata op te nemen.
- Maak de loggingexpressies van de coördinator voor elektriciteitsperiodes netter.

Build:
- Verhoog de integratie- en afhankelijkheidsversies naar 2026.6.21 en vereis de bijgewerkte `python-frank-energie`-client.

Tests:
- Breid de tests voor binaire sensoren uit om de beschikbaarheid en attribuuthandling van slimme HVAC af te dekken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate smart HVAC support into the user data flow and binary sensor while keeping unsupported accounts gracefully unavailable.

New Features:
- Expose smart HVAC user feature as a Home Assistant binary sensor with proper availability and attributes for user metadata.

Enhancements:
- Fetch smart HVAC status separately during user data refresh and ignore client/network errors so they do not break overall updates.
- Improve smart HVAC binary sensor availability handling to avoid unknown states when the feature is missing or unsupported.
- Extend smart HVAC binary sensor attributes to include user identifier metadata.
- Tidy coordinator logging expressions for electricity periods.

Build:
- Bump integration and dependency versions to 2026.6.21 and require the updated python-frank-energie client.

Tests:
- Expand binary sensor tests to cover smart HVAC availability and attribute handling.

</details>