### PR TITLE
fix(sensor): register battery session sensors unconditionally

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     SERVICE_NAME_BATTERIES,
     SERVICE_NAME_BATTERY_SESSIONS,
     SERVICE_NAME_ENODE_CHARGERS,
+    TIMEZONE_AMSTERDAM,
 )
 from .coordinator import (
     FrankEnergieCoordinator,
@@ -151,15 +152,15 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         async def _async_aligned_refresh(
             _: datetime,
         ) -> None:
-            # Check for midnight local Europe/Amsterdam rollover
-            now_local = dt_util.now(ZoneInfo("Europe/Amsterdam"))
+            # Check for midnight local TIMEZONE_AMSTERDAM rollover
+            now_local = dt_util.now(ZoneInfo(TIMEZONE_AMSTERDAM))
             if now_local.hour == 0 and now_local.minute == 0:
                 _LOGGER.info(
                     "Midnight local time: promoting tomorrow's prices to today"
                 )
                 price_coordinator.promote_tomorrow_prices()
 
-            # Check for 13:00 local Europe/Amsterdam transition to fetch tomorrow's prices
+            # Check for 13:00 local TIMEZONE_AMSTERDAM transition to fetch tomorrow's prices
             if now_local.hour == 13 and now_local.minute == 0:
                 _LOGGER.info("13:00 local time: explicitly triggering price fetch")
                 await price_coordinator.async_request_refresh()

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -61,6 +61,7 @@ from python_frank_energie.models import (
 )
 
 from .const import (
+    TIMEZONE_AMSTERDAM,
     DATA_BATTERIES,
     DATA_BATTERY_DETAILS,
     DATA_BATTERY_SESSIONS,
@@ -378,7 +379,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         )
 
         now_utc = datetime.now(ZoneInfo("UTC"))
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         tomorrow = today + timedelta(days=1)
 
         # skip API calls between 00:00 and 01:00 UTC to avoid maintenance window
@@ -548,7 +549,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         now_utc: datetime,
     ) -> MarketPrices | None:
         """Fetch and cache tomorrow's prices if the release window has passed."""
-        tz_amsterdam = ZoneInfo("Europe/Amsterdam")
+        tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
         now_local = now_utc.astimezone(tz_amsterdam)
 
         if now_local.hour < 13:
@@ -1929,7 +1930,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # event-driven (e.g. HA restart, button press) outside 13:00–15:00 Europe/Amsterdam local time.
         default_interval = None
 
-        tz_amsterdam = ZoneInfo("Europe/Amsterdam")
+        tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
         now_local = now_utc.astimezone(tz_amsterdam)
         local_time = now_local.time()
 
@@ -2346,7 +2347,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
 
     def _adjust_update_interval(self, now_utc: datetime) -> None:
         """Adjust coordinator update interval based on publication window and cache status."""
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         if (
             self.cached_prices_tomorrow is not None
             and self.last_fetch_tomorrow is not None
@@ -2354,7 +2355,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         ):
             new_interval = None
         else:
-            tz_amsterdam = ZoneInfo("Europe/Amsterdam")
+            tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
             now_local = now_utc.astimezone(tz_amsterdam)
             local_time = now_local.time()
             if local_time < time(13, 0):
@@ -2375,7 +2376,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
     async def _async_update_data(self) -> FrankEnergieData:
         """Fetch price data."""
         now_utc = datetime.now(ZoneInfo("UTC"))
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         tomorrow = today + timedelta(days=1)
 
         skip_api_calls = self._should_skip_api_calls(now_utc)
@@ -2511,7 +2512,7 @@ class FrankEnergieBatteryCoordinator(FrankEnergieCoordinator):
                 return self.data
             raise UpdateFailed("Maintenance window active")
 
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         tomorrow = today + timedelta(days=1)
         start_date = today - timedelta(days=1)
 
@@ -2573,7 +2574,7 @@ class FrankEnergieChargerCoordinator(FrankEnergieCoordinator):
             raise UpdateFailed("Maintenance window active")
 
         start_date = now_utc.astimezone(
-            ZoneInfo("Europe/Amsterdam")
+            ZoneInfo(TIMEZONE_AMSTERDAM)
         ).date() - timedelta(days=1)
 
         user_data = self.settings_coordinator.data.get(DATA_USER)
@@ -2633,7 +2634,7 @@ class FrankEnergiePVCoordinator(FrankEnergieCoordinator):
                 return self.data
             raise UpdateFailed("Maintenance window active")
 
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         if self.last_fetch_today is None or self.last_fetch_today.date() != today:
             self._has_pv_systems = None
         self.last_fetch_today = now_utc
@@ -2762,7 +2763,7 @@ class FrankEnergieStatisticsCoordinator(FrankEnergieCoordinator):
                 return self.data
             raise UpdateFailed("Maintenance window active")
 
-        today = now_utc.astimezone(ZoneInfo("Europe/Amsterdam")).date()
+        today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
         yesterday = today - timedelta(days=1)
         start_date = yesterday
 
@@ -2835,7 +2836,7 @@ class FrankEnergieBatterySessionCoordinator(
             UpdateFailed: If an error occurs during data fetching.
         """
         try:
-            today = datetime.now(ZoneInfo("Europe/Amsterdam")).date()
+            today = datetime.now(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
             tomorrow = today + timedelta(days=1)
 
             if not self.api.is_authenticated:

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2835,7 +2835,7 @@ class FrankEnergieBatterySessionCoordinator(
             UpdateFailed: If an error occurs during data fetching.
         """
         try:
-            today = date.today()
+            today = datetime.now(ZoneInfo("Europe/Amsterdam")).date()
             tomorrow = today + timedelta(days=1)
 
             if not self.api.is_authenticated:

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -5216,31 +5216,23 @@ async def async_setup_entry(
 
             # Create sensors for each battery session coordinator
             for battery_id, session_coordinator in session_coordinators.items():
-                sessions_data = session_coordinator.data
-                if sessions_data and sessions_data.sessions:
-                    _LOGGER.debug(
-                        "Creating battery session sensors for battery: %s",
-                        battery_id,
-                    )
-                    for description in BATTERY_SESSION_SENSOR_DESCRIPTIONS:
-                        if (
-                            not description.authenticated
-                            or settings_coordinator.api.is_authenticated
-                        ):
-                            entities.append(
-                                FrankEnergieBatterySessionSensor(
-                                    coordinator=session_coordinator,
-                                    description=description,
-                                    battery_id=battery_id,
-                                    is_total=False,
-                                )
+                _LOGGER.debug(
+                    "Creating battery session sensors for battery: %s",
+                    battery_id,
+                )
+                for description in BATTERY_SESSION_SENSOR_DESCRIPTIONS:
+                    if (
+                        not description.authenticated
+                        or settings_coordinator.api.is_authenticated
+                    ):
+                        entities.append(
+                            FrankEnergieBatterySessionSensor(
+                                coordinator=session_coordinator,
+                                description=description,
+                                battery_id=battery_id,
+                                is_total=False,
                             )
-                else:
-                    _LOGGER.debug(
-                        "No session data found in session coordinator for battery %s (entry %s)",
-                        battery_id,
-                        config_entry.entry_id,
-                    )
+                        )
 
     enode_vehicles = vehicle_coordinator.data.get(DATA_ENODE_VEHICLES)
     num_vehicles = len(enode_vehicles.vehicles) if enode_vehicles else 0

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -5216,10 +5216,18 @@ async def async_setup_entry(
 
             # Create sensors for each battery session coordinator
             for battery_id, session_coordinator in session_coordinators.items():
-                _LOGGER.debug(
-                    "Creating battery session sensors for battery: %s",
-                    battery_id,
-                )
+                sessions_data = session_coordinator.data
+                if not sessions_data or not getattr(sessions_data, "sessions", None):
+                    _LOGGER.debug(
+                        "No session data found in session coordinator for battery %s (entry %s). Sensors will still be created but report unknown state.",
+                        battery_id,
+                        config_entry.entry_id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Creating battery session sensors for battery: %s",
+                        battery_id,
+                    )
                 for description in BATTERY_SESSION_SENSOR_DESCRIPTIONS:
                     if (
                         not description.authenticated


### PR DESCRIPTION
## Summary
This PR addresses a critical lifecycle bug where battery session sensors (`period_start_date`, `period_total_result`, etc.) would sporadically disappear from the Home Assistant entity registry, displaying as "Unavailable" and "no longer being provided by the frank_energie integration." It also resolves an underlying timezone edge-case where the session API was queried using UTC days instead of local Dutch time.

## Why this is needed
- **Home Assistant Entity Lifecycle:** Home Assistant requires that all entities tied to a device be registered unconditionally during the integration's `async_setup_entry` phase. Previously, the setup logic would conditionally skip sensor creation if the battery had zero active trading sessions at the exact moment of a restart. This caused Home Assistant to assume the entities were permanently removed.
- **Timezone Boundary Consistency:** The `FrankEnergieBatterySessionCoordinator` calculated `today` using `date.today()` (which defaults to UTC/system time). Because Frank Energie's day boundary is midnight CET/CEST (`Europe/Amsterdam`), this mismatch caused the integration to fetch the *previous* day's sessions between 00:00 local time and 00:00 UTC (or 02:00 local time in summer). Consequently, any restarts immediately after midnight resulted in empty session data and triggered the missing-sensor bug.

## Key Changes
- **Unconditional Registration:** Removed the `if sessions_data and sessions_data.sessions:` guard in `sensor.py`. Sensors are now always instantiated during setup and will safely report their state as `unknown` when no sessions are active, preserving historical data and preventing dashboard/automation breakage.
- **Timezone Alignment:** Updated `FrankEnergieBatterySessionCoordinator` to calculate `today` using `ZoneInfo("Europe/Amsterdam")`, ensuring session boundaries align perfectly with the upstream API.

## Samenvatting door Sourcery

Registreer batterijsessiesensoren onvoorwaardelijk tijdens de setup en stem de datum­berekening voor batterijsessies af op de lokale tijdzone van de provider.

Bugfixes:
- Zorg ervoor dat batterijsessiesensoren geregistreerd en beschikbaar blijven, zelfs wanneer er bij het opstarten geen actieve sessies aanwezig zijn.
- Los problemen met het ophalen van batterijsessies rond middernacht op door lokale tijd `Europe/Amsterdam` te gebruiken voor de datum­berekening van sessies.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Zorg ervoor dat batterij-sessiesensoren altijd geregistreerd zijn en stem de datumcalculaties voor batterij-sessies af op de lokale tijdzone van de provider.

Bugfixes:
- Voorkom dat batterij-sessiesensoren verdwijnen wanneer er geen actieve sessies zijn tijdens het opstarten van Home Assistant door ze onvoorwaardelijk te registreren.
- Los problemen met het ophalen van batterij-sessies rond middernacht op door de sessiedatum te berekenen in de tijdzone Europe/Amsterdam in plaats van de systeem-/UTC-datum te gebruiken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure battery session sensors are always registered and align battery session date calculations with the provider’s local timezone.

Bug Fixes:
- Prevent battery session sensors from disappearing when no active sessions are present during Home Assistant startup by registering them unconditionally.
- Fix battery session retrieval around midnight by computing the session date in the Europe/Amsterdam timezone instead of using system/UTC date.

</details>

</details>