### PR TITLE
feat: implement reboot-survival disk caching for prices

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -132,12 +132,12 @@ def _price_to_dict(price: Price) -> dict[str, Any]:
 def _market_prices_to_dict(market_prices: MarketPrices) -> dict[str, Any]:
     """Convert MarketPrices to serializable dict."""
     return {
-        "electricity": [
-            _price_to_dict(p) for p in market_prices.electricity.all
-        ] if market_prices.electricity else [],
-        "gas": [
-            _price_to_dict(p) for p in market_prices.gas.all
-        ] if market_prices.gas else [],
+        "electricity": [_price_to_dict(p) for p in market_prices.electricity.all]
+        if market_prices.electricity
+        else [],
+        "gas": [_price_to_dict(p) for p in market_prices.gas.all]
+        if market_prices.gas
+        else [],
         "energy_country": market_prices.energy_country,
         "energy_type": market_prices.energy_type,
     }
@@ -2433,16 +2433,26 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             if cached_data:
                 _LOGGER.debug("Loading cached prices from disk")
                 if prices_today_dict := cached_data.get("prices_today"):
-                    self._static_prices_today = _dict_to_market_prices(prices_today_dict)
+                    self._static_prices_today = _dict_to_market_prices(
+                        prices_today_dict
+                    )
                 if prices_tomorrow_dict := cached_data.get("prices_tomorrow"):
-                    self.cached_prices_tomorrow = _dict_to_market_prices(prices_tomorrow_dict)
-                if resolution_state_dict := cached_data.get("contract_price_resolution_state"):
-                    self._static_contract_price_resolution_state = _dict_to_resolution_state(resolution_state_dict)
+                    self.cached_prices_tomorrow = _dict_to_market_prices(
+                        prices_tomorrow_dict
+                    )
+                if resolution_state_dict := cached_data.get(
+                    "contract_price_resolution_state"
+                ):
+                    self._static_contract_price_resolution_state = (
+                        _dict_to_resolution_state(resolution_state_dict)
+                    )
 
                 if last_fetch_today_str := cached_data.get("last_fetch_today"):
                     self.last_fetch_today = datetime.fromisoformat(last_fetch_today_str)
                 if last_fetch_tomorrow_str := cached_data.get("last_fetch_tomorrow"):
-                    self.last_fetch_tomorrow = datetime.fromisoformat(last_fetch_tomorrow_str)
+                    self.last_fetch_tomorrow = datetime.fromisoformat(
+                        last_fetch_tomorrow_str
+                    )
         except Exception as err:
             _LOGGER.warning("Failed to load cached prices from disk: %s", err)
 
@@ -2590,13 +2600,27 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
 
         if not skip_api_calls:
             try:
-                await self.store.async_save({
-                    "prices_today": _market_prices_to_dict(prices_today) if prices_today else None,
-                    "prices_tomorrow": _market_prices_to_dict(prices_tomorrow) if prices_tomorrow else None,
-                    "contract_price_resolution_state": _resolution_state_to_dict(data_contract_price_resolution_state) if data_contract_price_resolution_state else None,
-                    "last_fetch_today": self.last_fetch_today.isoformat() if self.last_fetch_today else None,
-                    "last_fetch_tomorrow": self.last_fetch_tomorrow.isoformat() if self.last_fetch_tomorrow else None,
-                })
+                await self.store.async_save(
+                    {
+                        "prices_today": _market_prices_to_dict(prices_today)
+                        if prices_today
+                        else None,
+                        "prices_tomorrow": _market_prices_to_dict(prices_tomorrow)
+                        if prices_tomorrow
+                        else None,
+                        "contract_price_resolution_state": _resolution_state_to_dict(
+                            data_contract_price_resolution_state
+                        )
+                        if data_contract_price_resolution_state
+                        else None,
+                        "last_fetch_today": self.last_fetch_today.isoformat()
+                        if self.last_fetch_today
+                        else None,
+                        "last_fetch_tomorrow": self.last_fetch_tomorrow.isoformat()
+                        if self.last_fetch_tomorrow
+                        else None,
+                    }
+                )
             except Exception as err:
                 _LOGGER.warning("Failed to save prices to disk cache: %s", err)
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
+from homeassistant.util import dt as dt_util
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import (
     AuthException,
@@ -187,7 +188,12 @@ def _resolution_state_to_dict(state: ContractPriceResolutionState) -> dict[str, 
 
 def _dict_to_resolution_state(data: dict[str, Any]) -> ContractPriceResolutionState:
     """Reconstruct ContractPriceResolutionState from dict."""
-    return ContractPriceResolutionState.from_dict(data)
+    state = ContractPriceResolutionState.from_dict(data)
+    if isinstance(state.upcoming_change, str):
+        parsed = dt_util.parse_datetime(state.upcoming_change)
+        if parsed:
+            state.upcoming_change = parsed
+    return state
 
 
 if sys.platform == "win32" and hasattr(asyncio, "set_event_loop_policy"):
@@ -2448,9 +2454,9 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     )
 
                 if last_fetch_today_str := cached_data.get("last_fetch_today"):
-                    self.last_fetch_today = datetime.fromisoformat(last_fetch_today_str)
+                    self.last_fetch_today = dt_util.parse_datetime(last_fetch_today_str)
                 if last_fetch_tomorrow_str := cached_data.get("last_fetch_tomorrow"):
-                    self.last_fetch_tomorrow = datetime.fromisoformat(
+                    self.last_fetch_tomorrow = dt_util.parse_datetime(
                         last_fetch_tomorrow_str
                     )
         except Exception as err:

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2460,7 +2460,9 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                         last_fetch_tomorrow_str
                     )
         except Exception as err:
-            _LOGGER.warning("Failed to load cached prices from disk: %s", err)
+            _LOGGER.warning(
+                "Failed to load cached prices from disk: %s", err, exc_info=True
+            )
 
         await super().async_config_entry_first_refresh()
 
@@ -2628,7 +2630,9 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     }
                 )
             except Exception as err:
-                _LOGGER.warning("Failed to save prices to disk cache: %s", err)
+                _LOGGER.warning(
+                    "Failed to save prices to disk cache: %s", err, exc_info=True
+                )
 
         return result
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -61,6 +62,7 @@ from python_frank_energie.models import (
 )
 
 from .const import (
+    DOMAIN,
     TIMEZONE_AMSTERDAM,
     DATA_BATTERIES,
     DATA_BATTERY_DETAILS,
@@ -112,6 +114,80 @@ def _get_refresh_token_expires_at(api: Any) -> datetime | None:
     ):
         return api._auth.refresh_token_expires_at
     return None
+
+
+def _price_to_dict(price: Price) -> dict[str, Any]:
+    """Convert Price to dict."""
+    return {
+        "from": price.date_from.isoformat() if price.date_from else None,
+        "till": price.date_till.isoformat() if price.date_till else None,
+        "marketPrice": price.market_price,
+        "marketPriceTax": price.market_price_tax,
+        "sourcingMarkupPrice": price.sourcing_markup_price,
+        "energyTaxPrice": price.energy_tax_price,
+        "perUnit": price.per_unit,
+    }
+
+
+def _market_prices_to_dict(market_prices: MarketPrices) -> dict[str, Any]:
+    """Convert MarketPrices to serializable dict."""
+    return {
+        "electricity": [
+            _price_to_dict(p) for p in market_prices.electricity.all
+        ] if market_prices.electricity else [],
+        "gas": [
+            _price_to_dict(p) for p in market_prices.gas.all
+        ] if market_prices.gas else [],
+        "energy_country": market_prices.energy_country,
+        "energy_type": market_prices.energy_type,
+    }
+
+
+def _dict_to_market_prices(data: dict[str, Any]) -> MarketPrices:
+    """Reconstruct MarketPrices from serialized dict."""
+    elec_prices = data.get("electricity", [])
+    gas_prices = data.get("gas", [])
+    country = data.get("energy_country", "NL")
+    energy_type = data.get("energy_type")
+
+    electricity = PriceData(prices=elec_prices, energy_type="electricity")
+    gas = PriceData(prices=gas_prices, energy_type="gas")
+
+    return MarketPrices(
+        electricity=electricity,
+        gas=gas,
+        energy_country=country,
+        energy_type=energy_type,
+    )
+
+
+def _resolution_state_to_dict(state: ContractPriceResolutionState) -> dict[str, Any]:
+    """Convert ContractPriceResolutionState to serializable dict."""
+    return {
+        "activeOption": state.active_option,
+        "availableOptions": state.available_options,
+        "changeRequestEffectiveDate": (
+            state.change_request_effective_date.isoformat()
+            if isinstance(state.change_request_effective_date, (date, datetime))
+            else state.change_request_effective_date
+        ),
+        "isChangeRequestPossible": state.is_change_request_possible,
+        "upcomingChange": (
+            state.upcoming_change.isoformat()
+            if isinstance(state.upcoming_change, (date, datetime))
+            else state.upcoming_change
+        ),
+        "upcomingChangeEffectiveDate": (
+            state.upcoming_change_effective_date.isoformat()
+            if isinstance(state.upcoming_change_effective_date, (date, datetime))
+            else state.upcoming_change_effective_date
+        ),
+    }
+
+
+def _dict_to_resolution_state(data: dict[str, Any]) -> ContractPriceResolutionState:
+    """Reconstruct ContractPriceResolutionState from dict."""
+    return ContractPriceResolutionState.from_dict(data)
 
 
 if sys.platform == "win32" and hasattr(asyncio, "set_event_loop_policy"):
@@ -2344,6 +2420,33 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         self.name = "Frank Energie price coordinator"
         self.settings_coordinator = settings_coordinator
         self.update_interval = None
+        self.store = Store(
+            hass,
+            1,
+            f"{DOMAIN}_prices_{config_entry.entry_id}",
+        )
+
+    async def async_config_entry_first_refresh(self) -> None:
+        """Load cached prices and then perform first refresh."""
+        try:
+            cached_data = await self.store.async_load()
+            if cached_data:
+                _LOGGER.debug("Loading cached prices from disk")
+                if prices_today_dict := cached_data.get("prices_today"):
+                    self._static_prices_today = _dict_to_market_prices(prices_today_dict)
+                if prices_tomorrow_dict := cached_data.get("prices_tomorrow"):
+                    self.cached_prices_tomorrow = _dict_to_market_prices(prices_tomorrow_dict)
+                if resolution_state_dict := cached_data.get("contract_price_resolution_state"):
+                    self._static_contract_price_resolution_state = _dict_to_resolution_state(resolution_state_dict)
+
+                if last_fetch_today_str := cached_data.get("last_fetch_today"):
+                    self.last_fetch_today = datetime.fromisoformat(last_fetch_today_str)
+                if last_fetch_tomorrow_str := cached_data.get("last_fetch_tomorrow"):
+                    self.last_fetch_tomorrow = datetime.fromisoformat(last_fetch_tomorrow_str)
+        except Exception as err:
+            _LOGGER.warning("Failed to load cached prices from disk: %s", err)
+
+        await super().async_config_entry_first_refresh()
 
     def _adjust_update_interval(self, now_utc: datetime) -> None:
         """Adjust coordinator update interval based on publication window and cache status."""
@@ -2484,6 +2587,18 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         self._maybe_fire_lowest_price_event(prices_today, today, now_utc)
         self._maybe_fire_lowest_4p_event(prices_today, today, now_utc)
         self._maybe_fire_lowest_16p_event(prices_today, today, now_utc)
+
+        if not skip_api_calls:
+            try:
+                await self.store.async_save({
+                    "prices_today": _market_prices_to_dict(prices_today) if prices_today else None,
+                    "prices_tomorrow": _market_prices_to_dict(prices_tomorrow) if prices_tomorrow else None,
+                    "contract_price_resolution_state": _resolution_state_to_dict(data_contract_price_resolution_state) if data_contract_price_resolution_state else None,
+                    "last_fetch_today": self.last_fetch_today.isoformat() if self.last_fetch_today else None,
+                    "last_fetch_tomorrow": self.last_fetch_tomorrow.isoformat() if self.last_fetch_tomorrow else None,
+                })
+            except Exception as err:
+                _LOGGER.warning("Failed to save prices to disk cache: %s", err)
 
         return result
 

--- a/custom_components/frank_energie/number.py
+++ b/custom_components/frank_energie/number.py
@@ -163,27 +163,25 @@ NETWORK_CHARGES = FrankEnergieNumberEntityDescription(
         )
     ),
 )
-EXPORT_ELECTRICITY_FEE = (
-    FrankEnergieNumberEntityDescription(
-        key="export_electricity_fee",
-        translation_key="export_electricity_fee",
-        option_key=CONF_EXPORT_ELECTRICITY_FEE,
-        service_name=SERVICE_NAME_COSTS,
-        native_min_value=0.00,
-        native_max_value=50.00,
-        native_step=0.000001,
-        native_unit_of_measurement=UNIT_ELECTRICITY,
-        suggested_display_precision=6,
-        icon="mdi:cash",
-        mode=NumberMode.BOX,
-        entity_category=EntityCategory.CONFIG,
-        value_fn=lambda entry: float(
-            entry.options.get(
-                CONF_EXPORT_ELECTRICITY_FEE,
-                DEFAULT_EXPORT_ELECTRICITY_FEE,
-            )
-        ),
-    )
+EXPORT_ELECTRICITY_FEE = FrankEnergieNumberEntityDescription(
+    key="export_electricity_fee",
+    translation_key="export_electricity_fee",
+    option_key=CONF_EXPORT_ELECTRICITY_FEE,
+    service_name=SERVICE_NAME_COSTS,
+    native_min_value=0.00,
+    native_max_value=50.00,
+    native_step=0.000001,
+    native_unit_of_measurement=UNIT_ELECTRICITY,
+    suggested_display_precision=6,
+    icon="mdi:cash",
+    mode=NumberMode.BOX,
+    entity_category=EntityCategory.CONFIG,
+    value_fn=lambda entry: float(
+        entry.options.get(
+            CONF_EXPORT_ELECTRICITY_FEE,
+            DEFAULT_EXPORT_ELECTRICITY_FEE,
+        )
+    ),
 )
 
 CONFIG_NUMBER_DESCRIPTIONS: Final = (

--- a/custom_components/frank_energie/number.py
+++ b/custom_components/frank_energie/number.py
@@ -146,7 +146,6 @@ ENERGY_TAX_REDUCTION = FrankEnergieNumberEntityDescription(
 NETWORK_CHARGES = FrankEnergieNumberEntityDescription(
     key="network_charges",
     translation_key="network_charges",
-    option_key=CONF_EXPORT_ELECTRICITY_FEE,
     option_key=CONF_NETWORK_CHARGES,
     service_name=SERVICE_NAME_COSTS,
     native_min_value=0.00,

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -1,0 +1,131 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from datetime import datetime, date
+from homeassistant.core import HomeAssistant
+from python_frank_energie.models import MarketPrices, PriceData, Price, ContractPriceResolutionState
+from custom_components.frank_energie.coordinator import (
+    FrankEnergiePriceCoordinator,
+    FrankEnergieSettingsCoordinator,
+    _price_to_dict,
+    _market_prices_to_dict,
+    _dict_to_market_prices,
+    _resolution_state_to_dict,
+    _dict_to_resolution_state,
+)
+
+@pytest.fixture
+def mock_store():
+    """Mock the Store helper."""
+    with patch("custom_components.frank_energie.coordinator.Store") as mock_store_class:
+        store_instance = mock_store_class.return_value
+        store_instance.async_load = AsyncMock(return_value=None)
+        store_instance.async_save = AsyncMock()
+        yield store_instance
+
+@pytest.mark.asyncio
+async def test_price_serialization():
+    """Test Price serialization and deserialization helpers."""
+    # Create mock Price data
+    raw_price = {
+        "from": "2026-06-26T07:30:00+00:00",
+        "till": "2026-06-26T07:45:00+00:00",
+        "marketPrice": 0.15,
+        "marketPriceTax": 0.03,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.12,
+        "perUnit": "kwh",
+    }
+    
+    price = Price(raw_price, energy_type="electricity")
+    serialized = _price_to_dict(price)
+    
+    assert serialized["from"] == "2026-06-26T07:30:00+00:00"
+    assert serialized["marketPrice"] == 0.15
+    assert serialized["energyTaxPrice"] == 0.12
+
+    # Test MarketPrices serialization and deserialization
+    electricity = PriceData([raw_price], energy_type="electricity")
+    gas = PriceData([], energy_type="gas")
+    market_prices = MarketPrices(electricity=electricity, gas=gas, energy_country="NL")
+    
+    serialized_mp = _market_prices_to_dict(market_prices)
+    deserialized_mp = _dict_to_market_prices(serialized_mp)
+    
+    assert len(deserialized_mp.electricity.all) == 1
+    assert deserialized_mp.electricity.all[0].market_price == 0.15
+    assert deserialized_mp.energy_country == "NL"
+
+@pytest.mark.asyncio
+async def test_resolution_state_serialization():
+    """Test ContractPriceResolutionState serialization and deserialization."""
+    raw_state = {
+        "activeOption": "PT15M",
+        "availableOptions": ["PT15M", "PT1H"],
+        "changeRequestEffectiveDate": "2026-07-01",
+        "isChangeRequestPossible": True,
+        "upcomingChange": None,
+        "upcomingChangeEffectiveDate": None,
+    }
+    state = ContractPriceResolutionState.from_dict(raw_state)
+    serialized = _resolution_state_to_dict(state)
+    deserialized = _dict_to_resolution_state(serialized)
+    
+    assert deserialized.active_option == "PT15M"
+    assert deserialized.is_change_request_possible is True
+    assert deserialized.change_request_effective_date == date(2026, 7, 1)
+
+@pytest.mark.asyncio
+async def test_coordinator_load_cache(mock_store, mock_config_entry):
+    """Test that coordinator loads cached data from Store on startup."""
+    mock_config_entry.data = {}
+    mock_config_entry.options = {}
+    
+    raw_price = {
+        "from": "2026-06-26T07:30:00+00:00",
+        "till": "2026-06-26T07:45:00+00:00",
+        "marketPrice": 0.15,
+        "marketPriceTax": 0.03,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.12,
+        "perUnit": "kwh",
+    }
+    
+    cached_data = {
+        "prices_today": {
+            "electricity": [raw_price],
+            "gas": [],
+            "energy_country": "NL",
+            "energy_type": "electricity",
+        },
+        "prices_tomorrow": None,
+        "contract_price_resolution_state": {
+            "activeOption": "PT15M",
+            "availableOptions": ["PT15M"],
+            "changeRequestEffectiveDate": None,
+            "isChangeRequestPossible": False,
+            "upcomingChange": None,
+            "upcomingChangeEffectiveDate": None,
+        },
+        "last_fetch_today": "2026-06-26T07:30:00+00:00",
+        "last_fetch_tomorrow": None,
+    }
+    
+    mock_store.async_load = AsyncMock(return_value=cached_data)
+    
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config = MagicMock()
+    hass.config.country = "NL"
+    
+    mock_api = MagicMock()
+    settings_coordinator = FrankEnergieSettingsCoordinator(hass, mock_config_entry, mock_api)
+    
+    price_coordinator = FrankEnergiePriceCoordinator(hass, mock_config_entry, mock_api, settings_coordinator)
+    
+    # We patch super().async_config_entry_first_refresh to avoid actual update call
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_config_entry_first_refresh", AsyncMock()):
+        await price_coordinator.async_config_entry_first_refresh()
+        
+    assert price_coordinator._static_prices_today is not None
+    assert price_coordinator._static_prices_today.electricity.all[0].market_price == 0.15
+    assert price_coordinator._static_contract_price_resolution_state.active_option == "PT15M"
+    assert price_coordinator.last_fetch_today == datetime.fromisoformat("2026-06-26T07:30:00+00:00")

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -2,7 +2,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from datetime import datetime, date
 from homeassistant.core import HomeAssistant
-from python_frank_energie.models import MarketPrices, PriceData, Price, ContractPriceResolutionState
+from python_frank_energie.models import (
+    MarketPrices,
+    PriceData,
+    Price,
+    ContractPriceResolutionState,
+)
 from custom_components.frank_energie.coordinator import (
     FrankEnergiePriceCoordinator,
     FrankEnergieSettingsCoordinator,
@@ -13,6 +18,7 @@ from custom_components.frank_energie.coordinator import (
     _dict_to_resolution_state,
 )
 
+
 @pytest.fixture
 def mock_store():
     """Mock the Store helper."""
@@ -21,6 +27,7 @@ def mock_store():
         store_instance.async_load = AsyncMock(return_value=None)
         store_instance.async_save = AsyncMock()
         yield store_instance
+
 
 @pytest.mark.asyncio
 async def test_price_serialization():
@@ -35,10 +42,10 @@ async def test_price_serialization():
         "energyTaxPrice": 0.12,
         "perUnit": "kwh",
     }
-    
+
     price = Price(raw_price, energy_type="electricity")
     serialized = _price_to_dict(price)
-    
+
     assert serialized["from"] == "2026-06-26T07:30:00+00:00"
     assert serialized["marketPrice"] == 0.15
     assert serialized["energyTaxPrice"] == 0.12
@@ -47,13 +54,14 @@ async def test_price_serialization():
     electricity = PriceData([raw_price], energy_type="electricity")
     gas = PriceData([], energy_type="gas")
     market_prices = MarketPrices(electricity=electricity, gas=gas, energy_country="NL")
-    
+
     serialized_mp = _market_prices_to_dict(market_prices)
     deserialized_mp = _dict_to_market_prices(serialized_mp)
-    
+
     assert len(deserialized_mp.electricity.all) == 1
     assert deserialized_mp.electricity.all[0].market_price == 0.15
     assert deserialized_mp.energy_country == "NL"
+
 
 @pytest.mark.asyncio
 async def test_resolution_state_serialization():
@@ -69,17 +77,18 @@ async def test_resolution_state_serialization():
     state = ContractPriceResolutionState.from_dict(raw_state)
     serialized = _resolution_state_to_dict(state)
     deserialized = _dict_to_resolution_state(serialized)
-    
+
     assert deserialized.active_option == "PT15M"
     assert deserialized.is_change_request_possible is True
     assert deserialized.change_request_effective_date == date(2026, 7, 1)
+
 
 @pytest.mark.asyncio
 async def test_coordinator_load_cache(mock_store, mock_config_entry):
     """Test that coordinator loads cached data from Store on startup."""
     mock_config_entry.data = {}
     mock_config_entry.options = {}
-    
+
     raw_price = {
         "from": "2026-06-26T07:30:00+00:00",
         "till": "2026-06-26T07:45:00+00:00",
@@ -89,7 +98,7 @@ async def test_coordinator_load_cache(mock_store, mock_config_entry):
         "energyTaxPrice": 0.12,
         "perUnit": "kwh",
     }
-    
+
     cached_data = {
         "prices_today": {
             "electricity": [raw_price],
@@ -109,23 +118,37 @@ async def test_coordinator_load_cache(mock_store, mock_config_entry):
         "last_fetch_today": "2026-06-26T07:30:00+00:00",
         "last_fetch_tomorrow": None,
     }
-    
+
     mock_store.async_load = AsyncMock(return_value=cached_data)
-    
+
     hass = MagicMock(spec=HomeAssistant)
     hass.config = MagicMock()
     hass.config.country = "NL"
-    
+
     mock_api = MagicMock()
-    settings_coordinator = FrankEnergieSettingsCoordinator(hass, mock_config_entry, mock_api)
-    
-    price_coordinator = FrankEnergiePriceCoordinator(hass, mock_config_entry, mock_api, settings_coordinator)
-    
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        hass, mock_config_entry, mock_api
+    )
+
+    price_coordinator = FrankEnergiePriceCoordinator(
+        hass, mock_config_entry, mock_api, settings_coordinator
+    )
+
     # We patch super().async_config_entry_first_refresh to avoid actual update call
-    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_config_entry_first_refresh", AsyncMock()):
+    with patch(
+        "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_config_entry_first_refresh",
+        AsyncMock(),
+    ):
         await price_coordinator.async_config_entry_first_refresh()
-        
+
     assert price_coordinator._static_prices_today is not None
-    assert price_coordinator._static_prices_today.electricity.all[0].market_price == 0.15
-    assert price_coordinator._static_contract_price_resolution_state.active_option == "PT15M"
-    assert price_coordinator.last_fetch_today == datetime.fromisoformat("2026-06-26T07:30:00+00:00")
+    assert (
+        price_coordinator._static_prices_today.electricity.all[0].market_price == 0.15
+    )
+    assert (
+        price_coordinator._static_contract_price_resolution_state.active_option
+        == "PT15M"
+    )
+    assert price_coordinator.last_fetch_today == datetime.fromisoformat(
+        "2026-06-26T07:30:00+00:00"
+    )

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from homeassistant.core import HomeAssistant
 from python_frank_energie.models import (
     MarketPrices,
@@ -78,9 +78,50 @@ async def test_resolution_state_serialization():
     serialized = _resolution_state_to_dict(state)
     deserialized = _dict_to_resolution_state(serialized)
 
+    # Serialized dict should contain ISO strings / None for date-like fields
+    assert serialized["changeRequestEffectiveDate"] == "2026-07-01"
+    assert "upcomingChange" in serialized
+    assert serialized["upcomingChange"] is None
+    assert "upcomingChangeEffectiveDate" in serialized
+    assert serialized["upcomingChangeEffectiveDate"] is None
+
+    # Deserialized object should preserve values and types
     assert deserialized.active_option == "PT15M"
     assert deserialized.is_change_request_possible is True
     assert deserialized.change_request_effective_date == date(2026, 7, 1)
+    assert deserialized.upcoming_change is None
+    assert deserialized.upcoming_change_effective_date is None
+
+
+@pytest.mark.asyncio
+async def test_resolution_state_serialization_from_date_types():
+    """ContractPriceResolutionState serializes date/datetime fields to ISO strings and round-trips None."""
+    change_request_date = date(2026, 7, 1)
+    upcoming_change_dt = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    state = ContractPriceResolutionState(
+        active_option="PT15M",
+        available_options=["PT15M", "PT1H"],
+        change_request_effective_date=change_request_date,
+        is_change_request_possible=True,
+        upcoming_change=upcoming_change_dt,
+        upcoming_change_effective_date=None,
+    )
+
+    serialized = _resolution_state_to_dict(state)
+
+    # Date / datetime instances should be converted to ISO 8601 strings
+    assert serialized["changeRequestEffectiveDate"] == "2026-07-01"
+    assert serialized["upcomingChange"] == upcoming_change_dt.isoformat()
+    # None should be preserved as None
+    assert serialized["upcomingChangeEffectiveDate"] is None
+
+    deserialized = _dict_to_resolution_state(serialized)
+
+    # Round-trip should preserve values and types
+    assert deserialized.change_request_effective_date == change_request_date
+    assert deserialized.upcoming_change == upcoming_change_dt
+    assert deserialized.upcoming_change_effective_date is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This pull request implements disk-caching reboot survival for the Frank Energie integration's dynamic price data (electricity and gas spot prices) and resolution state. By utilizing Home Assistant's secure `Store` helper, the integration can immediately recover price states and forecast attributes upon reboot without depending on immediate API availability. It also resolves a duplicate keyword syntax bug in the number entity configuration.

## Key Changes
- **Disk Caching for Price Data:**
  - Integrated `homeassistant.helpers.storage.Store` inside `FrankEnergiePriceCoordinator` to write and retrieve dynamic price forecasts.
  - Implemented serialization/deserialization helpers for mapping API library models (`Price`, `ContractPriceResolutionState`) to JSON-compatible structures.
  - Added cache loading during initial config entry refresh to restore state immediately.
  - Enabled automatic cache updates upon successful API update cycles.
- **Syntax and Entity Setup Fix:**
  - Removed the duplicate `option_key` keyword argument within the `NETWORK_CHARGES` entity definition in `[number.py] `which was causing a setup load crash.
- **Unit Testing:**
  - Added `[test_price_cache.py]` to mock `Store` operations and verify serialization, startup recovery, and state population.

## Why this is needed
- **Reboot Resilience:** Prevents dynamic price sensors from displaying as `unavailable` during Home Assistant restarts, ensuring automation and dashboard continuity.
- **Rate-Limit Mitigation:** Eliminates redundant start-up API egress, protecting against rate-limiting and ensuring offline resilience.
- **Platform Stability:** Fixes duplicate keyword argument syntax to ensure number entities load without raising runtime errors.

## Summary by Sourcery

Voeg reboot-bestendige schijfcaching toe voor Frank Energie dynamische prijsgegevens en contractresolutiestatus, en herstel een onjuist geconfigureerde `number`-entiteit-optiesleutel.

Nieuwe features:
- Sla Frank Energie elektriciteits- en gas-spotprijzen plus de contractprijs-resolutiestatus op in de Home Assistant-opslag zodat prijsgegevens herstarts overleven.

Bugfixes:
- Corrigeer de configuratie van de netwerkkosten-`number`-entiteit door een dubbele `option`-sleutelparameter te verwijderen die tot setup-fouten leidde.

Verbeteringen:
- Herstel gecachte prijzen en resolutiestatus bij de eerste config entry-refresh om te voorkomen dat sensoren niet beschikbaar worden wanneer de API niet direct bereikbaar is.
- Werk de prijscoördinator bij zodat bijgewerkte prijzen, resolutiestatus en tijdstempels na geslaagde API-updates terug naar schijf worden geschreven.

Tests:
- Voeg tests toe voor helpers voor serialisatie van prijs- en resolutiestatus en voor het startgedrag van de coördinator bij het laden uit de schijfcache.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add reboot-persistent disk caching for Frank Energie dynamic price data and contract resolution state, and fix a misconfigured number entity option key.

New Features:
- Persist Frank Energie electricity and gas spot prices plus contract price resolution state to Home Assistant storage so price data survives restarts.

Bug Fixes:
- Correct the network charges number entity configuration to remove a duplicate option key argument that caused setup failures.

Enhancements:
- Restore cached prices and resolution state on the first config entry refresh to avoid sensors becoming unavailable when the API is not immediately reachable.
- Update the price coordinator to write refreshed prices, resolution state, and timestamps back to disk after successful API updates.

Tests:
- Add tests for price and resolution state serialization helpers and for coordinator startup behavior when loading from the disk cache.

</details>

Nieuwe functies:
- Sla Frank Energie elektriciteits- en gas-spotprijsgegevens en contractresolutiestatus op in de Home Assistant-opslag voor hergebruik na een herstart.

Bugfixes:
- Corrigeer een dubbele `option_key`-configuratie in de network charges number entity om installatiefouten te voorkomen.

Verbeteringen:
- Herstel de gecachte prijs- en resolutiestatus bij de eerste vernieuwing van de config entry om te voorkomen dat sensoren ontoegankelijk zijn wanneer de API niet direct bereikbaar is.
- Werk de price coordinator bij zodat vernieuwde prijzen en tijdstempels na succesvolle API-updates terug naar schijf worden geschreven.

Tests:
- Voeg tests toe voor de hulpfuncties voor serialisatie van prijs- en resolutiestatus en voor het opstartgedrag van de coordinator bij het laden vanuit de schijfcache.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Voeg reboot-bestendige schijfcaching toe voor Frank Energie dynamische prijsgegevens en contractresolutiestatus, en herstel een onjuist geconfigureerde `number`-entiteit-optiesleutel.

Nieuwe features:
- Sla Frank Energie elektriciteits- en gas-spotprijzen plus de contractprijs-resolutiestatus op in de Home Assistant-opslag zodat prijsgegevens herstarts overleven.

Bugfixes:
- Corrigeer de configuratie van de netwerkkosten-`number`-entiteit door een dubbele `option`-sleutelparameter te verwijderen die tot setup-fouten leidde.

Verbeteringen:
- Herstel gecachte prijzen en resolutiestatus bij de eerste config entry-refresh om te voorkomen dat sensoren niet beschikbaar worden wanneer de API niet direct bereikbaar is.
- Werk de prijscoördinator bij zodat bijgewerkte prijzen, resolutiestatus en tijdstempels na geslaagde API-updates terug naar schijf worden geschreven.

Tests:
- Voeg tests toe voor helpers voor serialisatie van prijs- en resolutiestatus en voor het startgedrag van de coördinator bij het laden uit de schijfcache.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add reboot-persistent disk caching for Frank Energie dynamic price data and contract resolution state, and fix a misconfigured number entity option key.

New Features:
- Persist Frank Energie electricity and gas spot prices plus contract price resolution state to Home Assistant storage so price data survives restarts.

Bug Fixes:
- Correct the network charges number entity configuration to remove a duplicate option key argument that caused setup failures.

Enhancements:
- Restore cached prices and resolution state on the first config entry refresh to avoid sensors becoming unavailable when the API is not immediately reachable.
- Update the price coordinator to write refreshed prices, resolution state, and timestamps back to disk after successful API updates.

Tests:
- Add tests for price and resolution state serialization helpers and for coordinator startup behavior when loading from the disk cache.

</details>

</details>