### PR TITLE
Serialize token renewal, prevent in-place price mutations, and expose coordinators earlier in setup

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -235,6 +235,18 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         # Awaiting the site reference selection using settings coordinator
         await self._select_site_reference(settings_coordinator)
 
+        # Make runtime data available before refreshes, so diagnostics, services,
+        # and error paths can resolve the coordinators during setup.
+        await self._save_coordinator_to_hass_data(
+            settings_coordinator,
+            price_coordinator,
+            battery_coordinator,
+            charger_coordinator,
+            pv_coordinator,
+            vehicle_coordinator,
+            statistics_coordinator,
+        )
+
         # Perform the initial refresh sequentially for sub-coordinators in dependency order
         _LOGGER.debug("Performing initial refresh for sub-coordinators")
         await settings_coordinator.async_config_entry_first_refresh()
@@ -248,17 +260,6 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         # Schedule updates aligned to price slot boundaries for price coordinator
         _LOGGER.debug("Scheduling aligned updates for price coordinator")
         await self._schedule_aligned_updates(price_coordinator)
-
-        # Save the coordinators to Home Assistant data
-        await self._save_coordinator_to_hass_data(
-            settings_coordinator,
-            price_coordinator,
-            battery_coordinator,
-            charger_coordinator,
-            pv_coordinator,
-            vehicle_coordinator,
-            statistics_coordinator,
-        )
 
         # Forward entry setups to platforms
         _LOGGER.debug("Forwarding entry setups to platforms")

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -247,25 +247,31 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
             statistics_coordinator,
         )
 
-        # Perform the initial refresh sequentially for sub-coordinators in dependency order
-        _LOGGER.debug("Performing initial refresh for sub-coordinators")
-        await settings_coordinator.async_config_entry_first_refresh()
-        await price_coordinator.async_config_entry_first_refresh()
-        await statistics_coordinator.async_config_entry_first_refresh()
-        await battery_coordinator.async_config_entry_first_refresh()
-        await charger_coordinator.async_config_entry_first_refresh()
-        await pv_coordinator.async_config_entry_first_refresh()
-        await vehicle_coordinator.async_config_entry_first_refresh()
+        try:
+            # Perform the initial refresh sequentially for sub-coordinators in dependency order
+            _LOGGER.debug("Performing initial refresh for sub-coordinators")
+            await settings_coordinator.async_config_entry_first_refresh()
+            await price_coordinator.async_config_entry_first_refresh()
+            await statistics_coordinator.async_config_entry_first_refresh()
+            await battery_coordinator.async_config_entry_first_refresh()
+            await charger_coordinator.async_config_entry_first_refresh()
+            await pv_coordinator.async_config_entry_first_refresh()
+            await vehicle_coordinator.async_config_entry_first_refresh()
 
-        # Schedule updates aligned to price slot boundaries for price coordinator
-        _LOGGER.debug("Scheduling aligned updates for price coordinator")
-        await self._schedule_aligned_updates(price_coordinator)
+            # Schedule updates aligned to price slot boundaries for price coordinator
+            _LOGGER.debug("Scheduling aligned updates for price coordinator")
+            await self._schedule_aligned_updates(price_coordinator)
 
-        # Forward entry setups to platforms
-        _LOGGER.debug("Forwarding entry setups to platforms")
-        await self._async_forward_entry_setups()
-        _LOGGER.debug("Finished forwarding entry setups to platforms")
-        return True
+            # Forward entry setups to platforms
+            _LOGGER.debug("Forwarding entry setups to platforms")
+            await self._async_forward_entry_setups()
+            _LOGGER.debug("Finished forwarding entry setups to platforms")
+            return True
+        except Exception:
+            if DOMAIN in self.hass.data:
+                self.hass.data[DOMAIN].pop(self.entry.entry_id, None)
+            self.entry.runtime_data = None
+            raise
 
     def _update_unique_id(self) -> None:
         """Update the unique ID of the config entry."""

--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -258,14 +258,14 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
             await pv_coordinator.async_config_entry_first_refresh()
             await vehicle_coordinator.async_config_entry_first_refresh()
 
-            # Schedule updates aligned to price slot boundaries for price coordinator
-            _LOGGER.debug("Scheduling aligned updates for price coordinator")
-            await self._schedule_aligned_updates(price_coordinator)
-
             # Forward entry setups to platforms
             _LOGGER.debug("Forwarding entry setups to platforms")
             await self._async_forward_entry_setups()
             _LOGGER.debug("Finished forwarding entry setups to platforms")
+
+            # Schedule updates aligned to price slot boundaries for price coordinator
+            _LOGGER.debug("Scheduling aligned updates for price coordinator")
+            await self._schedule_aligned_updates(price_coordinator)
             return True
         except Exception:
             if DOMAIN in self.hass.data:

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -384,7 +384,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # Reset to None daily so PV ownership is re-probed in case of new installation.
         self._has_pv_systems: bool | None = None
 
-
     @staticmethod
     def _get_shared_auth_lock(api: FrankEnergie) -> asyncio.Lock:
         """Return an auth lock shared by coordinators using the same API client."""
@@ -1079,7 +1078,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
             # resolution_state is already a ContractPriceResolutionState dataclass.
             # Keep API state in coordinator data; explicit user commands own persistent options.
-            if self.config_entry.options.get("resolution") != resolution_state.activeOption:
+            if (
+                self.config_entry.options.get("resolution")
+                != resolution_state.activeOption
+            ):
                 _LOGGER.debug(
                     "API resolution differs from configured option (api=%s, option=%s)",
                     resolution_state.activeOption,
@@ -1624,7 +1626,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             _LOGGER.debug(_LOG_AUTH_TOKENS_EXPIRED, ex)
             await self._try_renew_token()
             raise UpdateFailed(ex) from ex
-
 
     def _combine_price_data(self, today_data: Any, tomorrow_data: Any) -> Any:
         """Combine price data without mutating cached API model instances."""
@@ -2217,10 +2218,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         """Effective price resolution used for API queries."""
         if self.config_entry is None:
             return DEFAULT_RESOLUTION
-            
+
         if self._api_resolution_state and not self._resolution_change_pending:
             return self._api_resolution_state.activeOption
-            
+
         return self.config_entry.options.get("resolution", DEFAULT_RESOLUTION)
 
     @property

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1675,17 +1675,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 result[DATA_GAS] = cache.prices_today.gas
 
         if prices_tomorrow is not None:
-            if (
-                result[DATA_ELECTRICITY] is not None
-                and prices_tomorrow.electricity is not None
-            ):
-                result[DATA_ELECTRICITY] = self._combine_price_data(
-                    result[DATA_ELECTRICITY], prices_tomorrow.electricity
-                )
-            if result[DATA_GAS] is not None and prices_tomorrow.gas is not None:
-                result[DATA_GAS] = self._combine_price_data(
-                    result[DATA_GAS], prices_tomorrow.gas
-                )
+            result[DATA_ELECTRICITY] = self._combine_price_data(
+                result[DATA_ELECTRICITY], prices_tomorrow.electricity
+            )
+            result[DATA_GAS] = self._combine_price_data(
+                result[DATA_GAS], prices_tomorrow.gas
+            )
 
         return result
 
@@ -1978,9 +1973,12 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                         )
                     except Exception as login_ex:
                         _LOGGER.exception(
-                            "Unexpected error during silent re-login: %s. Proceeding to reauth flow",
+                            "Unexpected error during silent re-login: %s. Retrying later.",
                             login_ex,
                         )
+                        raise UpdateFailed(
+                            f"Unexpected error during silent re-login: {login_ex}"
+                        ) from login_ex
 
                 _LOGGER.exception(
                     "Failed to renew token: %s. Starting user reauth flow", ex

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2214,6 +2214,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         """Effective price resolution used for API queries."""
         if self.config_entry is None:
             return DEFAULT_RESOLUTION
+            
+        if self._api_resolution_state and not self._resolution_change_pending:
+            return self._api_resolution_state.activeOption
+            
         return self.config_entry.options.get("resolution", DEFAULT_RESOLUTION)
 
     @property

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2495,7 +2495,22 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     self._today_prices_logged = True
                 except Exception as err:
                     await self._handle_fetch_exceptions(err)
-                    raise UpdateFailed(f"Failed to fetch today prices: {err}") from err
+                    if (
+                        self._static_prices_today is not None
+                        and self._static_prices_today.electricity is not None
+                        and self._static_prices_today.electricity.current is not None
+                        and self._static_prices_today.gas is not None
+                        and self._static_prices_today.gas.current is not None
+                    ):
+                        _LOGGER.warning(
+                            "Failed to fetch today prices, falling back to cached data: %s",
+                            err,
+                        )
+                        prices_today = self._static_prices_today
+                    else:
+                        raise UpdateFailed(
+                            f"Failed to fetch today prices: {err}"
+                        ) from err
             else:
                 prices_today = self._static_prices_today
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -6,6 +6,7 @@ Fetching the latest data from Frank Energie and updating the states."""
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 
 # import secrets
@@ -328,6 +329,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             config_entry=config_entry,
         )
         self._mutation_queue = MutationQueue()
+        self._auth_lock = self._get_shared_auth_lock(api)
         self.hass = hass
         self.config_entry = config_entry
         self.api = api
@@ -381,6 +383,16 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # None = not yet checked; True/False = confirmed this session.
         # Reset to None daily so PV ownership is re-probed in case of new installation.
         self._has_pv_systems: bool | None = None
+
+
+    @staticmethod
+    def _get_shared_auth_lock(api: FrankEnergie) -> asyncio.Lock:
+        """Return an auth lock shared by coordinators using the same API client."""
+        lock = getattr(api, "_frank_energie_auth_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            setattr(api, "_frank_energie_auth_lock", lock)
+        return lock
 
     @property
     def old_site_reference(self) -> str | None:
@@ -1065,15 +1077,13 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 False  # change has been processed by API, reset pending flag
             )
 
-            # resolution_state is already a ContractPriceResolutionState dataclass
-            if (
-                self.config_entry.options.get("resolution")
-                != resolution_state.activeOption
-            ):
-                options = dict(self.config_entry.options)
-                options["resolution"] = resolution_state.activeOption
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry, options=options
+            # resolution_state is already a ContractPriceResolutionState dataclass.
+            # Keep API state in coordinator data; explicit user commands own persistent options.
+            if self.config_entry.options.get("resolution") != resolution_state.activeOption:
+                _LOGGER.debug(
+                    "API resolution differs from configured option (api=%s, option=%s)",
+                    resolution_state.activeOption,
+                    self.config_entry.options.get("resolution"),
                 )
 
             _LOGGER.debug(
@@ -1168,20 +1178,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return vehicles
         except Exception as err:
             self._handle_dynamic_fetch_error("enode vehicles", err)
-            return None
-
-    async def old_fetch_smart_pv_systems(self) -> SmartPvSystems | None:
-        """Fetch Smart PV systems from the API."""
-        if not self.api.is_authenticated:
-            return None
-        try:
-            return await self.api.smart_pv_systems()
-        except (AuthException, AuthRequiredException):
-            raise
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Failed to fetch smart PV systems: %s", err)
             return None
 
     async def _fetch_smart_pv_systems(self) -> SmartPvSystems | None:
@@ -1626,6 +1622,21 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             await self._try_renew_token()
             raise UpdateFailed(ex) from ex
 
+
+    def _combine_price_data(self, today_data: Any, tomorrow_data: Any) -> Any:
+        """Combine price data without mutating cached API model instances."""
+        if today_data is None:
+            return tomorrow_data
+        if tomorrow_data is None:
+            return today_data
+
+        try:
+            combined = copy.copy(today_data)
+            combined += tomorrow_data
+            return combined
+        except TypeError:
+            return today_data + tomorrow_data
+
     def _aggregate_data(
         self,
         cache: PricesTodayCache,
@@ -1664,9 +1675,13 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 result[DATA_ELECTRICITY] is not None
                 and prices_tomorrow.electricity is not None
             ):
-                result[DATA_ELECTRICITY] += prices_tomorrow.electricity
+                result[DATA_ELECTRICITY] = self._combine_price_data(
+                    result[DATA_ELECTRICITY], prices_tomorrow.electricity
+                )
             if result[DATA_GAS] is not None and prices_tomorrow.gas is not None:
-                result[DATA_GAS] += prices_tomorrow.gas
+                result[DATA_GAS] = self._combine_price_data(
+                    result[DATA_GAS], prices_tomorrow.gas
+                )
 
         return result
 
@@ -1885,18 +1900,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self._cached_prices = user_prices
         return user_prices
 
-    async def _handle_fetch_exceptions(self, ex):
+    async def _handle_fetch_exceptions(self, ex: Exception) -> None:
+        """Normalize fetch exceptions for DataUpdateCoordinator callers."""
         if isinstance(ex, (ConfigEntryAuthFailed, AuthRequiredException)):
             raise ex
         if isinstance(ex, UpdateFailed):
-            if (
-                self.data[DATA_ELECTRICITY] is not None
-                and self.data[DATA_ELECTRICITY].get_future_prices()
-                and self.data[DATA_GAS] is not None
-                and self.data[DATA_GAS].get_future_prices()
-            ):
-                _LOGGER.warning(str(ex))
-                return self.data
             raise ex
         if isinstance(ex, RequestException) and str(ex).startswith("user-error:"):
             raise ConfigEntryAuthFailed from ex
@@ -1906,74 +1914,74 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             raise UpdateFailed(ex) from ex
 
     async def _try_renew_token(self) -> None:
-        """Try to renew authentication token."""
+        """Try to renew authentication token with shared-client serialization."""
 
-        try:
-            updated_tokens = await self.api.renew_token()
-            updated_data = {
-                **self.config_entry.data,
-                CONF_ACCESS_TOKEN: updated_tokens.authToken,
-                CONF_TOKEN: updated_tokens.refreshToken,
-            }
-            # Clean up old plaintext credentials in data if any
-            updated_data.pop(CONF_USERNAME, None)
-            updated_data.pop(CONF_PASSWORD, None)
+        async with self._auth_lock:
+            try:
+                updated_tokens = await self.api.renew_token()
+                updated_data = {
+                    **self.config_entry.data,
+                    CONF_ACCESS_TOKEN: updated_tokens.authToken,
+                    CONF_TOKEN: updated_tokens.refreshToken,
+                }
+                # Clean up old plaintext credentials in data if any
+                updated_data.pop(CONF_USERNAME, None)
+                updated_data.pop(CONF_PASSWORD, None)
 
-            # Update the config entry with the new tokens
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=updated_data
-            )
+                # Update the config entry with the new tokens
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=updated_data
+                )
 
-            _LOGGER.debug("Successfully renewed token")
+                _LOGGER.debug("Successfully renewed token")
 
-        except AuthException as ex:
-            _LOGGER.debug(
-                "Token renewal failed, attempting silent re-login using stored credentials"
-            )
-            username = self.config_entry.options.get(
-                CONF_USERNAME
-            ) or self.config_entry.data.get(CONF_USERNAME)
-            password = self.config_entry.options.get(
-                CONF_PASSWORD
-            ) or self.config_entry.data.get(CONF_PASSWORD)
+            except AuthException as ex:
+                _LOGGER.debug(
+                    "Token renewal failed, attempting silent re-login using stored credentials"
+                )
+                username = self.config_entry.options.get(
+                    CONF_USERNAME
+                ) or self.config_entry.data.get(CONF_USERNAME)
+                password = self.config_entry.options.get(
+                    CONF_PASSWORD
+                ) or self.config_entry.data.get(CONF_PASSWORD)
 
-            if username and password:
-                try:
-                    decrypted_password = decrypt_password(self.hass, password)
-                    if not decrypted_password:
-                        raise AuthException("Decrypted password is empty")
-                    auth = await self.api.login(username, decrypted_password)
-                    updated_data = {
-                        **self.config_entry.data,
-                        CONF_ACCESS_TOKEN: auth.authToken,
-                        CONF_TOKEN: auth.refreshToken,
-                    }
-                    updated_data.pop(CONF_USERNAME, None)
-                    updated_data.pop(CONF_PASSWORD, None)
+                if username and password:
+                    try:
+                        decrypted_password = decrypt_password(self.hass, password)
+                        if not decrypted_password:
+                            raise AuthException("Decrypted password is empty")
+                        auth = await self.api.login(username, decrypted_password)
+                        updated_data = {
+                            **self.config_entry.data,
+                            CONF_ACCESS_TOKEN: auth.authToken,
+                            CONF_TOKEN: auth.refreshToken,
+                        }
+                        updated_data.pop(CONF_USERNAME, None)
+                        updated_data.pop(CONF_PASSWORD, None)
 
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry, data=updated_data
-                    )
-                    _LOGGER.info(
-                        "Successfully re-authenticated silently using stored credentials"
-                    )
-                    return
-                except (AuthException, FrankEnergieException) as login_ex:
-                    _LOGGER.warning(
-                        "Silent re-login failed with API/Auth error: %s. Proceeding to reauth flow",
-                        login_ex,
-                    )
-                except Exception as login_ex:
-                    _LOGGER.exception(
-                        "Unexpected error during silent re-login: %s. Proceeding to reauth flow",
-                        login_ex,
-                    )
+                        self.hass.config_entries.async_update_entry(
+                            self.config_entry, data=updated_data
+                        )
+                        _LOGGER.info(
+                            "Successfully re-authenticated silently using stored credentials"
+                        )
+                        return
+                    except (AuthException, FrankEnergieException) as login_ex:
+                        _LOGGER.warning(
+                            "Silent re-login failed with API/Auth error: %s. Proceeding to reauth flow",
+                            login_ex,
+                        )
+                    except Exception as login_ex:
+                        _LOGGER.exception(
+                            "Unexpected error during silent re-login: %s. Proceeding to reauth flow",
+                            login_ex,
+                        )
 
-            _LOGGER.exception(
-                "Failed to renew token: %s. Starting user reauth flow", ex
-            )
-            # Consider setting the coordinator to an error state or handling the error appropriately
-            raise ConfigEntryAuthFailed from ex
+                _LOGGER.exception(
+                    "Failed to renew token: %s. Starting user reauth flow", ex
+                )
+                raise ConfigEntryAuthFailed from ex
 
     async def _fetch_authenticated[T](
         self,
@@ -2187,71 +2195,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             self._resolution_change_pending = (
                 True  # disable select until change is effective
-            )
-
-            if self.config_entry is None:
-                return
-
-            if self.config_entry.options.get("resolution") != value:
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    options={**self.config_entry.options, "resolution": value},
-                )
-
-        await self._mutation_queue.add(_mutation)
-        await self.async_request_refresh()
-
-    async def old_async_set_resolution(self, value: str) -> None:
-        """Update resolution safely via mutation queue."""
-        if not self.api.is_authenticated:
-            # Not authenticated — save to options only, no API call
-            if self.config_entry is not None:
-                _LOGGER.warning(  # use warning so it's visible in logs
-                    "Resolution saved to options (not authenticated): %s -> options=%s",
-                    value,
-                    self.config_entry.options,
-                )
-            if self.config_entry is not None:
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    options={**self.config_entry.options, "resolution": value},
-                )
-                await self.async_request_refresh()
-                _LOGGER.debug(
-                    "Resolution saved to options (not authenticated): %s", value
-                )
-            return
-
-        if not self._connection_id:
-            _LOGGER.warning(
-                "Cannot set resolution via API: connection_id not available"
-            )
-            return
-
-        if (
-            self._api_resolution_state is not None
-            and not self._api_resolution_state.isChangeRequestPossible
-        ):
-            _LOGGER.warning(
-                "Cannot set resolution via API: isChangeRequestPossible=False"
-            )
-            return
-
-        async def _mutation() -> None:
-            result = await self.api.contract_price_resolution_request_change(
-                self._connection_id,
-                cast(Resolution, value),
-            )
-
-            if result is None or not result.success:
-                raise UpdateFailed(
-                    "Resolution change request failed: %s"
-                    % (result.reason if result else "no response")
-                )
-
-            _LOGGER.info(
-                "Resolution change accepted (effective: %s)",
-                result.data.effectiveDate if result.data else "unknown",
             )
 
             if self.config_entry is None:


### PR DESCRIPTION
### Motivation
- Ensure coordinators are accessible to diagnostics/services/error paths during platform setup by saving runtime coordinator references before initial refreshes. 
- Prevent concurrent token renewals and silent re-logins from racing when multiple coordinators share the same API client. 
- Avoid mutating API model instances when combining today/tomorrow price data so cached objects remain immutable to callers. 
- Simplify/clarify handling of API-reported resolution state so persistent options remain controlled by explicit user actions.

### Description
- Save coordinator objects to Home Assistant data early in setup by calling `await self._save_coordinator_to_hass_data(...)` before performing initial refreshes in `__init__.py`. 
- Add a shared auth lock via `FrankEnergieCoordinator._get_shared_auth_lock(api)` and initialize `self._auth_lock` in the coordinator to serialize token renewal/login across coordinators. 
- Update `_try_renew_token` to acquire `self._auth_lock` while calling `renew_token()` and performing a silent re-login fallback, and to update config entry tokens atomically. 
- Introduce `FrankEnergieCoordinator._combine_price_data` that uses `copy.copy` (with a fallback) to combine price lists without mutating cached API model instances, and use it in `_aggregate_data` for electricity and gas. 
- Remove an older duplicate `old_fetch_smart_pv_systems`/`old_async_set_resolution` implementations and refine contract price resolution handling to no longer overwrite user `options` from a read-only API state (only logs differences). 
- Add minor typing/exception normalization improvements such as annotating `_handle_fetch_exceptions` and small logging clarifications.

### Testing
- Ran unit tests with `pytest` against the integration suite and all tests passed. 
- Ran static type checks with `mypy` and no type errors were reported. 
- Ran linting (`flake8`) and there were no new lint errors introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1089d8188322864a0f5c5c04abad)

## Summary by Sourcery

Serialiseer de vernieuwing van authenticatietokens tussen coördinatoren die dezelfde API‑client delen, voorkom mutaties van in de cache opgeslagen prijsgegevens bij het combineren van dagen, stel coördinatoren eerder beschikbaar aan Home Assistant tijdens de setup, en verfijn de afhandeling van contractresolutie en normalisatie van fouten.

Bugfixes:
- Serialiseer tokenvernieuwing en stille opnieuw-inlogflows met een gedeelde auth‑lock om gelijktijdige race‑condities tussen coördinatoren die dezelfde API‑client gebruiken te voorkomen.
- Voorkom in-place mutaties van gecachte modellen voor elektriciteits- en gasprijzen bij het samenvoegen van gegevens voor vandaag en morgen door ze te combineren in nieuwe instanties.
- Zorg ervoor dat coördinatoren beschikbaar zijn in de Home Assistant‑data vóór de eerste refreshes, zodat diagnostics, services en foutpaden er tijdens de setup toegang toe hebben.

Verbeteringen:
- Verfijn de afhandeling van contractprijsresolutie zodat gebruikersgeconfigureerde opties worden gerespecteerd, terwijl alleen verschillen ten opzichte van de door de API gerapporteerde status worden gelogd.
- Versterk typing en foutafhandeling door fetch‑exception‑afhandeling te annoteren en de normalisatie van update‑exceptions te vereenvoudigen.

Klusjes:
- Verwijder verouderde smart PV‑fetch‑ en resolutiemutatiemethoden die de nieuwere logica dupliceerden.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize authentication token renewal across coordinators sharing the same API client, avoid mutating cached price data when combining days, expose coordinators to Home Assistant earlier in setup, and refine contract resolution handling and error normalization.

Bug Fixes:
- Serialize token renewal and silent re-login flows with a shared auth lock to prevent concurrent races between coordinators using the same API client.
- Avoid in-place mutations of cached electricity and gas price models when merging today and tomorrow data by combining them into new instances.
- Ensure coordinators are available in Home Assistant data before initial refreshes so diagnostics, services, and error paths can access them during setup.

Enhancements:
- Refine contract price resolution handling to respect user-configured options while only logging differences from API-reported state.
- Tighten typing and error handling by annotating fetch exception handling and simplifying normalization of update exceptions.

Chores:
- Remove obsolete smart PV fetch and resolution mutation methods that duplicated newer logic.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability with safer rollback on refresh failures, preventing the integration from being left in a broken state.
  * Reduced authentication race conditions by serializing token renewal and performing silent re-login when needed.
  * Stabilized price updates by avoiding in-place mutation during future price aggregation.
  * Corrected contract price resolution behavior to reflect API “active” state while reconciling configuration drift.
  * Optimized smart PV ownership checks and tightened today-price fallback behavior to avoid using incomplete cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->