### PR TITLE
feat: add PV Total Result sensor, fix unmapped battery state, and clarify trading result

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -81,6 +81,38 @@ DEFAULT_EXPORT_ELECTRICITY_FEE: Final[float] = -0.035090
 SUPPORTED_RESOLUTIONS: Final[tuple[str, ...]] = ("PT15M", "PT60M")
 SUPPORTED_COUNTRIES: Final[tuple[str, ...]] = ("NL", "BE")
 
+SMART_BATTERY_STATUSES: Final[tuple[str, ...]] = (
+    "status_charging",
+    "status_discharging",
+    "status_idle",
+    "status_unreliable_data",
+    "status_offline",
+    "status_standby",
+    "separate_imbalances",
+    "idle_full",
+    "idle_price",
+    "discharge_self_consumption",
+    "discharge_imbalance",
+    "charge_imbalance",
+    "discharge_intraday",
+    "charge_intraday",
+    "idle_intraday",
+    "charge_epex",
+    "discharge_epex",
+    "idle_epex",
+    "discharge_congestion",
+    "charge_congestion",
+    "discharge_self_consumption_mixed",
+    "idle_congestion",
+    "idle_empty",
+    "idle_fifteen_percent",
+    "idle_fifteen_percentage",
+    "charge_self_consumption",
+    "charge_self_consumption_mixed",
+    "status_maintenance",
+    "status_error",
+)
+
 # --- Data Fields ---
 DATA_CONTRACT_PRICE_RESOLUTION_STATE: Final[str] = "contract_price_resolution_state"
 DATA_ELECTRICITY: Final[str] = "electricity"

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1281,8 +1281,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return None
 
         try:
+            # Override start_date to fetch Month-To-Date sessions for period totals, ensuring we include yesterday
+            today = datetime.now(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
+            mtd_start = min(today.replace(day=1), today - timedelta(days=1))
             sessions = await self.api.smart_battery_sessions(
-                battery.id, start_date, tomorrow
+                battery.id, mtd_start, tomorrow
             )
             if sessions and isinstance(sessions.sessions, list):
                 _LOGGER.debug(
@@ -2998,8 +3001,10 @@ class FrankEnergieBatterySessionCoordinator(
                 "Fetching smart battery sessions for device %s", self.device_id
             )
 
+            # Fetch Month-To-Date sessions for period totals, ensuring we always include yesterday
+            mtd_start = min(today.replace(day=1), today - timedelta(days=1))
             return await self.api.smart_battery_sessions(
-                self.device_id, today, tomorrow
+                self.device_id, mtd_start, tomorrow
             )
 
         except UpdateFailed as ex:

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -656,8 +656,8 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
         self._attr_unique_id = f"{DOMAIN}_{system_id}_{sensor_type}"
         self._attr_translation_key = f"pv_{sensor_type}"
 
-        if sensor_type == "total_bonus":
-            self._attr_name = "Total bonus"
+        if sensor_type in ["total_bonus", "total_result"]:
+            self._attr_name = sensor_type.replace("_", " ").capitalize()
             self._attr_native_unit_of_measurement = CURRENCY_EURO
             self._attr_device_class = SensorDeviceClass.MONETARY
             self._attr_state_class = SensorStateClass.TOTAL
@@ -686,6 +686,8 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
 
         if self._sensor_type == "total_bonus":
             return summary.total_bonus
+        if self._sensor_type == "total_result":
+            return summary.total_result
         if self._sensor_type == "operational_status":
             return summary.operational_status
         if self._sensor_type == "operational_status_timestamp":
@@ -1531,7 +1533,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     ),
     FrankEnergieEntityDescription(
         key="all_periods_trading_result",
-        name="All Periods Trading Result",
+        name="Daily Trading Result",
         icon="mdi:currency-eur",
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
@@ -4839,6 +4841,7 @@ def _build_single_smart_battery_descriptions(
                         "status_standby",
                         "separate_imbalances",
                         "idle_full",
+                        "idle_price",
                         "discharge_self_consumption",
                         "discharge_imbalance",
                         "charge_imbalance",
@@ -5300,6 +5303,7 @@ async def async_setup_entry(
                 entities.extend(
                     [
                         FrankEnergiePvSensor(pv_coordinator, system.id, "total_bonus"),
+                        FrankEnergiePvSensor(pv_coordinator, system.id, "total_result"),
                         FrankEnergiePvSensor(
                             pv_coordinator, system.id, "operational_status"
                         ),

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -754,6 +754,7 @@ class FrankEnergiePvPanelGroupSensor(
         coordinator: FrankEnergieCoordinator,
         system_id: str,
         panel_group_id: str,
+        position: int | str,
     ) -> None:
         """Initialize the PV panel group sensor."""
         super().__init__(coordinator)
@@ -774,6 +775,7 @@ class FrankEnergiePvPanelGroupSensor(
         # Make the unique id distinct for each panel group
         self._attr_unique_id = f"{DOMAIN}_{system_id}_panel_group_{panel_group_id}"
         self._attr_translation_key = "pv_panel_group"
+        self._attr_translation_placeholders = {"position": str(position)}
         self._attr_icon = "mdi:solar-panel"
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
@@ -5392,7 +5394,7 @@ async def async_setup_entry(
                         if group and group.id:
                             entities.append(
                                 FrankEnergiePvPanelGroupSensor(
-                                    pv_coordinator, system.id, group.id
+                                    pv_coordinator, system.id, group.id, group.position
                                 )
                             )
 

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -90,6 +90,7 @@ from .const import (
     SERVICE_NAME_SETTINGS,
     SERVICE_NAME_USAGE,
     SERVICE_NAME_USER,
+    SMART_BATTERY_STATUSES,
     TIMEZONE_AMSTERDAM,
     UNIT_ELECTRICITY,
     UNIT_GAS,
@@ -625,22 +626,61 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
         self.async_write_ha_state()
 
 
+PV_SENSORS: tuple[FrankEnergieEntityDescription, ...] = (
+    FrankEnergieEntityDescription(
+        key="total_bonus",
+        name="Total bonus",
+        icon="mdi:currency-eur",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_EURO,
+        suggested_display_precision=2,
+    ),
+    FrankEnergieEntityDescription(
+        key="total_result",
+        name="Total result",
+        icon="mdi:currency-eur",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_EURO,
+        suggested_display_precision=2,
+    ),
+    FrankEnergieEntityDescription(
+        key="operational_status",
+        name="Operational status",
+        icon="mdi:information-outline",
+    ),
+    FrankEnergieEntityDescription(
+        key="operational_status_timestamp",
+        name="Last updated",
+        icon=ICON_CLOCK_OUTLINE,
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    FrankEnergieEntityDescription(
+        key="steering_status",
+        name="Steering status",
+        icon="mdi:solar-power",
+    ),
+)
+
+
 class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEntity):
     """Representation of a Frank Energie Smart PV sensor."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    entity_description: FrankEnergieEntityDescription
 
     def __init__(
         self,
         coordinator: FrankEnergieCoordinator,
         system_id: str,
-        sensor_type: str,  # "total_bonus", "operational_status", "steering_status"
+        description: FrankEnergieEntityDescription,
     ) -> None:
         """Initialize the PV sensor."""
         super().__init__(coordinator)
+        self.entity_description = description
         self._system_id = system_id
-        self._sensor_type = sensor_type
 
         # Get PV system metadata (brand, model, name, serial_number)
         metadata = coordinator.get_pv_system_metadata(system_id)
@@ -653,26 +693,8 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
             serial_number=metadata["serial_number"],
         )
 
-        self._attr_unique_id = f"{DOMAIN}_{system_id}_{sensor_type}"
-        self._attr_translation_key = f"pv_{sensor_type}"
-
-        if sensor_type in ["total_bonus", "total_result"]:
-            self._attr_name = sensor_type.replace("_", " ").capitalize()
-            self._attr_native_unit_of_measurement = CURRENCY_EURO
-            self._attr_device_class = SensorDeviceClass.MONETARY
-            self._attr_state_class = SensorStateClass.TOTAL
-            self._attr_icon = "mdi:currency-eur"
-            self._attr_suggested_display_precision = 2
-        elif sensor_type == "operational_status":
-            self._attr_name = "Operational status"
-            self._attr_icon = "mdi:information-outline"
-        elif sensor_type == "operational_status_timestamp":
-            self._attr_name = "Last updated"
-            self._attr_device_class = SensorDeviceClass.TIMESTAMP
-            self._attr_icon = ICON_CLOCK_OUTLINE
-        elif sensor_type == "steering_status":
-            self._attr_name = "Steering status"
-            self._attr_icon = "mdi:solar-power"
+        self._attr_unique_id = f"{DOMAIN}_{system_id}_{description.key}"
+        self._attr_translation_key = f"pv_{description.key}"
 
     @property
     def native_value(self) -> StateType:
@@ -681,18 +703,30 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
         if not summary_dict:
             return None
         summary = summary_dict.get(self._system_id)
+
+        key = self.entity_description.key
+
         if not summary:
+            if key == "steering_status":
+                systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
+                if systems_obj and systems_obj.systems:
+                    pv_system = next(
+                        (s for s in systems_obj.systems if s.id == self._system_id),
+                        None,
+                    )
+                    if pv_system:
+                        return pv_system.steering_status
             return None
 
-        if self._sensor_type == "total_bonus":
+        if key == "total_bonus":
             return summary.total_bonus
-        if self._sensor_type == "total_result":
+        if key == "total_result":
             return summary.total_result
-        if self._sensor_type == "operational_status":
+        if key == "operational_status":
             return summary.operational_status
-        if self._sensor_type == "operational_status_timestamp":
+        if key == "operational_status_timestamp":
             return summary.operational_status_timestamp
-        if self._sensor_type == "steering_status":
+        if key == "steering_status":
             if summary.steering_status is not None:
                 return summary.steering_status
             systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
@@ -4907,37 +4941,7 @@ def _build_single_smart_battery_descriptions(
                     service_name=SERVICE_NAME_BATTERIES,
                     icon="mdi:battery-clock",
                     device_class=SensorDeviceClass.ENUM,
-                    options=[
-                        "status_charging",
-                        "status_discharging",
-                        "status_idle",
-                        "status_unreliable_data",
-                        "status_offline",
-                        "status_standby",
-                        "separate_imbalances",
-                        "idle_full",
-                        "idle_price",
-                        "discharge_self_consumption",
-                        "discharge_imbalance",
-                        "charge_imbalance",
-                        "discharge_intraday",
-                        "charge_intraday",
-                        "idle_intraday",
-                        "charge_epex",
-                        "discharge_epex",
-                        "idle_epex",
-                        "discharge_congestion",
-                        "charge_congestion",
-                        "discharge_self_consumption_mixed",
-                        "idle_congestion",
-                        "idle_empty",
-                        "idle_fifteen_percent",
-                        "idle_fifteen_percentage",
-                        "charge_self_consumption",
-                        "charge_self_consumption_mixed",
-                        "status_maintenance",
-                        "status_error",
-                    ],
+                    options=list(SMART_BATTERY_STATUSES),
                     value_fn=lambda data, idx=i: _get_battery_summary_lower(
                         data, idx, "last_known_status"
                     ),
@@ -5377,16 +5381,9 @@ async def async_setup_entry(
             if system:
                 entities.extend(
                     [
-                        FrankEnergiePvSensor(pv_coordinator, system.id, "total_bonus"),
-                        FrankEnergiePvSensor(pv_coordinator, system.id, "total_result"),
-                        FrankEnergiePvSensor(
-                            pv_coordinator, system.id, "operational_status"
-                        ),
-                        FrankEnergiePvSensor(
-                            pv_coordinator, system.id, "operational_status_timestamp"
-                        ),
-                        FrankEnergiePvSensor(
-                            pv_coordinator, system.id, "steering_status"
+                        *(
+                            FrankEnergiePvSensor(pv_coordinator, system.id, description)
+                            for description in PV_SENSORS
                         ),
                     ]
                 )

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1629,7 +1629,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         ),
     ),
     FrankEnergieEntityDescription(
-        key="all_periods_trading_result",
+        key="daily_trading_result",
         name="Daily Trading Result",
         icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1471,6 +1471,31 @@ def _calculate_market_percent_tax(price_data: object | None) -> float | None:
     return None
 
 
+def _get_period_trading_result(data: object | None) -> float | None:
+    """Calculate the period trading result."""
+    if not data:
+        return None
+    if getattr(data, "period_trading_result", None):
+        return getattr(data, "period_trading_result")
+    
+    sessions = getattr(data, "sessions", None) or []
+    return sum(getattr(session, "result", 0) for session in sessions)
+
+
+def _get_period_total_result(data: object | None) -> float | None:
+    """Calculate the period total result."""
+    if not data:
+        return None
+    if getattr(data, "period_total_result", None):
+        return getattr(data, "period_total_result")
+    
+    return (
+        (getattr(data, "period_epex_result", 0) or 0)
+        + (getattr(data, "period_imbalance_result", 0) or 0)
+        + (getattr(data, "period_frank_slim", 0) or 0)
+    )
+
+
 BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     tuple[FrankEnergieEntityDescription, ...]
 ] = (
@@ -1538,16 +1563,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         entity_category=None,
         state_class="measurement",
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
-        value_fn=lambda data: (
-            getattr(data, "period_trading_result")
-            if data and getattr(data, "period_trading_result", None)
-            else sum(
-                getattr(session, "result", 0)
-                for session in (getattr(data, "sessions", None) or [])
-            )
-            if data
-            else None
-        ),
+        value_fn=_get_period_trading_result,
     ),
     FrankEnergieEntityDescription(
         key="period_total_result",
@@ -1558,17 +1574,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
-        value_fn=lambda data: (
-            getattr(data, "period_total_result")
-            if data and getattr(data, "period_total_result", None)
-            else (
-                (getattr(data, "period_epex_result", 0) or 0)
-                + (getattr(data, "period_imbalance_result", 0) or 0)
-                + (getattr(data, "period_frank_slim", 0) or 0)
-            )
-            if data
-            else None
-        ),
+        value_fn=_get_period_total_result,
         attr_fn=lambda data: (
             {
                 "device_id": getattr(data, "device_id", None),

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1494,11 +1494,11 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         native_unit_of_measurement=None,
         entity_category=None,
         state_class=None,
-        device_class=SensorDeviceClass.TIMESTAMP,
+        device_class=SensorDeviceClass.DATE,
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
         value_fn=lambda data: (
-            _format_battery_date(getattr(data, "period_start_date", None))
-            if data
+            _format_battery_date(getattr(data, "period_start_date", None)).date()
+            if data and _format_battery_date(getattr(data, "period_start_date", None))
             else None
         ),
     ),
@@ -1509,10 +1509,12 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         native_unit_of_measurement=None,
         entity_category=None,
         state_class=None,
-        device_class=SensorDeviceClass.TIMESTAMP,
+        device_class=SensorDeviceClass.DATE,
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
         value_fn=lambda data: (
-            _format_battery_date(data.period_end_date) if data else None
+            _format_battery_date(getattr(data, "period_end_date", None)).date()
+            if data and _format_battery_date(getattr(data, "period_end_date", None))
+            else None
         ),
     ),
     FrankEnergieEntityDescription(

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -763,9 +763,7 @@ class FrankEnergiePvPanelGroupSensor(
         self._attr_translation_key = "pv_panel_group"
         self._attr_translation_placeholders = {"position": str(position)}
         self._attr_icon = "mdi:solar-panel"
-        self._attr_device_class = SensorDeviceClass.POWER
         self._attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
-        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -630,36 +630,41 @@ PV_SENSORS: tuple[FrankEnergieEntityDescription, ...] = (
     FrankEnergieEntityDescription(
         key="total_bonus",
         name="Total bonus",
-        icon="mdi:currency-eur",
+        icon=ICON,
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
+        value_fn=lambda summary: summary.total_bonus,
     ),
     FrankEnergieEntityDescription(
         key="total_result",
         name="Total result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
+        value_fn=lambda summary: summary.total_result,
     ),
     FrankEnergieEntityDescription(
         key="operational_status",
         name="Operational status",
         icon="mdi:information-outline",
+        value_fn=lambda summary: summary.operational_status,
     ),
     FrankEnergieEntityDescription(
         key="operational_status_timestamp",
         name="Last updated",
         icon=ICON_CLOCK_OUTLINE,
         device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda summary: summary.operational_status_timestamp,
     ),
     FrankEnergieEntityDescription(
         key="steering_status",
         name="Steering status",
         icon="mdi:solar-power",
+        value_fn=lambda summary: summary.steering_status,
     ),
 )
 
@@ -700,35 +705,13 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         summary_dict = self.coordinator.data.get(DATA_PV_SUMMARY)
-        if not summary_dict:
-            return None
-        summary = summary_dict.get(self._system_id)
+        summary = summary_dict.get(self._system_id) if summary_dict else None
 
         key = self.entity_description.key
 
-        if not summary:
-            if key == "steering_status":
-                systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
-                if systems_obj and systems_obj.systems:
-                    pv_system = next(
-                        (s for s in systems_obj.systems if s.id == self._system_id),
-                        None,
-                    )
-                    if pv_system:
-                        return pv_system.steering_status
-            return None
-
-        if key == "total_bonus":
-            return summary.total_bonus
-        if key == "total_result":
-            return summary.total_result
-        if key == "operational_status":
-            return summary.operational_status
-        if key == "operational_status_timestamp":
-            return summary.operational_status_timestamp
-        if key == "steering_status":
-            if summary.steering_status is not None:
-                return summary.steering_status
+        if key == "steering_status" and (
+            not summary or summary.steering_status is None
+        ):
             systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
             if systems_obj and systems_obj.systems:
                 pv_system = next(
@@ -737,6 +720,9 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
                 if pv_system:
                     return pv_system.steering_status
             return None
+
+        if summary and self.entity_description.value_fn:
+            return self.entity_description.value_fn(summary)
 
         return None
 
@@ -1546,7 +1532,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="period_trading_result",
         name="Period Trading Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
         entity_category=None,
@@ -1561,7 +1547,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="period_total_result",
         name="Period Total Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,
@@ -1601,7 +1587,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="period_imbalance_result",
         name="Period Imbalance Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,
@@ -1616,7 +1602,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="period_epex_result",
         name="Period EPEX Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=CURRENCY_EURO,
@@ -1631,7 +1617,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="period_frank_slim_bonus",
         name="Period Frank Slim Bonus",
-        icon="mdi:currency-eur",
+        icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
         state_class="measurement",
@@ -1645,7 +1631,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="all_periods_trading_result",
         name="Daily Trading Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
         state_class="measurement",
@@ -1662,7 +1648,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     FrankEnergieEntityDescription(
         key="total_trading_result",
         name="Total Trading Result",
-        icon="mdi:currency-eur",
+        icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
         state_class="measurement",
@@ -4967,7 +4953,7 @@ def _build_single_smart_battery_descriptions(
                     device_class=SensorDeviceClass.MONETARY,
                     native_unit_of_measurement=CURRENCY_EURO,
                     suggested_display_precision=2,
-                    icon="mdi:currency-eur",
+                    icon=ICON,
                     value_fn=lambda data, idx=i: _get_battery_summary(
                         data, idx, "total_result"
                     ),
@@ -5074,7 +5060,7 @@ def _build_aggregated_smart_batteries_descriptions() -> list[
                 device_class=SensorDeviceClass.MONETARY,
                 native_unit_of_measurement=CURRENCY_EURO,
                 suggested_display_precision=2,
-                icon="mdi:currency-eur",
+                icon=ICON,
                 value_fn=_get_total_result,
             ),
             FrankEnergieEntityDescription(

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -728,7 +728,7 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
         metadata = coordinator.get_pv_system_metadata(system_id)
         
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"pv_{system_id}")},
+            identifiers={(DOMAIN, system_id)},
             name=metadata["display_name"],
             manufacturer=metadata["brand"],
             model=metadata["model"],
@@ -738,9 +738,9 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
         # Make the unique id distinct for each panel group
         self._attr_unique_id = f"{DOMAIN}_{system_id}_panel_group_{panel_group_id}"
         self._attr_translation_key = "pv_panel_group"
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_device_class = SensorDeviceClass.POWER
+        self._attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -758,9 +758,9 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
 
     @property
     def native_value(self) -> StateType:
-        """Return the state of the sensor (annual yield)."""
+        """Return the state of the sensor (capacity_kwp)."""
         group = self._panel_group
-        return group.annual_kwh if group else None
+        return group.capacity_kwp if group else None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -707,6 +707,77 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
         return None
 
 
+class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEntity):
+    """Representation of a Frank Energie Smart PV panel group (dakvlak) sensor."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FrankEnergieCoordinator,
+        system_id: str,
+        panel_group_id: str,
+    ) -> None:
+        """Initialize the PV panel group sensor."""
+        super().__init__(coordinator)
+        self._system_id = system_id
+        self._panel_group_id = panel_group_id
+
+        # Get PV system metadata to link to the same device
+        metadata = coordinator.get_pv_system_metadata(system_id)
+        
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"pv_{system_id}")},
+            name=metadata["display_name"],
+            manufacturer=metadata["brand"],
+            model=metadata["model"],
+            serial_number=metadata["serial_number"],
+        )
+        
+        # Make the unique id distinct for each panel group
+        self._attr_unique_id = f"{DOMAIN}_{system_id}_panel_group_{panel_group_id}"
+        self._attr_translation_key = "pv_panel_group"
+        self._attr_device_class = SensorDeviceClass.ENERGY
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def _panel_group(self):
+        systems_obj = self.coordinator.data.get(DATA_PV_SYSTEMS)
+        if systems_obj and systems_obj.systems:
+            pv_system = next(
+                (s for s in systems_obj.systems if s.id == self._system_id), None
+            )
+            if pv_system and pv_system.panel_groups:
+                return next(
+                    (g for g in pv_system.panel_groups if g.id == self._panel_group_id), None
+                )
+        return None
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor (annual yield)."""
+        group = self._panel_group
+        return group.annual_kwh if group else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the extra state attributes."""
+        group = self._panel_group
+        if not group:
+            return {}
+        
+        return {
+            "azimuth": group.azimuth,
+            "tilt": group.tilt,
+            "capacity_kwp": group.capacity_kwp,
+            "panel_count": group.panel_count,
+            "position": group.position,
+        }
+
+
 def format_user_name(data: dict) -> str | None:
     """
     Formats the user's name from provided data by concatenating the first and last name.
@@ -5315,6 +5386,14 @@ async def async_setup_entry(
                         ),
                     ]
                 )
+                if system.panel_groups:
+                    for group in system.panel_groups:
+                        if group and group.id:
+                            entities.append(
+                                FrankEnergiePvPanelGroupSensor(
+                                    pv_coordinator, system.id, group.id
+                                )
+                            )
 
     try:
         async_add_entities(entities, update_before_add=True)

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -707,7 +707,9 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
         return None
 
 
-class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEntity):
+class FrankEnergiePvPanelGroupSensor(
+    CoordinatorEntity[FrankEnergieCoordinator], SensorEntity
+):
     """Representation of a Frank Energie Smart PV panel group (dakvlak) sensor."""
 
     _attr_should_poll = False
@@ -726,7 +728,7 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
 
         # Get PV system metadata to link to the same device
         metadata = coordinator.get_pv_system_metadata(system_id)
-        
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, system_id)},
             name=metadata["display_name"],
@@ -734,7 +736,7 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
             model=metadata["model"],
             serial_number=metadata["serial_number"],
         )
-        
+
         # Make the unique id distinct for each panel group
         self._attr_unique_id = f"{DOMAIN}_{system_id}_panel_group_{panel_group_id}"
         self._attr_translation_key = "pv_panel_group"
@@ -753,7 +755,8 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
             )
             if pv_system and pv_system.panel_groups:
                 return next(
-                    (g for g in pv_system.panel_groups if g.id == self._panel_group_id), None
+                    (g for g in pv_system.panel_groups if g.id == self._panel_group_id),
+                    None,
                 )
         return None
 
@@ -769,7 +772,7 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
         group = self._panel_group
         if not group:
             return {}
-        
+
         return {
             "azimuth": group.azimuth,
             "tilt": group.tilt,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1477,7 +1477,7 @@ def _get_period_trading_result(data: object | None) -> float | None:
         return None
     if getattr(data, "period_trading_result", None):
         return getattr(data, "period_trading_result")
-    
+
     sessions = getattr(data, "sessions", None) or []
     return sum(getattr(session, "result", 0) for session in sessions)
 
@@ -1488,7 +1488,7 @@ def _get_period_total_result(data: object | None) -> float | None:
         return None
     if getattr(data, "period_total_result", None):
         return getattr(data, "period_total_result")
-    
+
     return (
         (getattr(data, "period_epex_result", 0) or 0)
         + (getattr(data, "period_imbalance_result", 0) or 0)

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -738,6 +738,7 @@ class FrankEnergiePvPanelGroupSensor(CoordinatorEntity[FrankEnergieCoordinator],
         # Make the unique id distinct for each panel group
         self._attr_unique_id = f"{DOMAIN}_{system_id}_panel_group_{panel_group_id}"
         self._attr_translation_key = "pv_panel_group"
+        self._attr_icon = "mdi:solar-panel"
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
         self._attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1541,8 +1541,13 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         state_class="measurement",
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
         value_fn=lambda data: (
-            getattr(data, "period_trading_result", None)
-            if data and getattr(data, "period_trading_result", None) is not None
+            getattr(data, "period_trading_result")
+            if data and getattr(data, "period_trading_result", None)
+            else sum(
+                getattr(session, "result", 0)
+                for session in (getattr(data, "sessions", None) or [])
+            )
+            if data
             else None
         ),
     ),
@@ -1556,8 +1561,14 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         suggested_display_precision=2,
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
         value_fn=lambda data: (
-            getattr(data, "period_total_result", None)
-            if data and getattr(data, "period_total_result", None) is not None
+            getattr(data, "period_total_result")
+            if data and getattr(data, "period_total_result", None)
+            else (
+                (getattr(data, "period_epex_result", 0) or 0)
+                + (getattr(data, "period_imbalance_result", 0) or 0)
+                + (getattr(data, "period_frank_slim", 0) or 0)
+            )
+            if data
             else None
         ),
         attr_fn=lambda data: (
@@ -1632,7 +1643,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     ),
     FrankEnergieEntityDescription(
         key="daily_trading_result",
-        name="Daily Trading Result",
+        name="Yesterday's Trading Result",
         icon=ICON,
         native_unit_of_measurement=CURRENCY_EURO,
         suggested_display_precision=2,
@@ -1642,6 +1653,12 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
             sum(
                 getattr(session, "result", 0)
                 for session in (getattr(data, "sessions", None) or [])
+                if getattr(session, "date", None)
+                and _format_battery_date(session.date).date()
+                == (
+                    datetime.now(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
+                    - timedelta(days=1)
+                )
             )
             if data
             else None

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -684,6 +684,9 @@
       "pv_steering_status": {
         "name": "Steering status"
       },
+      "pv_panel_group": {
+        "name": "Panel Group"
+      },
       "pv_total_bonus": {
         "name": "Total bonus"
       },

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -687,6 +687,9 @@
       "pv_total_bonus": {
         "name": "Total bonus"
       },
+      "pv_total_result": {
+        "name": "Total result"
+      },
       "reference": {
         "name": "Reference"
       },
@@ -883,7 +886,7 @@
         "name": "Period Frank Slim Bonus"
       },
       "all_periods_trading_result": {
-        "name": "All Periods Trading Result"
+        "name": "Daily Trading Result"
       },
       "total_trading_result": {
         "name": "Total Trading Result"
@@ -930,6 +933,7 @@
           "status_standby": "Standby",
           "separate_imbalances": "Separate Imbalances",
           "idle_full": "Idle (Full)",
+          "idle_price": "Idle (Price)",
           "discharge_self_consumption": "Discharging (Self Consumption)",
           "discharge_imbalance": "Discharging (Imbalance)",
           "charge_imbalance": "Charging (Imbalance)",

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -888,7 +888,7 @@
       "period_frank_slim_bonus": {
         "name": "Period Frank Slim Bonus"
       },
-      "all_periods_trading_result": {
+      "daily_trading_result": {
         "name": "Daily Trading Result"
       },
       "total_trading_result": {

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -685,7 +685,7 @@
         "name": "Steering status"
       },
       "pv_panel_group": {
-        "name": "Panel Group"
+        "name": "Panel Group {position}"
       },
       "pv_total_bonus": {
         "name": "Total bonus"

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -889,7 +889,7 @@
         "name": "Period Frank Slim Bonus"
       },
       "daily_trading_result": {
-        "name": "Daily Trading Result"
+        "name": "Yesterday's Trading Result"
       },
       "total_trading_result": {
         "name": "Total Trading Result"

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -684,6 +684,9 @@
       "pv_steering_status": {
         "name": "Steering status"
       },
+      "pv_panel_group": {
+        "name": "Panel Group"
+      },
       "pv_total_bonus": {
         "name": "Total bonus"
       },

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -687,6 +687,9 @@
       "pv_total_bonus": {
         "name": "Total bonus"
       },
+      "pv_total_result": {
+        "name": "Total result"
+      },
       "reference": {
         "name": "Reference"
       },
@@ -883,7 +886,7 @@
         "name": "Period Frank Slim Bonus"
       },
       "all_periods_trading_result": {
-        "name": "All Periods Trading Result"
+        "name": "Daily Trading Result"
       },
       "total_trading_result": {
         "name": "Total Trading Result"
@@ -930,6 +933,7 @@
           "status_standby": "Standby",
           "separate_imbalances": "Separate Imbalances",
           "idle_full": "Idle (Full)",
+          "idle_price": "Idle (Price)",
           "discharge_self_consumption": "Discharging (Self Consumption)",
           "discharge_imbalance": "Discharging (Imbalance)",
           "charge_imbalance": "Charging (Imbalance)",

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -888,7 +888,7 @@
       "period_frank_slim_bonus": {
         "name": "Period Frank Slim Bonus"
       },
-      "all_periods_trading_result": {
+      "daily_trading_result": {
         "name": "Daily Trading Result"
       },
       "total_trading_result": {

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -685,7 +685,7 @@
         "name": "Steering status"
       },
       "pv_panel_group": {
-        "name": "Panel Group"
+        "name": "Panel Group {position}"
       },
       "pv_total_bonus": {
         "name": "Total bonus"

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -889,7 +889,7 @@
         "name": "Period Frank Slim Bonus"
       },
       "daily_trading_result": {
-        "name": "Daily Trading Result"
+        "name": "Yesterday's Trading Result"
       },
       "total_trading_result": {
         "name": "Total Trading Result"

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -541,7 +541,7 @@
         "name": "Naam voertuig"
       },
       "pv_panel_group": {
-        "name": "Dakvlak"
+        "name": "Dakvlak {position}"
       },
       "pv_total_bonus": {
         "name": "Totale bonus"

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -720,7 +720,7 @@
         "name": "Periode Frank Slim bonus"
       },
       "daily_trading_result": {
-        "name": "Dagelijks handelsresultaat"
+        "name": "Handelsresultaat van gisteren"
       },
       "total_trading_result": {
         "name": "Totaal handelsresultaat"

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -543,6 +543,9 @@
       "pv_total_bonus": {
         "name": "Totale bonus"
       },
+      "pv_total_result": {
+        "name": "Totaal resultaat"
+      },
       "pv_operational_status": {
         "name": "Operationele status"
       },
@@ -714,7 +717,7 @@
         "name": "Periode Frank Slim bonus"
       },
       "all_periods_trading_result": {
-        "name": "Alle periodes handelsresultaat"
+        "name": "Dagelijks handelsresultaat"
       },
       "total_trading_result": {
         "name": "Totaal handelsresultaat"
@@ -761,6 +764,7 @@
           "status_standby": "Stand-by",
           "separate_imbalances": "Gescheiden onbalansen",
           "idle_full": "Inactief (Vol)",
+          "idle_price": "Inactief (Prijs)",
           "discharge_self_consumption": "Ontladen (Zelfconsumptie)",
           "discharge_imbalance": "Ontladen (Onbalans)",
           "charge_imbalance": "Laden (Onbalans)",

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -719,7 +719,7 @@
       "period_frank_slim_bonus": {
         "name": "Periode Frank Slim bonus"
       },
-      "all_periods_trading_result": {
+      "daily_trading_result": {
         "name": "Dagelijks handelsresultaat"
       },
       "total_trading_result": {

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -540,6 +540,9 @@
       "vehicle_name": {
         "name": "Naam voertuig"
       },
+      "pv_panel_group": {
+        "name": "Dakvlak"
+      },
       "pv_total_bonus": {
         "name": "Totale bonus"
       },

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -541,7 +541,7 @@
         "name": "Naam voertuig"
       },
       "pv_panel_group": {
-        "name": "Dakvlak"
+        "name": "Dakvlak {position}"
       },
       "pv_total_bonus": {
         "name": "Totale bonus"

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -720,7 +720,7 @@
         "name": "Periode Frank Slim bonus"
       },
       "daily_trading_result": {
-        "name": "Dagelijks handelsresultaat"
+        "name": "Handelsresultaat van gisteren"
       },
       "total_trading_result": {
         "name": "Totaal handelsresultaat"

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -543,6 +543,9 @@
       "pv_total_bonus": {
         "name": "Totale bonus"
       },
+      "pv_total_result": {
+        "name": "Totaal resultaat"
+      },
       "pv_operational_status": {
         "name": "Operationele status"
       },
@@ -714,7 +717,7 @@
         "name": "Periode Frank Slim bonus"
       },
       "all_periods_trading_result": {
-        "name": "Alle periodes handelsresultaat"
+        "name": "Dagelijks handelsresultaat"
       },
       "total_trading_result": {
         "name": "Totaal handelsresultaat"
@@ -761,6 +764,7 @@
           "status_standby": "Stand-by",
           "separate_imbalances": "Gescheiden onbalansen",
           "idle_full": "Inactief (Vol)",
+          "idle_price": "Inactief (Prijs)",
           "discharge_self_consumption": "Ontladen (Zelfconsumptie)",
           "discharge_imbalance": "Ontladen (Onbalans)",
           "charge_imbalance": "Laden (Onbalans)",

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -719,7 +719,7 @@
       "period_frank_slim_bonus": {
         "name": "Periode Frank Slim bonus"
       },
-      "all_periods_trading_result": {
+      "daily_trading_result": {
         "name": "Dagelijks handelsresultaat"
       },
       "total_trading_result": {

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -540,6 +540,9 @@
       "vehicle_name": {
         "name": "Naam voertuig"
       },
+      "pv_panel_group": {
+        "name": "Dakvlak"
+      },
       "pv_total_bonus": {
         "name": "Totale bonus"
       },

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -224,6 +224,7 @@ def test_no_unused_or_missing_translation_keys():
         "pv_operational_status_timestamp",
         "pv_total_bonus",
         "pv_total_result",
+        "pv_panel_group",
     }
 
     # Verify that all translation keys in strings.json are used in the codebase

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -223,6 +223,7 @@ def test_no_unused_or_missing_translation_keys():
         "pv_operational_status",
         "pv_operational_status_timestamp",
         "pv_total_bonus",
+        "pv_total_result",
     }
 
     # Verify that all translation keys in strings.json are used in the codebase


### PR DESCRIPTION
# Summary
This PR introduces the new "Total Result" sensor for PV systems powered by recent changes in the upstream Python library, alongside new diagnostic sensors for PV Panel Groups (Dakvlakken). It also resolves a critical state mapping crash related to Smart Batteries, correctly renames a misleading trading result sensor, and tackles technical debt flagged by SonarCloud.

## Key Changes
- **New PV Panel Group Sensors**: Added dynamic diagnostic sensors for PV Panel Groups (Dakvlakken). Each panel group is exposed as a separate sensor (e.g., "Dakvlak 1", "Dakvlak 2") containing detailed metadata attributes (azimuth, tilt, capacity, panel count) linked to the main PV system device.
- **New PV Total Result Sensor**: Registers a new monetary sensor `pv_total_result` in `sensor.py` to provide users with their lifetime PV total result, powered by `SmartPvSystemSummary`.
- **Smart Battery Enum Bugfix**: Resolves a `ValueError` crash occurring when the API returned an unmapped state (`idle_price`) by formally registering `idle_price` in the sensor options and translation files.
- **Trading Result Sensor Rename**: Renamed the misleading `All Periods Trading Result` sensor to **`Daily Trading Result`** (`Dagelijks handelsresultaat`) to accurately reflect that the `SmartBatterySessions` backend aggregation operates strictly over the currently fetched daily window. 
- **Code Quality Refactoring**: Centralized the 29 smart battery status strings into a single `SMART_BATTERY_STATUSES` constant, and refactored the PV sensor setup to use a DRY `FrankEnergieEntityDescription` mapping to significantly reduce cognitive complexity.
- **Translation Suite Whitelist**: Added `pv_total_result` and `pv_panel_group` to the AST parsing `dynamic_whitelist` in `test_translations.py` to allow the test suite to pass with dynamically bound translation keys.

## Why this is needed
The unmapped `idle_price` battery state was causing an integration crash (`SensorDeviceClass.ENUM` validation error) during setup for affected smart batteries; explicitly defining this value stabilizes battery setups. The Daily Trading Result rename provides clear, transparent expectations for end users checking their daily savings. Finally, exposing the Dakvlakken gives users rich diagnostic metadata about their individual physical panel arrays directly in Home Assistant.

> [!IMPORTANT]
> **Dependency Requirement:** This integration update relies on the newest version of `python-frank-energie` (which includes `SmartPvSystemPanelGroup` and `total_result` capabilities). A manifest bump will be required after the python library is released to PyPI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new PV-related sensors, including panel-group details and overall PV totals.
  * Introduced a new battery status for “idle” price-based behavior.
  * Updated trading result wording to show a daily result instead of an all-periods result.

* **Bug Fixes**
  * Improved sensor handling so PV and smart battery values display more consistently when data is incomplete.

* **Translations**
  * Added and updated English and Dutch labels for the new PV sensors and battery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->