### PR TITLE
Fix battery status ValueErrors and trading result TypeError

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -111,6 +111,9 @@ SMART_BATTERY_STATUSES: Final[tuple[str, ...]] = (
     "charge_self_consumption_mixed",
     "status_maintenance",
     "status_error",
+    "discharge_smart_home",
+    "charge_smart_home",
+    "idle_smart_home",
 )
 
 # --- Data Fields ---

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1479,7 +1479,7 @@ def _get_period_trading_result(data: object | None) -> float | None:
         return getattr(data, "period_trading_result")
 
     sessions = getattr(data, "sessions", None) or []
-    return sum(getattr(session, "result", 0) for session in sessions)
+    return sum((getattr(session, "result", None) or 0.0) for session in sessions)
 
 
 def _get_period_total_result(data: object | None) -> float | None:
@@ -1653,7 +1653,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         value_fn=lambda data: (
             round(
                 sum(
-                    getattr(session, "result", 0)
+                    (getattr(session, "result", None) or 0.0)
                     for session in (getattr(data, "sessions", None) or [])
                     if getattr(session, "date", None)
                     and _format_battery_date(session.date).date()

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1471,6 +1471,16 @@ def _calculate_market_percent_tax(price_data: object | None) -> float | None:
     return None
 
 
+def _safe_session_result_sum(sessions: Any) -> float:
+    """Safely sum session results, explicitly handling None values."""
+    total = 0.0
+    for session in sessions:
+        res = getattr(session, "result", None)
+        if res is not None:
+            total += res
+    return total
+
+
 def _get_period_trading_result(data: object | None) -> float | None:
     """Calculate the period trading result."""
     if not data:
@@ -1479,7 +1489,7 @@ def _get_period_trading_result(data: object | None) -> float | None:
         return getattr(data, "period_trading_result")
 
     sessions = getattr(data, "sessions", None) or []
-    return sum((getattr(session, "result", None) or 0.0) for session in sessions)
+    return _safe_session_result_sum(sessions)
 
 
 def _get_period_total_result(data: object | None) -> float | None:
@@ -1652,8 +1662,8 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
         service_name=SERVICE_NAME_BATTERY_SESSIONS,
         value_fn=lambda data: (
             round(
-                sum(
-                    (getattr(session, "result", None) or 0.0)
+                _safe_session_result_sum(
+                    session
                     for session in (getattr(data, "sessions", None) or [])
                     if getattr(session, "date", None)
                     and _format_battery_date(session.date).date()

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -956,7 +956,10 @@
           "charge_self_consumption": "Charging (Self Consumption)",
           "charge_self_consumption_mixed": "Charging (Self Consumption Mixed)",
           "status_maintenance": "Maintenance",
-          "status_error": "Error"
+          "status_error": "Error",
+          "discharge_smart_home": "Discharging (Smart Home)",
+          "charge_smart_home": "Charging (Smart Home)",
+          "idle_smart_home": "Idle (Smart Home)"
         }
       }
     }

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -956,7 +956,10 @@
           "charge_self_consumption": "Charging (Self Consumption)",
           "charge_self_consumption_mixed": "Charging (Self Consumption Mixed)",
           "status_maintenance": "Maintenance",
-          "status_error": "Error"
+          "status_error": "Error",
+          "discharge_smart_home": "Discharging (Smart Home)",
+          "charge_smart_home": "Charging (Smart Home)",
+          "idle_smart_home": "Idle (Smart Home)"
         }
       }
     }

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -787,7 +787,10 @@
           "charge_self_consumption": "Laden (Zelfconsumptie)",
           "charge_self_consumption_mixed": "Laden (Zelfconsumptie Gemengd)",
           "status_maintenance": "Onderhoud",
-          "status_error": "Fout"
+          "status_error": "Fout",
+          "discharge_smart_home": "Ontladen (Smart Home)",
+          "charge_smart_home": "Laden (Smart Home)",
+          "idle_smart_home": "Inactief (Smart Home)"
         }
       }
     },

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -787,7 +787,10 @@
           "charge_self_consumption": "Laden (Zelfconsumptie)",
           "charge_self_consumption_mixed": "Laden (Zelfconsumptie Gemengd)",
           "status_maintenance": "Onderhoud",
-          "status_error": "Fout"
+          "status_error": "Fout",
+          "discharge_smart_home": "Ontladen (Smart Home)",
+          "charge_smart_home": "Laden (Smart Home)",
+          "idle_smart_home": "Inactief (Smart Home)"
         }
       }
     },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -671,22 +671,22 @@ def test_safe_session_result_sum():
 
     # Test with normal values
     sessions = [DummySession(1.5), DummySession(2.5)]
-    assert _safe_session_result_sum(sessions) == 4.0
+    assert _safe_session_result_sum(sessions) == pytest.approx(4.0)
 
     # Test with None values
     sessions = [DummySession(1.5), DummySession(None), DummySession(2.5)]
-    assert _safe_session_result_sum(sessions) == 4.0
+    assert _safe_session_result_sum(sessions) == pytest.approx(4.0)
 
     # Test with 0.0 values
     sessions = [DummySession(0.0), DummySession(0)]
-    assert _safe_session_result_sum(sessions) == 0.0
+    assert _safe_session_result_sum(sessions) == pytest.approx(0.0)
 
     # Test with missing result attribute (should default to None safely)
     class MissingResultSession:
         pass
 
     sessions = [DummySession(1.5), MissingResultSession()]
-    assert _safe_session_result_sum(sessions) == 1.5
+    assert _safe_session_result_sum(sessions) == pytest.approx(1.5)
 
     # Test empty
-    assert _safe_session_result_sum([]) == 0.0
+    assert _safe_session_result_sum([]) == pytest.approx(0.0)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -659,3 +659,34 @@ def test_calculate_market_percent_tax() -> None:
     price_data_all_zero.all = [zero_hour, zero_hour]
 
     assert _calculate_market_percent_tax(price_data_all_zero) == 0.0
+
+
+def test_safe_session_result_sum():
+    """Test that _safe_session_result_sum handles None and values correctly."""
+    from custom_components.frank_energie.sensor import _safe_session_result_sum
+
+    class DummySession:
+        def __init__(self, result):
+            self.result = result
+
+    # Test with normal values
+    sessions = [DummySession(1.5), DummySession(2.5)]
+    assert _safe_session_result_sum(sessions) == 4.0
+
+    # Test with None values
+    sessions = [DummySession(1.5), DummySession(None), DummySession(2.5)]
+    assert _safe_session_result_sum(sessions) == 4.0
+
+    # Test with 0.0 values
+    sessions = [DummySession(0.0), DummySession(0)]
+    assert _safe_session_result_sum(sessions) == 0.0
+
+    # Test with missing result attribute (should default to None safely)
+    class MissingResultSession:
+        pass
+
+    sessions = [DummySession(1.5), MissingResultSession()]
+    assert _safe_session_result_sum(sessions) == 1.5
+
+    # Test empty
+    assert _safe_session_result_sum([]) == 0.0


### PR DESCRIPTION
### Summary
Resolves several edge-case `ValueError` and `TypeError` exceptions caused by unexpected `None` values and missing ENUM options during data processing for smart batteries.

### Key Changes
- **Missing Enums**: Added `charge_smart_home`, `discharge_smart_home`, and `idle_smart_home` to the `SMART_BATTERY_STATUSES` enum in `custom_components/frank_energie/const.py`, along with their corresponding localization strings in English, Dutch, and Belgian Dutch.
- **Type Guard for Trading Results**: Updated `_get_period_trading_result` in `sensor.py` and the `daily_trading_result` sensor to safely handle `None` values in a session's `result` by falling back to `0.0` before calculating their total sum, preventing a `TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`.

### Why this is needed
1. When the upstream API provides an unmapped battery state (like `discharge_smart_home`), Home Assistant raises a `ValueError` for violating the `options` constraints on the sensor entity. Defining these options prevents these update failures.
2. The `period_trading_result` and `daily_trading_result` calculations were attempting to add a float to `NoneType` if any session lacked a valid result, causing the coordinator to throw a `TypeError`. Providing a default float prevents this unhandled exception and ensures the sensors continue to update gracefully.

## Summary by Sourcery

Afhandelen van randgevallen in de status van de slimme batterij en handelsresultaten om runtime-fouten te voorkomen.

Bugfixes:
- Voorkom een `ValueError` wanneer de slimme batterij eerder niet-toegewezen slimme huis laad-/ontlaad-/idle-statussen rapporteert door deze toe te voegen aan de statusopties.
- Voorkom een `TypeError` in periode- en dagelijkse handelsresultaatberekeningen door ontbrekende of `None` sessieresultaten als `0.0` te behandelen vóór het sommeren.

Verbeteringen:
- Breid `SMART_BATTERY_STATUSES` en de bijbehorende vertalingen uit om nieuwe slimme huis laad-/ontlaad-/idle-statussen te ondersteunen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle smart battery status and trading result edge cases to prevent runtime errors.

Bug Fixes:
- Prevent ValueError when smart battery reports previously unmapped smart home charge/discharge/idle states by adding them to the status options.
- Avoid TypeError in period and daily trading result calculations by treating missing or None session results as 0.0 before summing.

Enhancements:
- Extend SMART_BATTERY_STATUSES and corresponding translations to support new smart home charge/discharge/idle states.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new battery status values for Smart Home charging behavior: discharge, charge, and idle.
  * These new statuses are now available in both English and Dutch translations.

* **Bug Fixes**
  * Improved trading result calculations so missing session values are handled consistently as zero, helping prevent incorrect totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->