### PR TITLE
Allow local price resolution fallback for unavailable connectionId

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -103,7 +103,7 @@ from .const import (
     DEFAULT_INTERVAL_VEHICLES,
     DEFAULT_INTERVAL_PV,
 )
-from .helpers import decrypt_password
+from .helpers import decrypt_password, get_connection_id
 from .mutation_queue import MutationQueue
 
 _LOGGER = logging.getLogger(__name__)
@@ -1051,9 +1051,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     if country_code in {"NL", "BE"}:
                         self._country_code = country_code
             if not self._connection_id and user_data and user_data.connections:
-                connection = user_data.connections[0]
-
-                if connection_id := connection.get("connectionId"):
+                if connection_id := get_connection_id(user_data.connections):
                     self._connection_id = connection_id
 
             return user_data
@@ -2198,14 +2196,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
     async def async_set_resolution(self, value: str) -> None:
         """Update resolution safely via mutation queue."""
-        if not self.api.is_authenticated:
+        if not self.api.is_authenticated or not self._connection_id:
             if self.config_entry is not None:
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
                     options={**self.config_entry.options, "resolution": value},
                 )
                 _LOGGER.debug(
-                    "Resolution saved to options (not authenticated): %s -> options=%s",
+                    "Resolution saved to options (API sync bypassed): %s -> options=%s",
                     value,
                     self.config_entry.options,
                 )
@@ -2215,12 +2213,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 self.cached_prices_tomorrow = None
                 self.last_fetch_tomorrow = None
                 await self.async_request_refresh()
-            return
 
-        if not self._connection_id:
-            _LOGGER.warning(
-                "Cannot set resolution via API: connection_id not available"
-            )
+            if self.api.is_authenticated and not self._connection_id:
+                _LOGGER.warning(
+                    "Resolution updated locally but could not sync with API: connection_id not available"
+                )
             return
 
         if (
@@ -2577,11 +2574,8 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         connection_id = None
         user_data = self.settings_coordinator.data.get(DATA_USER)
         if user_data and user_data.connections:
-            connection = user_data.connections[0]
-            if isinstance(connection, dict):
-                connection_id = connection.get("connectionId")
-            else:
-                connection_id = getattr(connection, "connectionId", None)
+            if cid := get_connection_id(user_data.connections):
+                connection_id = cid
 
             self._connection_id = connection_id
 

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final
 
 from cryptography.fernet import Fernet  # type: ignore[import]
 from homeassistant.core import HomeAssistant
+from typing import Any
 
 from .const import (
     DOMAIN,
@@ -46,6 +47,24 @@ def resolve_gas_unit(per_unit: str | None) -> str:
         return UNIT_GAS_NL
 
     return unit
+
+
+def get_connection_id(connections: list[Any]) -> str | None:
+    """Extract a valid connectionId from a list of connection objects.
+
+    Supports both legacy dict structures and newer python-frank-energie
+    Connection models to ensure robust parsing across API versions.
+    """
+    for connection in connections:
+        if isinstance(connection, dict):
+            cid = connection.get("connectionId")
+        else:
+            cid = getattr(connection, "connectionId", None)
+
+        if cid:
+            return str(cid)
+
+    return None
 
 
 def build_charge_settings_input(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -711,13 +711,17 @@ class TestAsyncSetResolution:
     """Tests for the new async_set_resolution method."""
 
     @pytest.mark.asyncio
-    async def test_raises_update_failed_when_no_connection_id(self, coordinator):
-        """Must return early without raising when _connection_id is None."""
+    async def test_updates_locally_when_no_connection_id(self, coordinator):
+        """Must bypass API sync and update locally when _connection_id is None."""
         coordinator._connection_id = None
         coordinator.async_request_refresh = AsyncMock()
 
         await coordinator.async_set_resolution("PT15M")
-        coordinator.async_request_refresh.assert_not_called()
+        coordinator.async_request_refresh.assert_awaited_once()
+        coordinator.hass.config_entries.async_update_entry.assert_called_once_with(
+            coordinator.config_entry,
+            options={**coordinator.config_entry.options, "resolution": "PT15M"},
+        )
 
     @pytest.mark.asyncio
     async def test_raises_update_failed_when_api_returns_none(
@@ -841,15 +845,6 @@ class TestAsyncSetResolution:
 
         await coordinator.async_set_resolution("PT15M")
         coordinator.async_request_refresh.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_refresh_not_called_when_connection_id_is_none(self, coordinator):
-        """async_request_refresh must NOT be called when _connection_id is None."""
-        coordinator._connection_id = None
-        coordinator.async_request_refresh = AsyncMock()
-
-        await coordinator.async_set_resolution("PT15M")
-        coordinator.async_request_refresh.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_error_message_contains_reason_when_result_fails(


### PR DESCRIPTION
### Summary
Fixes a UI lockup where some users could not change their price resolution setting in Home Assistant.

### Key Changes
- Modified `_fetch_user_data` to iterate through all active connections to reliably locate `connectionId` (rather than just checking `connections[0]`, which could be a secondary service like Gas).
- Applied the identical safe iteration logic to `FrankEnergiePricesCoordinator` to prevent a missing `connectionId` from silently failing market price fetch routines.
- Modified `async_set_resolution` to allow local updating of the resolution setting when `connectionId` is missing completely (e.g. legacy/non-dynamic contracts or inactive contracts).

### Why this is needed
Previously, if a user lacked a backend `connectionId` on their primary connection, the API sync step would hard abort, preventing the local config option from ever being updated. This allows these users to gracefully toggle their resolution setting within Home Assistant for viewing prices, bypassing the backend sync requirement.

Fixes #209

## Summary by Sourcery

Verbeter de robuustheid van de afhandeling van prijsresolutie wanneer een backend-`connectionId` ontbreekt, zodat gebruikers de resolutie nog steeds kunnen aanpassen en prijzen blijven vernieuwen.

Bugfixes:
- Zorg ervoor dat `connectionId` wordt afgeleid van elke beschikbare gebruikersverbinding in plaats van alleen de eerste, om fouten te voorkomen wanneer de primaire verbinding geen ID heeft.
- Voorkom dat marktprijsupdates stilletjes mislukken door `connectionId` veilig te bepalen op basis van alle beschikbare verbindingen.
- Sta toe dat wijzigingen in prijsresolutie lokaal worden opgeslagen en een refresh triggeren, zelfs wanneer `connectionId` niet beschikbaar is, zodat UI-verstoppingen worden vermeden.

Verbeteringen:
- Verfijn logging rond resolutie-updates om te verduidelijken wanneer API-synchronisatie wordt overgeslagen vanwege een ontbrekende `connectionId`.

Tests:
- Werk `async_set_resolution`-tests bij zodat ze lokale-only resolutie-updates dekken en de beperking verwijderen die refreshes blokkeerde wanneer `connectionId` ontbrak.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of price resolution handling when a backend connectionId is missing so users can still adjust resolution and prices continue to update.

Bug Fixes:
- Ensure connectionId is derived from any available user connection instead of only the first, preventing failures when the primary connection lacks an ID.
- Prevent market price updates from silently failing by safely resolving connectionId from all available connections.
- Allow price resolution changes to be persisted locally and trigger refreshes even when connectionId is unavailable, avoiding UI lockups.

Enhancements:
- Refine logging around resolution updates to clarify when API sync is bypassed due to missing connectionId.

Tests:
- Update async_set_resolution tests to cover local-only resolution updates and removal of the constraint that blocked refreshes when connectionId was missing.

</details>