### PR TITLE
Enforce strict connectionId and ensure resolution select availability

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2622,7 +2622,8 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             self._tomorrow_prices_logged = False
 
         user_data = self.settings_coordinator.data.get(DATA_USER)
-        self._connection_id = _extract_electricity_connection_id(user_data)
+        if extracted_conn_id := _extract_electricity_connection_id(user_data):
+            self._connection_id = extracted_conn_id
 
         if skip_api_calls:
             _LOGGER.debug("Skipping price API calls during maintenance window")

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2244,6 +2244,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             return
 
+        if self._resolution_change_pending:
+            _LOGGER.warning("Cannot set resolution: a change is already pending")
+            return
+
         if (
             self._api_resolution_state is not None
             and not self._api_resolution_state.isChangeRequestPossible
@@ -2253,53 +2257,69 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             return
 
+        self._resolution_change_pending = True
+
         async def _mutation() -> None:
-            result = await self.api.contract_price_resolution_request_change(
-                self._connection_id,
-                cast(Resolution, value),
-            )
-
-            if result is None:
-                raise UpdateFailed("Resolution change request failed: no response")
-
-            if not result.success:
-                if result.reason == "CHANGE_NOT_POSSIBLE":
-                    _LOGGER.warning(
-                        "Resolution change not possible at this time "
-                        "(contract does not allow changes or cooling-off period active)"
-                    )
-                    async_create(
-                        self.hass,
-                        message=(
-                            "Resolution change is not possible at this time. "
-                            "Your contract may not allow changes or a cooling-off period is active. "
-                            f"Upcoming change: {self._api_resolution_state.upcomingChange if self._api_resolution_state else 'unknown'} "
-                            f"(effective: {self._api_resolution_state.upcomingChangeEffectiveDate if self._api_resolution_state else 'unknown'})"
-                        ),
-                        title="Frank Energie - Resolution Change Failed",
-                        notification_id="frank_energie_resolution_change_failed",
-                    )
-                    return  # not an error, just not allowed right now
-                raise UpdateFailed(
-                    "Resolution change request failed: %s" % (result.reason)
+            try:
+                result = await self.api.contract_price_resolution_request_change(
+                    self._connection_id,
+                    cast(Resolution, value),
                 )
 
-            _LOGGER.info(
-                "Resolution change accepted (effective: %s)",
-                result.data.effectiveDate if result.data else "unknown",
-            )
-            self._resolution_change_pending = (
-                True  # disable select until change is effective
-            )
+                if result is None:
+                    raise UpdateFailed("Resolution change request failed: no response")
 
-            if self.config_entry is None:
-                return
+                if not result.success:
+                    if result.reason == "CHANGE_NOT_POSSIBLE":
+                        _LOGGER.warning(
+                            "Resolution change not possible at this time "
+                            "(contract does not allow changes or cooling-off period active)"
+                        )
+                        async_create(
+                            self.hass,
+                            message=(
+                                "Resolution change is not possible at this time. "
+                                "Your contract may not allow changes or a cooling-off period is active. "
+                                f"Upcoming change: {self._api_resolution_state.upcomingChange if self._api_resolution_state else 'unknown'} "
+                                f"(effective: {self._api_resolution_state.upcomingChangeEffectiveDate if self._api_resolution_state else 'unknown'})"
+                            ),
+                            title="Frank Energie - Resolution Change Failed",
+                            notification_id="frank_energie_resolution_change_failed",
+                        )
+                        return  # not an error, just not allowed right now
+                    raise UpdateFailed(
+                        "Resolution change request failed: %s" % (result.reason)
+                    )
 
-            if self.config_entry.options.get("resolution") != value:
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    options={**self.config_entry.options, "resolution": value},
+                _LOGGER.info(
+                    "Resolution change accepted (effective: %s)",
+                    result.data.effectiveDate if result.data else "unknown",
                 )
+
+                if self.config_entry is None:
+                    return
+
+                if self.config_entry.options.get("resolution") != value:
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        options={**self.config_entry.options, "resolution": value},
+                    )
+
+                # Re-fetch resolution state to update our internal tracker immediately
+                try:
+                    state = await self._fetch_contract_price_resolution_state(
+                        self._connection_id
+                    )
+                    if state:
+                        self.data[DATA_CONTRACT_PRICE_RESOLUTION_STATE] = state
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Failed to re-fetch resolution state after successful change: %s",
+                        err,
+                    )
+
+            finally:
+                self._resolution_change_pending = False
 
         await self._mutation_queue.add(_mutation)
         await self.async_request_refresh()
@@ -2506,7 +2526,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     )
                     self._api_resolution_state = data_contract_price_resolution_state
                     self._resolution_change_pending = (
-                        data_contract_price_resolution_state.hasUpcomingChange
+                        bool(data_contract_price_resolution_state.upcoming_change)
                         if data_contract_price_resolution_state
                         else False
                     )

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1051,10 +1051,17 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     if country_code in {"NL", "BE"}:
                         self._country_code = country_code
             if not self._connection_id and user_data and user_data.connections:
-                connection = user_data.connections[0]
+                for connection in user_data.connections:
+                    if isinstance(connection, dict):
+                        cid = connection.get("connectionId")
+                        segment = connection.get("segment")
+                    else:
+                        cid = getattr(connection, "connectionId", None)
+                        segment = getattr(connection, "segment", None)
 
-                if connection_id := connection.get("connectionId"):
-                    self._connection_id = connection_id
+                    if cid and segment == "ELECTRICITY":
+                        self._connection_id = str(cid)
+                        break
 
             return user_data
         except AuthException as ex:
@@ -2206,7 +2213,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     options={**self.config_entry.options, "resolution": value},
                 )
                 _LOGGER.debug(
-                    "Resolution saved to options (not authenticated): %s -> options=%s",
+                    "Resolution saved to options (unauthenticated API): %s -> options=%s",
                     value,
                     self.config_entry.options,
                 )
@@ -2219,8 +2226,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return
 
         if not self._connection_id:
-            _LOGGER.warning(
-                "Cannot set resolution via API: connection_id not available"
+            _LOGGER.error(
+                "Cannot set resolution via API: electricity connection_id not available"
             )
             return
 
@@ -2484,6 +2491,12 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     self._static_contract_price_resolution_state = (
                         data_contract_price_resolution_state
                     )
+                    self._api_resolution_state = data_contract_price_resolution_state
+                    self._resolution_change_pending = (
+                        data_contract_price_resolution_state.hasUpcomingChange
+                        if data_contract_price_resolution_state
+                        else False
+                    )
 
                 if last_fetch_today_str := cached_data.get("last_fetch_today"):
                     self.last_fetch_today = dt_util.parse_datetime(last_fetch_today_str)
@@ -2578,11 +2591,17 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         connection_id = None
         user_data = self.settings_coordinator.data.get(DATA_USER)
         if user_data and user_data.connections:
-            connection = user_data.connections[0]
-            if isinstance(connection, dict):
-                connection_id = connection.get("connectionId")
-            else:
-                connection_id = getattr(connection, "connectionId", None)
+            for connection in user_data.connections:
+                if isinstance(connection, dict):
+                    cid = connection.get("connectionId")
+                    segment = connection.get("segment")
+                else:
+                    cid = getattr(connection, "connectionId", None)
+                    segment = getattr(connection, "segment", None)
+
+                if cid and segment == "ELECTRICITY":
+                    connection_id = str(cid)
+                    break
 
             self._connection_id = connection_id
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -213,6 +213,29 @@ def _dict_to_resolution_state(data: dict[str, Any]) -> ContractPriceResolutionSt
     return state
 
 
+def _extract_electricity_connection_id(user_data: Any) -> str | None:
+    """Extract the ELECTRICITY connection ID from user data."""
+    if not user_data or not getattr(user_data, "connections", None):
+        return None
+
+    for connection in user_data.connections:
+        if isinstance(connection, dict):
+            cid = connection.get("connectionId")
+            segment = connection.get("segment")
+        else:
+            cid = getattr(connection, "connectionId", None)
+            segment = getattr(connection, "segment", None)
+
+        if cid and segment == "ELECTRICITY":
+            return str(cid)
+
+    _LOGGER.debug(
+        "No ELECTRICITY segment connection found in user data. "
+        "Resolution changes are only supported for electricity."
+    )
+    return None
+
+
 if sys.platform == "win32" and hasattr(asyncio, "set_event_loop_policy"):
     # Python 3.14-3.16
     try:
@@ -1050,18 +1073,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                     country_code = country_code_raw.upper()
                     if country_code in {"NL", "BE"}:
                         self._country_code = country_code
-            if not self._connection_id and user_data and user_data.connections:
-                for connection in user_data.connections:
-                    if isinstance(connection, dict):
-                        cid = connection.get("connectionId")
-                        segment = connection.get("segment")
-                    else:
-                        cid = getattr(connection, "connectionId", None)
-                        segment = getattr(connection, "segment", None)
-
-                    if cid and segment == "ELECTRICITY":
-                        self._connection_id = str(cid)
-                        break
+            if not self._connection_id:
+                self._connection_id = _extract_electricity_connection_id(user_data)
 
             return user_data
         except AuthException as ex:
@@ -2588,22 +2601,8 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         if self.last_fetch_tomorrow is None or self.last_fetch_tomorrow.date() != today:
             self._tomorrow_prices_logged = False
 
-        connection_id = None
         user_data = self.settings_coordinator.data.get(DATA_USER)
-        if user_data and user_data.connections:
-            for connection in user_data.connections:
-                if isinstance(connection, dict):
-                    cid = connection.get("connectionId")
-                    segment = connection.get("segment")
-                else:
-                    cid = getattr(connection, "connectionId", None)
-                    segment = getattr(connection, "segment", None)
-
-                if cid and segment == "ELECTRICITY":
-                    connection_id = str(cid)
-                    break
-
-            self._connection_id = connection_id
+        self._connection_id = _extract_electricity_connection_id(user_data)
 
         if skip_api_calls:
             _LOGGER.debug("Skipping price API calls during maintenance window")
@@ -2649,7 +2648,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                 prices_today = self._static_prices_today
 
             data_contract_price_resolution_state = (
-                await self._fetch_contract_price_resolution_state(connection_id)
+                await self._fetch_contract_price_resolution_state(self._connection_id)
             )
             self._static_contract_price_resolution_state = (
                 data_contract_price_resolution_state

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2526,7 +2526,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                     )
                     self._api_resolution_state = data_contract_price_resolution_state
                     self._resolution_change_pending = (
-                        bool(data_contract_price_resolution_state.upcoming_change)
+                        bool(data_contract_price_resolution_state.upcomingChange)
                         if data_contract_price_resolution_state
                         else False
                     )

--- a/custom_components/frank_energie/select.py
+++ b/custom_components/frank_energie/select.py
@@ -154,6 +154,18 @@ class FrankEnergieResolutionSelect(CoordinatorEntity, SelectEntity):
         )
 
     @property
+    def available(self) -> bool:
+        """Return False when a resolution change is not currently possible."""
+        if not self.coordinator.api.is_authenticated:
+            return True
+        if getattr(self.coordinator, "_resolution_change_pending", False):
+            return False
+        state = getattr(self.coordinator, "_api_resolution_state", None)
+        if state is None:
+            return True  # unknown, allow optimistically
+        return state.is_change_request_possible
+
+    @property
     def extra_state_attributes(self) -> dict:
         api = getattr(self.coordinator, "api_resolution", None)
         state = getattr(self.coordinator, "_api_resolution_state", None)

--- a/custom_components/frank_energie/select.py
+++ b/custom_components/frank_energie/select.py
@@ -153,17 +153,7 @@ class FrankEnergieResolutionSelect(CoordinatorEntity, SelectEntity):
             entry_type=DeviceEntryType.SERVICE,
         )
 
-    @property
-    def available(self) -> bool:
-        """Return False when a resolution change is not currently possible."""
-        if not self.coordinator.api.is_authenticated:
-            return True
-        if getattr(self.coordinator, "_resolution_change_pending", False):
-            return False
-        state = getattr(self.coordinator, "_api_resolution_state", None)
-        if state is None:
-            return True  # unknown, allow optimistically
-        return state.isChangeRequestPossible
+
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/frank_energie/select.py
+++ b/custom_components/frank_energie/select.py
@@ -156,6 +156,8 @@ class FrankEnergieResolutionSelect(CoordinatorEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return False when a resolution change is not currently possible."""
+        if not super().available:
+            return False
         if not self.coordinator.api.is_authenticated:
             return True
         if getattr(self.coordinator, "_resolution_change_pending", False):

--- a/custom_components/frank_energie/select.py
+++ b/custom_components/frank_energie/select.py
@@ -153,8 +153,6 @@ class FrankEnergieResolutionSelect(CoordinatorEntity, SelectEntity):
             entry_type=DeviceEntryType.SERVICE,
         )
 
-
-
     @property
     def extra_state_attributes(self) -> dict:
         api = getattr(self.coordinator, "api_resolution", None)

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1768,12 +1768,12 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
             and data[DATA_CONTRACT_PRICE_RESOLUTION_STATE].active_option
             else STATE_UNKNOWN
         ),
-        available_fn=lambda data: data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE) is not None,
+        available_fn=lambda data: (
+            data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE) is not None
+        ),
         attr_fn=lambda data: (
             {
-                "available_options": [
-                    opt.lower() for opt in state.available_options
-                ]
+                "available_options": [opt.lower() for opt in state.available_options]
                 if state.available_options
                 else None,
                 "change_request_effective_date": state.change_request_effective_date,

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -301,6 +301,7 @@ class FrankEnergieEntityDescription(
     # Function to extract the sensor value from the coordinator's data
     value_fn: Callable[[_DataT], StateType] = lambda _: STATE_UNKNOWN
     attr_fn: Callable[[_DataT], dict[str, object]] = lambda _: {}
+    available_fn: Callable[[_DataT], bool] | None = None
 
     # Flags for filtering
     is_gas: bool = False
@@ -630,6 +631,8 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
         try:
             if self.coordinator.data is not None:
                 value = self.native_value
+                if self.entity_description.available_fn is not None:
+                    return self.entity_description.available_fn(self.coordinator.data)
         except (KeyError, AttributeError, TypeError) as err:
             _LOGGER.debug(
                 "Availability check failed for %s: %s",
@@ -1763,25 +1766,22 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
             data[DATA_CONTRACT_PRICE_RESOLUTION_STATE].active_option.lower()
             if data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE)
             and data[DATA_CONTRACT_PRICE_RESOLUTION_STATE].active_option
-            else None
+            else STATE_UNKNOWN
         ),
+        available_fn=lambda data: data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE) is not None,
         attr_fn=lambda data: (
             {
-                key: value
-                for key, value in {
-                    "available_options": [
-                        opt.lower() for opt in state.available_options
-                    ]
-                    if state.available_options
-                    else None,
-                    "change_request_effective_date": state.change_request_effective_date,
-                    "is_change_request_possible": state.is_change_request_possible,
-                    "upcoming_change": state.upcoming_change.lower()
-                    if state.upcoming_change
-                    else None,
-                    "upcoming_change_effective_date": state.upcoming_change_effective_date,
-                }.items()
-                if value is not None
+                "available_options": [
+                    opt.lower() for opt in state.available_options
+                ]
+                if state.available_options
+                else None,
+                "change_request_effective_date": state.change_request_effective_date,
+                "is_change_request_possible": state.is_change_request_possible,
+                "upcoming_change": state.upcoming_change.lower()
+                if state.upcoming_change
+                else None,
+                "upcoming_change_effective_date": state.upcoming_change_effective_date,
             }
             if (state := data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE))
             else {}

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -628,6 +628,8 @@ class EnodeVehicleSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return True if the sensor value is valid."""
+        if not super().available:
+            return False
         try:
             if self.coordinator.data is not None:
                 value = self.native_value

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1753,6 +1753,29 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
     ),
 )
 
+
+def _get_price_resolution_attributes(data: dict) -> dict:
+    state = data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE)
+    if not state:
+        return {}
+
+    available_opts = None
+    if state.available_options:
+        available_opts = [opt.lower() for opt in state.available_options]
+
+    upcoming = None
+    if state.upcoming_change:
+        upcoming = state.upcoming_change.lower()
+
+    return {
+        "available_options": available_opts,
+        "change_request_effective_date": state.change_request_effective_date,
+        "is_change_request_possible": state.is_change_request_possible,
+        "upcoming_change": upcoming,
+        "upcoming_change_effective_date": state.upcoming_change_effective_date,
+    }
+
+
 SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
     FrankEnergieEntityDescription(
         key="contract_price_resolution_state",
@@ -1773,21 +1796,7 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         available_fn=lambda data: (
             data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE) is not None
         ),
-        attr_fn=lambda data: (
-            {
-                "available_options": [opt.lower() for opt in state.available_options]
-                if state.available_options
-                else None,
-                "change_request_effective_date": state.change_request_effective_date,
-                "is_change_request_possible": state.is_change_request_possible,
-                "upcoming_change": state.upcoming_change.lower()
-                if state.upcoming_change
-                else None,
-                "upcoming_change_effective_date": state.upcoming_change_effective_date,
-            }
-            if (state := data.get(DATA_CONTRACT_PRICE_RESOLUTION_STATE))
-            else {}
-        ),
+        attr_fn=_get_price_resolution_attributes,
     ),
     FrankEnergieEntityDescription(
         key="elec_markup",

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -358,28 +358,31 @@
         },
         "state_attributes": {
           "available_options": {
-            "name": "Contract Price Resolution State",
+            "name": "Available options",
             "state": {
               "pt15m": "15 minutes",
               "pt60m": "60 minutes"
             }
           },
+          "change_request_effective_date": {
+            "name": "Change request effective date"
+          },
           "is_change_request_possible": {
-            "name": "Contract Price Resolution State",
+            "name": "Change possible",
             "state": {
               "false": "No",
               "true": "Yes"
             }
           },
           "upcoming_change": {
-            "name": "Contract Price Resolution State",
+            "name": "Upcoming change",
             "state": {
               "pt15m": "15 minutes",
               "pt60m": "60 minutes"
             }
           },
           "upcoming_change_effective_date": {
-            "name": "Contract Price Resolution State"
+            "name": "Upcoming change effective date"
           }
         }
       },

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -358,28 +358,31 @@
         },
         "state_attributes": {
           "available_options": {
-            "name": "Contract Price Resolution State",
+            "name": "Available options",
             "state": {
               "pt15m": "15 minutes",
               "pt60m": "60 minutes"
             }
           },
+          "change_request_effective_date": {
+            "name": "Change request effective date"
+          },
           "is_change_request_possible": {
-            "name": "Contract Price Resolution State",
+            "name": "Change possible",
             "state": {
               "false": "No",
               "true": "Yes"
             }
           },
           "upcoming_change": {
-            "name": "Contract Price Resolution State",
+            "name": "Upcoming change",
             "state": {
               "pt15m": "15 minutes",
               "pt60m": "60 minutes"
             }
           },
           "upcoming_change_effective_date": {
-            "name": "Contract Price Resolution State"
+            "name": "Upcoming change effective date"
           }
         }
       },

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -394,28 +394,31 @@
         },
         "state_attributes": {
           "available_options": {
-            "name": "Contract prijsresolutie status",
+            "name": "Beschikbare opties",
             "state": {
               "pt15m": "15 minuten",
               "pt60m": "60 minuten"
             }
           },
+          "change_request_effective_date": {
+            "name": "Aangevraagde wijziging ingangsdatum"
+          },
           "is_change_request_possible": {
-            "name": "Contract prijsresolutie status",
+            "name": "Wijziging mogelijk",
             "state": {
               "false": "Nee",
               "true": "Ja"
             }
           },
           "upcoming_change": {
-            "name": "Contract prijsresolutie status",
+            "name": "Aankomende wijziging",
             "state": {
               "pt15m": "15 minuten",
               "pt60m": "60 minuten"
             }
           },
           "upcoming_change_effective_date": {
-            "name": "Contract prijsresolutie status"
+            "name": "Aankomende wijziging ingangsdatum"
           }
         }
       },

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -400,22 +400,25 @@
               "pt60m": "60 minuten"
             }
           },
+          "change_request_effective_date": {
+            "name": "Aangevraagde wijziging ingangsdatum"
+          },
           "is_change_request_possible": {
-            "name": "Is veranderen mogelijk",
+            "name": "Wijziging mogelijk",
             "state": {
               "false": "Nee",
               "true": "Ja"
             }
           },
           "upcoming_change": {
-            "name": "Gekozen resolutie",
+            "name": "Aankomende wijziging",
             "state": {
               "pt15m": "15 minuten",
               "pt60m": "60 minuten"
             }
           },
           "upcoming_change_effective_date": {
-            "name": "Verandering gaat in op"
+            "name": "Aankomende wijziging ingangsdatum"
           }
         }
       },


### PR DESCRIPTION
# Summary
This PR addresses several critical issues related to the contract price resolution feature, ensuring that connection IDs are strictly validated, state drift between the API and Home Assistant is accurately monitored, and the UI remains accessible when pending API changes are active.

Fixes #209

# Key Changes
- **Strict Segment Enforcement**: Refactored `coordinator.py` to ensure `connection_id` specifically selects the `ELECTRICITY` segment, preventing the integration from mistakenly attempting to change the resolution on gas connections.
- **Removed Improper Config Fallbacks**: Updated `async_set_resolution` so that authenticated users who lack an electricity connection_id gracefully fail with an explicit warning, rather than improperly falling back to modifying the unauthenticated local config parameters.
- **Fixed Cache Restoration Bug**: Updated `_process_fetched_data` to properly restore `_api_resolution_state` and `_resolution_change_pending` from the cached startup data. This prevents the `FrankEnergieResolutionSelect` entity from defaulting to an "optimistic" state with "Unknown" attributes after a reload.
- **Improved Select Entity UI**: Removed the `available` property overriding logic in `select.py`. The entity now remains fully visible and clickable even when `isChangeRequestPossible` is `False`. This allows users to continually view the `Upcoming change` and `Effective date` attributes, rather than Home Assistant hiding them due to the entity becoming "Unavailable".

# Why this is needed
When users requested a resolution change, the API correctly placed their account in a "cooling-off" period where `isChangeRequestPossible` became `False`. Because of a missing cache assignment, Home Assistant would temporarily show the dropdown as available on restart, only to fail silently when used. When the cache bug was fixed, the dropdown correctly became `Unavailable`, but Home Assistant's default behavior completely hides all extended attributes for unavailable entities, masking the crucial context (like the effective date) from the user. 

By keeping the entity available but strictly blocking the mutation logic internally, we preserve a defense-in-depth approach against invalid API mutations while ensuring maximum transparency and feedback for the user in the Home Assistant UI.

## Summary by Sourcery

Strikte selectie van elektriciteitsaansluitings-ID’s afdwingen voor wijzigingen in contractresolutie, de API-resolutiestatus herstellen op basis van gecachte opstartgegevens, en de resolutie-select entity zichtbaar houden in Home Assistant, zelfs wanneer API-wijzigingen momenteel niet mogelijk zijn.

Bugfixes:
- Ervoor zorgen dat `connection_id` altijd het ELECTRICITY-segment target in plaats van mogelijk een gasaansluiting te gebruiken.
- Voorkomen dat resolutiewijzigingen via de API worden uitgevoerd wanneer geen elektriciteit-`connection_id` beschikbaar is, waarbij een fout wordt gelogd in plaats van stilzwijgend terug te vallen op lokale configuratieopties.
- `_api_resolution_state` en `_resolution_change_pending` herstellen uit gecachte contractprijs-resolutiegegevens bij opstart om optimistische of onbekende select entity-statussen na een herlaadbeurt te voorkomen.

Verbeteringen:
- De resolutie-select entity beschikbaar houden in de UI, ongeacht `isChangeRequestPossible`, zodat de zichtbaarheid van aankomende wijzigings- en ingangsdatum-attributen behouden blijft.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce strict selection of electricity connection IDs for contract resolution changes, restore API resolution state from cached startup data, and keep the resolution select entity visible in Home Assistant even when API changes are not currently possible.

Bug Fixes:
- Ensure connection_id always targets the ELECTRICITY segment instead of potentially using a gas connection.
- Prevent resolution changes via the API when no electricity connection_id is available, logging an error instead of silently falling back to local config options.
- Restore _api_resolution_state and _resolution_change_pending from cached contract price resolution data on startup to avoid optimistic or unknown select entity states after reload.

Enhancements:
- Keep the resolution select entity available in the UI regardless of isChangeRequestPossible, preserving visibility of upcoming change and effective date attributes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for accounts with multiple connections by selecting the correct electricity connection.
  * Restored resolution state is now retained and reflected correctly after restart.
  * Resolution change controls now update more consistently and prevent overlapping change requests.
  * Improved error reporting when resolution changes cannot be submitted due to missing connection details.
* **UI/Localization**
  * Updated the “Price Resolution” sensor label and attribute texts, including a new “Change request effective date” field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->