### PR TITLE
fix(coordinator): handle RequestException for missing prices

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -223,6 +223,16 @@ if sys.platform == "win32" and hasattr(asyncio, "set_event_loop_policy"):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
+ERROR_NO_MARKET_PRICES: Final[str] = "No marketprices found"
+
+
+def _is_no_market_prices_error(ex: Exception) -> bool:
+    """Check if the exception represents a 'No market prices available' error."""
+    if isinstance(ex, NoMarketPricesAvailableException):
+        return True
+    return isinstance(ex, RequestException) and ERROR_NO_MARKET_PRICES in str(ex)
+
+
 class FrankEnergieData(TypedDict):
     """Represents data fetched from Frank Energie API."""
 

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1837,10 +1837,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 self.resolution,
             )
 
-        except (NoMarketPricesAvailableException, RequestException) as ex:
-            if isinstance(ex, RequestException) and "No marketprices found" not in str(
-                ex
-            ):
+        except RequestException as ex:
+            if not _is_no_market_prices_error(ex):
                 raise
             _LOGGER.debug(
                 "No market prices available yet for %s (%s - %s)",
@@ -1888,10 +1886,8 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 end_date,
             )
 
-        except (NoMarketPricesAvailableException, RequestException) as ex:
-            if isinstance(ex, RequestException) and "No marketprices found" not in str(
-                ex
-            ):
+        except RequestException as ex:
+            if not _is_no_market_prices_error(ex):
                 raise
             _LOGGER.debug(
                 "No user market prices available yet for %s (%s - %s)",

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1828,7 +1828,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
 
         except (NoMarketPricesAvailableException, RequestException) as ex:
-            if isinstance(ex, RequestException) and "No marketprices found" not in str(ex):
+            if isinstance(ex, RequestException) and "No marketprices found" not in str(
+                ex
+            ):
                 raise
             _LOGGER.debug(
                 "No market prices available yet for %s (%s - %s)",
@@ -1877,7 +1879,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
 
         except (NoMarketPricesAvailableException, RequestException) as ex:
-            if isinstance(ex, RequestException) and "No marketprices found" not in str(ex):
+            if isinstance(ex, RequestException) and "No marketprices found" not in str(
+                ex
+            ):
                 raise
             _LOGGER.debug(
                 "No user market prices available yet for %s (%s - %s)",

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1827,7 +1827,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 self.resolution,
             )
 
-        except NoMarketPricesAvailableException:
+        except (NoMarketPricesAvailableException, RequestException) as ex:
+            if isinstance(ex, RequestException) and "No marketprices found" not in str(ex):
+                raise
             _LOGGER.debug(
                 "No market prices available yet for %s (%s - %s)",
                 country_code,
@@ -1874,7 +1876,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 end_date,
             )
 
-        except NoMarketPricesAvailableException:
+        except (NoMarketPricesAvailableException, RequestException) as ex:
+            if isinstance(ex, RequestException) and "No marketprices found" not in str(ex):
+                raise
             _LOGGER.debug(
                 "No user market prices available yet for %s (%s - %s)",
                 user_country,


### PR DESCRIPTION
**Summary**
This pull request catches `RequestException` for cases where the Frank Energie API returns "No marketprices found" instead of raising `NoMarketPricesAvailableException`, preventing integration setup from failing.

**Why this is needed**
Currently, when the Belgian `be_prices` endpoint encounters an absence of electricity prices (e.g. they aren't fully published yet for the day or tomorrow), the `python_frank_energie` library throws a `RequestException` rather than `NoMarketPricesAvailableException`. Because our coordinator explicitly only catches the latter, this results in an uncaught exception crash during setup:
`python_frank_energie.exceptions.RequestException: No marketprices found for segment ELECTRICITY for 2026-07-02`
This causes the integration to go into a failed setup loop until prices are published. Users frequently misattribute the resolution of this to "re-installing the integration," but the actual cause is the API's temporary unavailable state during certain times. By catching this correctly, the integration will gracefully fall back or skip instead of crashing.

**Key Changes**
- Added `RequestException` to the caught exception tuple in `_fetch_public_prices_for_range` and `_fetch_user_prices_for_range`.
- Specifically checked if the string `"No marketprices found"` is in the exception error message. If so, it logs as unavailable and returns `None` safely.

Fixes #203

## Summary by Sourcery

Bugfixes:
- Behandel specifieke `RequestException`-responses die aangeven dat marktprijzen ontbreken als een tijdelijke onbeschikbaarheid in plaats van als een fatale fout tijdens het ophalen van prijzen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Treat specific RequestException responses indicating missing market prices as a temporary unavailability instead of a fatal error during price fetching.

</details>