### PR TITLE
feat(sensor): expose battery trading session status in period total sensor attributes

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1501,6 +1501,14 @@ def _safe_session_result_sum(sessions: Any) -> float:
     return total
 
 
+def _get_session_status(session: Any) -> str:
+    """Safely extract the session status string without a walrus operator."""
+    status = getattr(session, "status", None)
+    if status is None:
+        return "unknown"
+    return str(getattr(status, "value", status)).lower()
+
+
 def _get_period_trading_result(data: object | None) -> float | None:
     """Calculate the period trading result."""
     if not data:
@@ -1663,9 +1671,7 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
                         "date": s.date,
                         "result": s.result,
                         "cumulative_result": s.cumulative_result,
-                        "status": str(s.status).lower()
-                        if getattr(s, "status", None)
-                        else "unknown",
+                        "status": _get_session_status(s),
                     }
                     for s in getattr(data, "sessions", []) or []
                 ],

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -1663,6 +1663,9 @@ BATTERY_SESSION_SENSOR_DESCRIPTIONS: Final[
                         "date": s.date,
                         "result": s.result,
                         "cumulative_result": s.cumulative_result,
+                        "status": str(s.status).lower()
+                        if getattr(s, "status", None)
+                        else "unknown",
                     }
                     for s in getattr(data, "sessions", []) or []
                 ],


### PR DESCRIPTION
## Summary
This PR exposes the individual `status` of each battery trading session within the `sessions` list attribute on the "Period Total to Settle" sensor.
## Key Changes
- Modified `FrankEnergieBatterySessionSensor`'s `attr_fn` to capture and include the `status` string from the underlying `SmartBatterySessions` object.
- Safely coerces the Enum to a lowercase string, defaulting to `"unknown"` if the API doesn't provide a status.
## Why this is needed
In a recent update to the `python-frank-energie` library, the `SessionStatus` enum was expanded to include statuses like `ACTIVE` and `COMPLETE_PRELIMINARY` (see python-frank-energie PR 118). Exposing these in Home Assistant gives advanced users visibility into the lifecycle of their daily trading sessions (e.g., understanding that a result is preliminary vs. finalized), which is especially useful when tracking daily fluctuations.
*(Note: Because this data is exposed as a nested dictionary inside a list attribute, it intentionally relies on the raw lowercase string values and does not require additions to `strings.json` for Home Assistant translation).*

## Summary by Sourcery

Nieuwe functies:
- Voeg een statusveld toe voor elke batterijhandelsessie in de attribuutgegevens van de periodieke totalsensor, waarbij standaard "unknown" wordt gebruikt wanneer geen waarde wordt opgegeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Include a status field for each battery trading session in the period total sensor attributes, defaulting to "unknown" when not provided.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status value to smart battery session details.
  * Session statuses are displayed in lowercase, with “unknown” shown when no status is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->