### PR TITLE
fix: add defensive logging for price data resolution

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1718,7 +1718,19 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
             return combined
         except TypeError:
-            return today_data + tomorrow_data
+            combined = today_data + tomorrow_data
+
+            # Defensive logging to trace resolution changes during merge fallback (Issue #221)
+            old_res = getattr(today_data, "resolution_minutes", None)
+            new_res = getattr(combined, "resolution_minutes", None)
+            if old_res is not None and old_res != new_res:
+                _LOGGER.debug(
+                    "Price data merge (non in-place) mutated resolution from %s to %s",
+                    old_res,
+                    new_res,
+                )
+
+            return combined
 
     def _aggregate_data(
         self,

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1702,7 +1702,20 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         try:
             combined = copy.copy(today_data)
+
+            # Defensive logging to trace resolution changes during merge (Issue #221)
+            old_res = getattr(combined, "resolution_minutes", None)
+
             combined += tomorrow_data
+
+            new_res = getattr(combined, "resolution_minutes", None)
+            if old_res is not None and old_res != new_res:
+                _LOGGER.debug(
+                    "Price data merge mutated resolution from %s to %s",
+                    old_res,
+                    new_res,
+                )
+
             return combined
         except TypeError:
             return today_data + tomorrow_data


### PR DESCRIPTION
## Summary
This PR adds defensive logging to `_combine_price_data` to track when price resolution metadata is dropped or mutated during object merges.

## Key Changes
- Added a `_LOGGER.debug` statement in `_combine_price_data` that triggers if the `resolution_minutes` attribute changes before and after appending tomorrow's price data.

## Why this is needed
This helps with diagnosing data corruption issues (like Issue #221) where upstream library merges drop crucial metadata, causing Home Assistant charts to render 15-minute data as 60-minute blocks. The actual fix for the bug is upstream in `python-frank-energie`, but this logging will make similar issues much easier to track down in the future.

Related to #221

## Summary by Sourcery

Verbeteringen:
- Log `resolution_minutes` vóór en na het samenvoegen van prijsgegevens om te helpen bij het diagnosticeren van problemen met beschadigde metadata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Log resolution_minutes before and after merging price data to aid diagnosis of metadata corruption issues.

</details>