### PR TITLE
fix: hide irrelevant polling interval config options

### DIFF
--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -45,6 +45,10 @@ from .const import (
     DEFAULT_INTERVAL_CHARGERS,
     DEFAULT_INTERVAL_VEHICLES,
     DEFAULT_INTERVAL_PV,
+    DATA_BATTERIES,
+    DATA_ENODE_CHARGERS,
+    DATA_ENODE_VEHICLES,
+    DATA_PV_SYSTEMS,
 )
 from .helpers import decrypt_password, encrypt_password
 
@@ -894,72 +898,110 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
                 _LOGGER.exception("Unexpected error in options flow: %s", ex)
                 errors = {"base": "unknown_error"}
 
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_USERNAME, default=current_username): str,
-                # Leave password blank to avoid exposing it in the UI
-                vol.Optional(CONF_PASSWORD, default=""): str,
-                vol.Required(
-                    CONF_INTERVAL_SETTINGS,
-                    default=entry.options.get(
-                        CONF_INTERVAL_SETTINGS, DEFAULT_INTERVAL_SETTINGS
-                    ),
-                ): NumberSelector(
-                    NumberSelectorConfig(min=1, max=72, mode=NumberSelectorMode.SLIDER)
+        runtime_data = getattr(entry, "runtime_data", None)
+
+        has_batteries = True
+        has_chargers = True
+        has_vehicles = True
+        has_pv = True
+
+        if runtime_data:
+            battery_data = runtime_data.battery_coordinator.data.get(DATA_BATTERIES) if runtime_data.battery_coordinator.data else None
+            has_batteries = bool(battery_data and battery_data.batteries)
+
+            charger_data = runtime_data.charger_coordinator.data.get(DATA_ENODE_CHARGERS) if runtime_data.charger_coordinator.data else None
+            has_chargers = bool(charger_data and charger_data.chargers)
+
+            vehicle_data = runtime_data.vehicle_coordinator.data.get(DATA_ENODE_VEHICLES) if runtime_data.vehicle_coordinator.data else None
+            has_vehicles = bool(vehicle_data and vehicle_data.vehicles)
+
+            pv_data = runtime_data.pv_coordinator.data.get(DATA_PV_SYSTEMS) if runtime_data.pv_coordinator.data else None
+            has_pv = bool(pv_data and pv_data.systems)
+
+        schema_dict = {
+            vol.Required(CONF_USERNAME, default=current_username): str,
+            # Leave password blank to avoid exposing it in the UI
+            vol.Optional(CONF_PASSWORD, default=""): str,
+            vol.Required(
+                CONF_INTERVAL_SETTINGS,
+                default=entry.options.get(
+                    CONF_INTERVAL_SETTINGS, DEFAULT_INTERVAL_SETTINGS
                 ),
-                vol.Required(
-                    CONF_INTERVAL_STATISTICS,
-                    default=entry.options.get(
-                        CONF_INTERVAL_STATISTICS, DEFAULT_INTERVAL_STATISTICS
-                    ),
-                ): NumberSelector(
-                    NumberSelectorConfig(
-                        min=15, max=1440, mode=NumberSelectorMode.SLIDER
-                    )
+            ): NumberSelector(
+                NumberSelectorConfig(min=1, max=72, mode=NumberSelectorMode.SLIDER)
+            ),
+            vol.Required(
+                CONF_INTERVAL_STATISTICS,
+                default=entry.options.get(
+                    CONF_INTERVAL_STATISTICS, DEFAULT_INTERVAL_STATISTICS
                 ),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=15, max=1440, mode=NumberSelectorMode.SLIDER
+                )
+            ),
+        }
+
+        if has_batteries:
+            schema_dict[
                 vol.Required(
                     CONF_INTERVAL_BATTERIES,
                     default=entry.options.get(
                         CONF_INTERVAL_BATTERIES, DEFAULT_INTERVAL_BATTERIES
                     ),
-                ): NumberSelector(
-                    NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
-                ),
+                )
+            ] = NumberSelector(
+                NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
+            )
+            schema_dict[
                 vol.Required(
                     CONF_INTERVAL_BATTERY_SESSIONS,
                     default=entry.options.get(
                         CONF_INTERVAL_BATTERY_SESSIONS,
                         DEFAULT_INTERVAL_BATTERY_SESSIONS,
                     ),
-                ): NumberSelector(
-                    NumberSelectorConfig(
-                        min=5, max=1440, mode=NumberSelectorMode.SLIDER
-                    )
-                ),
+                )
+            ] = NumberSelector(
+                NumberSelectorConfig(
+                    min=5, max=1440, mode=NumberSelectorMode.SLIDER
+                )
+            )
+
+        if has_chargers:
+            schema_dict[
                 vol.Required(
                     CONF_INTERVAL_CHARGERS,
                     default=entry.options.get(
                         CONF_INTERVAL_CHARGERS, DEFAULT_INTERVAL_CHARGERS
                     ),
-                ): NumberSelector(
-                    NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
-                ),
+                )
+            ] = NumberSelector(
+                NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
+            )
+
+        if has_vehicles:
+            schema_dict[
                 vol.Required(
                     CONF_INTERVAL_VEHICLES,
                     default=entry.options.get(
                         CONF_INTERVAL_VEHICLES, DEFAULT_INTERVAL_VEHICLES
                     ),
-                ): NumberSelector(
-                    NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
-                ),
+                )
+            ] = NumberSelector(
+                NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
+            )
+
+        if has_pv:
+            schema_dict[
                 vol.Required(
                     CONF_INTERVAL_PV,
                     default=entry.options.get(CONF_INTERVAL_PV, DEFAULT_INTERVAL_PV),
-                ): NumberSelector(
-                    NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
-                ),
-            }
-        )
+                )
+            ] = NumberSelector(
+                NumberSelectorConfig(min=5, max=60, mode=NumberSelectorMode.SLIDER)
+            )
+
+        data_schema = vol.Schema(schema_dict)
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors

--- a/custom_components/frank_energie/config_flow.py
+++ b/custom_components/frank_energie/config_flow.py
@@ -906,16 +906,32 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
         has_pv = True
 
         if runtime_data:
-            battery_data = runtime_data.battery_coordinator.data.get(DATA_BATTERIES) if runtime_data.battery_coordinator.data else None
+            battery_data = (
+                runtime_data.battery_coordinator.data.get(DATA_BATTERIES)
+                if runtime_data.battery_coordinator.data
+                else None
+            )
             has_batteries = bool(battery_data and battery_data.batteries)
 
-            charger_data = runtime_data.charger_coordinator.data.get(DATA_ENODE_CHARGERS) if runtime_data.charger_coordinator.data else None
+            charger_data = (
+                runtime_data.charger_coordinator.data.get(DATA_ENODE_CHARGERS)
+                if runtime_data.charger_coordinator.data
+                else None
+            )
             has_chargers = bool(charger_data and charger_data.chargers)
 
-            vehicle_data = runtime_data.vehicle_coordinator.data.get(DATA_ENODE_VEHICLES) if runtime_data.vehicle_coordinator.data else None
+            vehicle_data = (
+                runtime_data.vehicle_coordinator.data.get(DATA_ENODE_VEHICLES)
+                if runtime_data.vehicle_coordinator.data
+                else None
+            )
             has_vehicles = bool(vehicle_data and vehicle_data.vehicles)
 
-            pv_data = runtime_data.pv_coordinator.data.get(DATA_PV_SYSTEMS) if runtime_data.pv_coordinator.data else None
+            pv_data = (
+                runtime_data.pv_coordinator.data.get(DATA_PV_SYSTEMS)
+                if runtime_data.pv_coordinator.data
+                else None
+            )
             has_pv = bool(pv_data and pv_data.systems)
 
         schema_dict = {
@@ -936,9 +952,7 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_INTERVAL_STATISTICS, DEFAULT_INTERVAL_STATISTICS
                 ),
             ): NumberSelector(
-                NumberSelectorConfig(
-                    min=15, max=1440, mode=NumberSelectorMode.SLIDER
-                )
+                NumberSelectorConfig(min=15, max=1440, mode=NumberSelectorMode.SLIDER)
             ),
         }
 
@@ -962,9 +976,7 @@ class FrankEnergieOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 )
             ] = NumberSelector(
-                NumberSelectorConfig(
-                    min=5, max=1440, mode=NumberSelectorMode.SLIDER
-                )
+                NumberSelectorConfig(min=5, max=1440, mode=NumberSelectorMode.SLIDER)
             )
 
         if has_chargers:


### PR DESCRIPTION
## Summary
This PR conditionally builds the integration's options flow schema so that it only displays polling intervals for features that are actually available on the user's Frank Energie account (e.g., smart batteries, EV chargers, electric vehicles, and PV systems).

## Key Changes
- Modified `OptionsFlowHandler.async_step_user` in `config_flow.py` to check the current `runtime_data` coordinators.
- Defaults to showing all polling intervals if `runtime_data` is unavailable (e.g., during initial setup), but intelligently hides unused intervals on subsequent configurations.

## Why this is needed
Users without certain smart hardware (like EV chargers or smart batteries) were seeing polling interval configuration options for these devices in the integration's settings, which was confusing and cluttered the UI. This change makes the integration feel more polished by hiding irrelevant options.

Closes #216

## Summary by Sourcery

Bouw het options flow-schema conditioneel, zodat instellingen voor poll-intervals alleen worden getoond voor functies die aanwezig zijn op de Frank Energie-account van de gebruiker.

Verbeteringen:
- Leid het schema van het optiesformulier af uit runtime-coördinatoren om poll-intervalbediening te verbergen voor batterijen, laders, voertuigen en PV-systemen die niet beschikbaar zijn.
- Val terug op het tonen van alle poll-intervalopties wanneer runtime-data niet beschikbaar is, bijvoorbeeld tijdens de eerste installatie.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Conditionally build the options flow schema so that polling interval settings are only shown for features present on the user’s Frank Energie account.

Enhancements:
- Derive the options form schema from runtime coordinators to hide polling interval controls for batteries, chargers, vehicles, and PV systems that are not available.
- Fallback to displaying all polling interval options when runtime data is unavailable, such as during initial setup.

</details>