### PR TITLE
fix: unauthenticated tomorrow-price caching bug, disk-cache resolution round-trip, and midnight promotion crash

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -159,6 +159,14 @@ def _market_prices_to_dict(market_prices: MarketPrices) -> dict[str, Any]:
         else [],
         "energy_country": market_prices.energy_country,
         "energy_type": market_prices.energy_type,
+        "electricity_resolution_minutes": (
+            market_prices.electricity.resolution_minutes
+            if market_prices.electricity
+            else None
+        ),
+        "gas_resolution_minutes": (
+            market_prices.gas.resolution_minutes if market_prices.gas else None
+        ),
     }
 
 
@@ -169,8 +177,16 @@ def _dict_to_market_prices(data: dict[str, Any]) -> MarketPrices:
     country = data.get("energy_country", "NL")
     energy_type = data.get("energy_type")
 
-    electricity = PriceData(prices=elec_prices, energy_type="electricity")
-    gas = PriceData(prices=gas_prices, energy_type="gas")
+    electricity = PriceData(
+        prices=elec_prices,
+        energy_type="electricity",
+        resolution_minutes=data.get("electricity_resolution_minutes") or 60,
+    )
+    gas = PriceData(
+        prices=gas_prices,
+        energy_type="gas",
+        resolution_minutes=data.get("gas_resolution_minutes") or 60,
+    )
 
     return MarketPrices(
         electricity=electricity,
@@ -408,10 +424,6 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         self._last_update_success = False
         self.user_electricity_enabled = False
         self.user_gas_enabled = False
-        _LOGGER.debug(
-            "Initializing Frank Energie coordinator with country_code: %s",
-            self.country_code,
-        )
 
         self.cached_prices: FrankEnergieData | None = None
         self.cached_prices_today: PricesTodayCache | None = None
@@ -725,6 +737,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             and self.last_fetch_tomorrow is not None
             and self.last_fetch_tomorrow.date() == today
         ):
+            _LOGGER.debug(
+                "Tomorrow prices already cached (fetched %s), skipping API call",
+                self.last_fetch_tomorrow,
+            )
             return self.cached_prices_tomorrow
 
         _LOGGER.debug(
@@ -969,6 +985,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_user_sites(self) -> UserSites | None:
         """Fetch user sites from the API."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping user sites fetch because the client is not authenticated"
+            )
             return None
         try:
             sites = await self.api.UserSites()
@@ -1014,6 +1033,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_invoices(self) -> Invoices | None:
         """Fetch invoices from the API."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping invoices fetch because the client is not authenticated"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch invoices.")
@@ -1040,6 +1062,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_period_usage(self, start_date: date) -> PeriodUsageAndCosts | None:
         """Fetch period usage and costs from the API."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping period usage fetch because the client is not authenticated"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch period usage.")
@@ -1068,6 +1093,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_user_data(self) -> User | None:
         """Fetch user data from the API."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping user data fetch because the client is not authenticated"
+            )
             return None
         if not self.site_reference:
             _LOGGER.warning("Site reference is missing, cannot fetch user data.")
@@ -1245,6 +1273,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         Failures leave the flag unchanged so the next cycle retries.
         """
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping smart PV systems fetch because the client is not authenticated"
+            )
             return None
         if self._has_pv_systems is False:
             return None
@@ -1278,6 +1309,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     async def _fetch_user_smart_feed_in(self) -> UserSmartFeedInStatus | None:
         """Fetch user smart feed-in status from the API."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping user smart feed-in fetch because the client is not authenticated"
+            )
             return None
         try:
             return await self.api.user_smart_feed_in()
@@ -1712,6 +1746,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             combined += tomorrow_data
             return combined
         except TypeError:
+            _LOGGER.debug(
+                "In-place merge of %s failed, falling back to __add__",
+                type(today_data).__name__,
+            )
             return today_data + tomorrow_data
 
     def _aggregate_data(
@@ -1801,7 +1839,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if not remaining:
             return None
 
-        return replace(price_data, price_data=remaining)
+        # `price_data` (the parsed Price list) is set in __post_init__, not a
+        # dataclass field, so replace(..., price_data=...) would raise
+        # TypeError. Clear `prices` via replace() to keep the other metadata
+        # (energy_type, resolution_minutes, ...), then inject the
+        # already-filtered, already-parsed entries directly.
+        filtered = replace(price_data, prices=[])
+        filtered.price_data = remaining
+        return filtered
 
     @staticmethod
     def _merge_prices(
@@ -1825,15 +1870,13 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         return MarketPrices(
             electricity=remaining_electricity
             or (
-                replace(prices_tomorrow.electricity, price_data=[])
+                replace(prices_tomorrow.electricity, prices=[])
                 if prices_tomorrow.electricity
                 else None
             ),
             gas=remaining_gas
             or (
-                replace(prices_tomorrow.gas, price_data=[])
-                if prices_tomorrow.gas
-                else None
+                replace(prices_tomorrow.gas, prices=[]) if prices_tomorrow.gas else None
             ),
             energy_country=prices_tomorrow.energy_country,
             energy_type=prices_tomorrow.energy_type,
@@ -1849,6 +1892,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         """
         prices_tomorrow = self.cached_prices_tomorrow
         if prices_tomorrow is None:
+            _LOGGER.debug(
+                "Midnight rollover: no cached tomorrow prices to promote "
+                "(last_fetch_tomorrow=%s), today's prices will be refetched live",
+                self.last_fetch_tomorrow,
+            )
             return
 
         source_data = self.cached_prices or self.data
@@ -1868,13 +1916,23 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
         except ValueError:
             _LOGGER.warning(
-                "Cannot merge price data: resolution or type mismatch, "
-                "retaining today's prices if available, else falling back to tomorrow's prices"
+                "Cannot merge price data: resolution or type mismatch "
+                "(likely a contract resolution change). Using tomorrow's "
+                "prices for the new day instead of yesterday's stale resolution"
             )
+            # An empty PriceData instance is truthy, so check for actual
+            # entries — the tomorrow cache holds an empty series for an
+            # energy type the user has no contract for.
             combined_electricity = (
-                source_data.get(DATA_ELECTRICITY) or prices_tomorrow.electricity
+                prices_tomorrow.electricity
+                if prices_tomorrow.electricity and prices_tomorrow.electricity.all
+                else source_data.get(DATA_ELECTRICITY)
             )
-            combined_gas = source_data.get(DATA_GAS) or prices_tomorrow.gas
+            combined_gas = (
+                prices_tomorrow.gas
+                if prices_tomorrow.gas and prices_tomorrow.gas.all
+                else source_data.get(DATA_GAS)
+            )
 
         updated_data = source_data.copy()
         updated_data[DATA_ELECTRICITY] = combined_electricity
@@ -1903,12 +1961,19 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
 
         self.async_update_listeners()
 
+        promoted_elec = (
+            len(prices_tomorrow.electricity.all) if prices_tomorrow.electricity else 0
+        )
+        promoted_gas = len(prices_tomorrow.gas.all) if prices_tomorrow.gas else 0
         kept_elec = len(remaining_electricity.all) if remaining_electricity else 0
         kept_gas = len(remaining_gas.all) if remaining_gas else 0
 
         _LOGGER.debug(
-            "Promoted cached tomorrow prices to today's prices "
-            "(%s electricity and %s gas price entries kept for the new tomorrow)",
+            "Promoted %s electricity and %s gas price entries from tomorrow to "
+            "today's prices (%s electricity and %s gas price entries kept for "
+            "the new tomorrow)",
+            promoted_elec,
+            promoted_gas,
             kept_elec,
             kept_gas,
         )
@@ -1985,6 +2050,9 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     ) -> MarketPrices | None:
         """Fetch user-specific prices for a given date range."""
         if not self.api.is_authenticated:
+            _LOGGER.debug(
+                "Skipping user prices fetch because the client is not authenticated"
+            )
             return None
 
         site_reference = self.site_reference
@@ -2050,6 +2118,14 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         )
 
         if public_prices is None:
+            if not use_fallback and not self.api.is_authenticated:
+                # e.g. tomorrow's prices not published yet — don't substitute
+                # today's cached prices, or _refresh_tomorrow_cache will treat
+                # today's data as a successful tomorrow fetch and stop retrying.
+                _LOGGER.debug(
+                    "No public prices available yet, skipping fallback to cached prices"
+                )
+                return None
             public_prices = getattr(
                 self,
                 "_cached_prices",
@@ -2563,6 +2639,7 @@ class FrankEnergieSettingsCoordinator(FrankEnergieCoordinator):
         """Initialize the settings coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie settings coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.update_interval = timedelta(
             hours=config_entry.options.get(
                 CONF_INTERVAL_SETTINGS, DEFAULT_INTERVAL_SETTINGS
@@ -2609,6 +2686,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         """Initialize the price coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie price coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = None
         self.store = Store(
@@ -2937,6 +3015,7 @@ class FrankEnergieBatteryCoordinator(FrankEnergieCoordinator):
         """Initialize the battery coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie battery coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = timedelta(
             minutes=config_entry.options.get(
@@ -3008,6 +3087,7 @@ class FrankEnergieChargerCoordinator(FrankEnergieCoordinator):
         """Initialize the charger coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie charger coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = timedelta(
             minutes=config_entry.options.get(
@@ -3077,6 +3157,7 @@ class FrankEnergiePVCoordinator(FrankEnergieCoordinator):
         """Initialize the PV coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie PV coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = timedelta(
             minutes=config_entry.options.get(CONF_INTERVAL_PV, DEFAULT_INTERVAL_PV)
@@ -3151,6 +3232,7 @@ class FrankEnergieVehicleCoordinator(FrankEnergieCoordinator):
         """Initialize the vehicle coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie vehicle coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = timedelta(
             minutes=config_entry.options.get(
@@ -3221,6 +3303,7 @@ class FrankEnergieStatisticsCoordinator(FrankEnergieCoordinator):
         """Initialize the statistics coordinator."""
         super().__init__(hass, config_entry, api)
         self.name = "Frank Energie statistics coordinator"
+        _LOGGER.debug("Initializing %s (country_code=%s)", self.name, self.country_code)
         self.settings_coordinator = settings_coordinator
         self.update_interval = timedelta(
             minutes=config_entry.options.get(

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -177,6 +177,19 @@ def _dict_to_market_prices(data: dict[str, Any]) -> MarketPrices:
     country = data.get("energy_country", "NL")
     energy_type = data.get("energy_type")
 
+    if elec_prices and data.get("electricity_resolution_minutes") is None:
+        _LOGGER.debug(
+            "Cached electricity prices have no persisted resolution_minutes "
+            "(older cache format); relying on PriceData to derive it from "
+            "entry spacing"
+        )
+    if gas_prices and data.get("gas_resolution_minutes") is None:
+        _LOGGER.debug(
+            "Cached gas prices have no persisted resolution_minutes "
+            "(older cache format); relying on PriceData to derive it from "
+            "entry spacing"
+        )
+
     electricity = PriceData(
         prices=elec_prices,
         energy_type="electricity",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -992,6 +992,57 @@ async def test_fetch_contract_price_resolution_state_skips_when_unauthenticated_
 
 
 @pytest.mark.asyncio
+async def test_fetch_prices_with_fallback_unauthenticated_tomorrow_not_published(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Unauthenticated tomorrow-fetch must not fall back to cached today prices.
+
+    Regression test: when the public API hasn't published tomorrow's prices yet,
+    the coordinator previously substituted `_cached_prices` (today's data) and
+    returned it as if it were tomorrow's prices. `_refresh_tomorrow_cache` would
+    then believe tomorrow was successfully fetched, cache a duplicate of today's
+    data, and permanently skip retries for the rest of the day.
+    """
+    from datetime import date
+
+    mock_frank_energie.is_authenticated = False
+
+    today_prices = MagicMock()
+    coordinator._cached_prices = today_prices
+
+    coordinator._fetch_public_prices_for_range = AsyncMock(return_value=None)
+    coordinator._fetch_user_prices_for_range = AsyncMock(return_value=None)
+
+    result = await coordinator._fetch_prices_with_fallback(
+        date(2026, 7, 20), date(2026, 7, 21), use_fallback=False
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_prices_with_fallback_unauthenticated_today_uses_cache(
+    coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
+) -> None:
+    """Today's fetch should still fall back to cached prices on transient failure."""
+    from datetime import date
+
+    mock_frank_energie.is_authenticated = False
+
+    today_prices = MagicMock()
+    coordinator._cached_prices = today_prices
+
+    coordinator._fetch_public_prices_for_range = AsyncMock(return_value=None)
+    coordinator._fetch_user_prices_for_range = AsyncMock(return_value=None)
+
+    result = await coordinator._fetch_prices_with_fallback(
+        date(2026, 7, 19), date(2026, 7, 20), use_fallback=True
+    )
+
+    assert result is today_prices
+
+
+@pytest.mark.asyncio
 async def test_dynamic_fetches_skip_when_feature_disabled(
     coordinator: FrankEnergieCoordinator, mock_frank_energie: AsyncMock
 ) -> None:
@@ -1399,6 +1450,48 @@ async def test_price_coordinator_midnight_rollover(
 
 
 @pytest.mark.asyncio
+async def test_price_coordinator_midnight_rollover_resolution_mismatch(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """On a resolution-change day, promotion must prefer tomorrow's (new) resolution.
+
+    Regression test: when `_merge_prices` raises ValueError because today's and
+    tomorrow's cached price series have mismatched resolutions (e.g. a contract
+    resolution change taking effect at midnight), the fallback previously kept
+    yesterday's stale-resolution data instead of the freshly-fetched,
+    correct-resolution tomorrow data.
+    """
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    tomorrow_prices = MagicMock()
+    tomorrow_prices.electricity = MagicMock(name="tomorrow_electricity")
+    tomorrow_prices.gas = MagicMock(name="tomorrow_gas")
+    price_coordinator.cached_prices_tomorrow = tomorrow_prices
+
+    price_coordinator.cached_prices = {
+        DATA_ELECTRICITY: MagicMock(name="yesterday_electricity"),
+        DATA_GAS: MagicMock(name="yesterday_gas"),
+    }
+
+    price_coordinator._merge_prices = MagicMock(
+        side_effect=ValueError("resolution mismatch")
+    )
+
+    price_coordinator.promote_tomorrow_prices()
+
+    assert (
+        price_coordinator._static_prices_today.electricity
+        is tomorrow_prices.electricity
+    )
+    assert price_coordinator._static_prices_today.gas is tomorrow_prices.gas
+
+
+@pytest.mark.asyncio
 async def test_sub_coordinators_properties(
     mock_frank_energie, mock_config_entry
 ) -> None:
@@ -1540,3 +1633,70 @@ async def test_coordinator_helpers() -> None:
         )
         assert res3.electricity is elec_rem
         assert res3.gas == "empty"
+
+
+@pytest.mark.asyncio
+async def test_price_data_after_and_build_tomorrow_cache_with_real_pricedata() -> None:
+    """_price_data_after/_build_tomorrow_cache must not crash on a real multi-day window.
+
+    Regression test: both methods called `dataclasses.replace(price_data, price_data=...)`,
+    but `price_data` is an instance attribute set in `PriceData.__post_init__`, not a
+    declared dataclass field. `replace()` always raised TypeError for any real PriceData
+    object, so a genuine multi-day API response would silently crash midnight promotion.
+    The previous test only exercised this with MagicMocks, which masked the bug since
+    mocked `replace()` never touches the real dataclass machinery.
+    """
+    from datetime import date, timezone
+    from python_frank_energie.models import PriceData
+
+    raw_today = {
+        "from": "2026-07-19T22:00:00.000Z",
+        "till": "2026-07-19T22:15:00.000Z",
+        "marketPrice": 0.1,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    raw_day_after = {
+        "from": "2026-07-20T22:00:00.000Z",
+        "till": "2026-07-20T22:15:00.000Z",
+        "marketPrice": 0.2,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    multi_day_electricity = PriceData(
+        [raw_today, raw_day_after], energy_type="electricity"
+    )
+    empty_gas = PriceData([], energy_type="gas")
+
+    new_today = date(2026, 7, 20)
+
+    remaining_electricity = FrankEnergiePriceCoordinator._price_data_after(
+        multi_day_electricity, new_today
+    )
+    remaining_gas = FrankEnergiePriceCoordinator._price_data_after(empty_gas, new_today)
+
+    assert remaining_electricity is not None
+    assert len(remaining_electricity.all) == 1
+    assert remaining_electricity.all[0].date_from == datetime(
+        2026, 7, 20, 22, 0, tzinfo=timezone.utc
+    )
+    # Metadata (e.g. resolution) must survive the rebuild.
+    assert remaining_electricity.resolution_minutes == 15
+    assert remaining_gas is None
+
+    tomorrow_prices = MagicMock()
+    tomorrow_prices.electricity = multi_day_electricity
+    tomorrow_prices.gas = empty_gas
+    tomorrow_prices.energy_country = "NL"
+    tomorrow_prices.energy_type = "electricity"
+
+    built = FrankEnergiePriceCoordinator._build_tomorrow_cache(
+        tomorrow_prices, remaining_electricity, remaining_gas
+    )
+
+    assert built is not None
+    assert built.electricity is remaining_electricity
+    assert built.gas is not None
+    assert built.gas.all == []

--- a/tests/test_price_cache.py
+++ b/tests/test_price_cache.py
@@ -64,6 +64,40 @@ async def test_price_serialization():
 
 
 @pytest.mark.asyncio
+async def test_market_prices_resolution_minutes_round_trip():
+    """resolution_minutes must survive the disk-cache serialize/deserialize round trip.
+
+    Regression test: `_market_prices_to_dict`/`_dict_to_market_prices` previously
+    dropped `resolution_minutes` entirely, so restoring a cached PT15M contract's
+    prices silently fell back to the PriceData dataclass default of 60. This made
+    `_is_cache_resolution_valid()` always see a (bogus) resolution mismatch after
+    every HA restart for PT15M users, forcing a full live re-fetch every time and
+    defeating the disk-cache optimization.
+    """
+    raw_price = {
+        "from": "2026-06-26T07:30:00+00:00",
+        "till": "2026-06-26T07:45:00+00:00",
+        "marketPrice": 0.15,
+        "marketPriceTax": 0.03,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.12,
+        "perUnit": "kwh",
+    }
+
+    electricity = PriceData(
+        [raw_price], energy_type="electricity", resolution_minutes=15
+    )
+    gas = PriceData([], energy_type="gas", resolution_minutes=60)
+    market_prices = MarketPrices(electricity=electricity, gas=gas, energy_country="NL")
+
+    serialized_mp = _market_prices_to_dict(market_prices)
+    deserialized_mp = _dict_to_market_prices(serialized_mp)
+
+    assert deserialized_mp.electricity.resolution_minutes == 15
+    assert deserialized_mp.gas.resolution_minutes == 60
+
+
+@pytest.mark.asyncio
 async def test_resolution_state_serialization():
     """Test ContractPriceResolutionState serialization and deserialization."""
     raw_state = {
@@ -146,6 +180,8 @@ async def test_coordinator_load_cache(mock_store, mock_config_entry):
             "gas": [],
             "energy_country": "NL",
             "energy_type": "electricity",
+            "electricity_resolution_minutes": 15,
+            "gas_resolution_minutes": 60,
         },
         "prices_tomorrow": None,
         "contract_price_resolution_state": {


### PR DESCRIPTION
## Summary
Three related bugs in the price coordinator's caching logic, found while investigating why unauthenticated (public-price-only) users never received next-day prices:

1. **Unauthenticated tomorrow-fetch silently "succeeded" with duplicated
today data.** When the public API hadn't published tomorrow's prices yet, `_fetch_prices_with_fallback` substituted `_cached_prices` (today's data) and returned it unconditionally for unauthenticated users, ignoring the caller's `use_fallback=False`. The coordinator then treated that non-empty (but wrong) data as a successful tomorrow-fetch, cached it, and marked `last_fetch_tomorrow` as today — permanently skipping every further retry for the rest of the day (refresh button, reload, and the 5/15/60-minute retry schedule all hit the same short-circuit).

2. **`resolution_minutes` was dropped on every disk-cache save/load.**
`_market_prices_to_dict`/`_dict_to_market_prices` never serialized it, so it always came back as the dataclass default (60) after a restart, causing `_is_cache_resolution_valid()` to see a false mismatch against a PT15M contract and wipe the entire cache (today's and tomorrow's) on every reload — forcing an unnecessary full live re-fetch every time.

4. **Midnight promotion crashed on any multi-day price window.** 
`_price_data_after`/`_build_tomorrow_cache` called `dataclasses.replace(price_data, price_data=...)`, but `price_data` is an instance attribute set in `PriceData.__post_init__`, not a declared dataclass field — always raising `TypeError`. This silently broke `promote_tomorrow_prices()` whenever the API returned a window spanning more than one day ahead.

Also fixes a resolution-mismatch fallback in midnight promotion that preferred yesterday's stale-resolution data over tomorrow's correct data during a contract resolution change, including a truthiness bug found in review (an empty-but-truthy `PriceData` for an energy type the user has no contract for could otherwise win over valid cached data).

Adds debug logging throughout: per-coordinator init messages (previously 6-7 identical lines), unauthenticated fetch skips (previously silent — the original motivation for this investigation), cache-hit short-circuits, and promotion entry counts.

## Why this matters
Unauthenticated users never received next-day prices at all, and any restart forced an unnecessary full re-fetch for every user regardless of auth status.

## Test plan
- `test_fetch_prices_with_fallback_unauthenticated_tomorrow_not_published` / `..._today_uses_cache`
- `test_price_coordinator_midnight_rollover_resolution_mismatch`
- `test_price_data_after_and_build_tomorrow_cache_with_real_pricedata` (uses real `PriceData`, not mocks — the existing test used mocks, which is exactly why the `replace()` crash went unnoticed)
- `test_market_prices_resolution_minutes_round_trip`
- `test_coordinator_load_cache` updated to reflect the corrected cache format
- Full suite: 162 passed, 3 skipped
- Verified live end-to-end in the dev environment: watched the unauthenticated path through a full 13:00 publish cycle — confirmed clean retries every 5 minutes with no cache poisoning, successful pickup of real tomorrow's prices once published, and correct "fresh cache" reuse on a subsequent reload.

## Note
Depends on the companion fix in `python-frank-energie` [#130](https://github.com/HiDiHo01/python-frank-energie/pull/130), so bug 2 above isn't fully resolved in production until that library fix is released and this repo's pin is bumped.

## Summary by Sourcery

Los meerdere bugs in de price coordinator met betrekking tot caching en promoties die invloed hebben op niet-geauthenticeerde gebruikers, cachepersistentie en middernachtoverschakelingen, en voeg gerichte debug-logging toe.

Bugfixes:
- Zorg ervoor dat het ophalen van prijzen voor morgen voor niet-geauthenticeerde gebruikers niet terugvalt op gecachte prijzen van vandaag wanneer er geen publieke data beschikbaar is, om cachevergiftiging en gemiste retries te voorkomen.
- Behoud `PriceData` `resolution_minutes` tijdens serialisatie/deserialisatie naar en van de schijf-cache zodat gecachte prijzen geldig blijven na herstarts en geen onnodige live-refetches triggeren.
- Voorkom dat de promotie rond middernacht crasht bij echte meerdaagse `PriceData`-vensters door gefilterde `PriceData`-instanties correct opnieuw op te bouwen zonder niet-dataclass velden te gebruiken in `dataclasses.replace`.
- Geef tijdens middernachtoverschakeling bij resolutiemismatch de voorkeur aan prijzen voor morgen met de juiste resolutie boven verouderde data van gisteren en voorkom dat lege-maar-truthy `PriceData` wordt gekozen voor niet-gecontracteerde energietypen.

Verbeteringen:
- Verbeter logging voor het verversen van de cache voor morgen en promoties, inclusief short-circuits bij cache-hits, aantallen entries bij overschakeling, en het ontbreken van prijzen voor morgen.
- Voeg expliciete debug-logging toe wanneer geauthenticeerde-only API-calls worden overgeslagen voor niet-geauthenticeerde clients en wanneer wordt teruggevallen op `__add__` tijdens het combineren van prijsdata.

Tests:
- Voeg regressietests toe die het fallbackgedrag voor prijzen morgen/vandaag voor niet-geauthenticeerde gebruikers, resolutiemismatches bij middernachtoverschakeling, meerdaagse `PriceData`-promotie en `resolution_minutes`-cache round trips afdekken.
- Werk tests voor het laden van coordinator-cache bij om het verbeterde cacheformaat, inclusief resolutiemetadata, te weerspiegelen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix multiple price coordinator caching and promotion bugs affecting unauthenticated users, cache persistence, and midnight rollovers, and add targeted debug logging.

Bug Fixes:
- Ensure unauthenticated tomorrow price fetches do not fall back to cached today prices when no public data is available, preventing cache poisoning and missed retries.
- Preserve PriceData resolution_minutes across disk-cache serialization/deserialization so cached prices remain valid after restarts and do not trigger unnecessary live refetches.
- Prevent midnight promotion from crashing on real multi-day PriceData windows by correctly rebuilding filtered PriceData instances without using non-dataclass fields in dataclasses.replace.
- During midnight rollover on resolution mismatch, prefer tomorrow’s correct-resolution prices over yesterday’s stale data and avoid choosing empty-but-truthy PriceData for non-contracted energy types.

Enhancements:
- Improve tomorrow-cache refresh and promotion logging, including cache-hit short-circuits, rollover entry counts, and absence of tomorrow prices.
- Add explicit debug logging when skipping authenticated-only API calls for unauthenticated clients and when falling back to __add__ during price data combination.

Tests:
- Add regression tests covering unauthenticated tomorrow/today price fallback behavior, midnight rollover resolution mismatches, multi-day PriceData promotion, and resolution_minutes cache round trips.
- Update coordinator cache loading tests to reflect the enhanced cache format including resolution metadata.

</details>