### PR TITLE
fix: self-heal tomorrow-price cache poisoned by a stale bug

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -711,6 +711,29 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             )
             raise UpdateFailed from err
 
+    @staticmethod
+    def _tomorrow_cache_matches_date(
+        cached_prices_tomorrow: MarketPrices | None, tomorrow: date
+    ) -> bool:
+        """Check that cached_prices_tomorrow's entries are actually dated for tomorrow.
+
+        Guards against trusting `last_fetch_tomorrow`'s timestamp alone: a cache
+        poisoned by a since-fixed bug (e.g. today's prices mistakenly cached as
+        tomorrow's) would otherwise look like a legitimate same-day fetch forever,
+        since nothing else ever re-validates its contents against reality.
+        """
+        price_series = (
+            cached_prices_tomorrow.electricity or cached_prices_tomorrow.gas
+            if cached_prices_tomorrow
+            else None
+        )
+        if not price_series or not price_series.all:
+            return False
+
+        tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
+        first_entry_date = price_series.all[0].date_from.astimezone(tz_amsterdam).date()
+        return first_entry_date >= tomorrow
+
     async def _refresh_tomorrow_cache(
         self,
         today: date,
@@ -750,11 +773,21 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             and self.last_fetch_tomorrow is not None
             and self.last_fetch_tomorrow.date() == today
         ):
-            _LOGGER.debug(
-                "Tomorrow prices already cached (fetched %s), skipping API call",
-                self.last_fetch_tomorrow,
+            if self._tomorrow_cache_matches_date(self.cached_prices_tomorrow, tomorrow):
+                _LOGGER.debug(
+                    "Tomorrow prices already cached (fetched %s), skipping API call",
+                    self.last_fetch_tomorrow,
+                )
+                return self.cached_prices_tomorrow
+
+            _LOGGER.warning(
+                "Cached tomorrow prices claim to be fetched today but are not "
+                "actually dated for %s — discarding stale/incorrect cache and "
+                "fetching fresh data",
+                tomorrow,
             )
-            return self.cached_prices_tomorrow
+            self.cached_prices_tomorrow = None
+            self.last_fetch_tomorrow = None
 
         _LOGGER.debug(
             "Tomorrow cache status: cached=%s last_fetch=%s",

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -715,12 +715,22 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
     def _tomorrow_cache_matches_date(
         cached_prices_tomorrow: MarketPrices | None, tomorrow: date
     ) -> bool:
-        """Check that cached_prices_tomorrow's entries are actually dated for tomorrow.
+        """Check that cached_prices_tomorrow's entries are all dated tomorrow or later.
 
         Guards against trusting `last_fetch_tomorrow`'s timestamp alone: a cache
         poisoned by a since-fixed bug (e.g. today's prices mistakenly cached as
         tomorrow's) would otherwise look like a legitimate same-day fetch forever,
         since nothing else ever re-validates its contents against reality.
+
+        Checks every entry, not just the first, so a partially-poisoned or
+        unsorted series can't slip a today-dated entry past validation.
+
+        Entries dated *after* tomorrow are accepted too (`>=`, not `==`): the
+        API can return multi-day windows, and _price_data_after/
+        _build_tomorrow_cache (see promote_tomorrow_prices) deliberately
+        preserve that leftover data as the next day's tomorrow cache. None of
+        that is stale, so rejecting anything past tomorrow would discard
+        legitimately-cached multi-day data.
         """
         price_series = (
             cached_prices_tomorrow.electricity or cached_prices_tomorrow.gas
@@ -731,8 +741,10 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             return False
 
         tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
-        first_entry_date = price_series.all[0].date_from.astimezone(tz_amsterdam).date()
-        return first_entry_date >= tomorrow
+        return all(
+            price.date_from.astimezone(tz_amsterdam).date() >= tomorrow
+            for price in price_series.all
+        )
 
     async def _refresh_tomorrow_cache(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1700,3 +1700,80 @@ async def test_price_data_after_and_build_tomorrow_cache_with_real_pricedata() -
     assert built.electricity is remaining_electricity
     assert built.gas is not None
     assert built.gas.all == []
+
+
+def _make_market_prices(entry_date_iso: str):
+    """Build a minimal real MarketPrices with one electricity entry at the given ISO start."""
+    from datetime import timedelta as _timedelta
+
+    from python_frank_energie.models import MarketPrices, PriceData
+
+    entry_start = datetime.fromisoformat(entry_date_iso.replace("Z", "+00:00"))
+    raw_price = {
+        "from": entry_date_iso,
+        "till": (entry_start + _timedelta(minutes=15)).isoformat(),
+        "marketPrice": 0.1,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    electricity = PriceData([raw_price], energy_type="electricity")
+    gas = PriceData([], energy_type="gas")
+    return MarketPrices(electricity=electricity, gas=gas, energy_country="NL")
+
+
+@pytest.mark.asyncio
+async def test_refresh_tomorrow_cache_detects_poisoned_same_day_cache(
+    coordinator: FrankEnergieCoordinator,
+) -> None:
+    """A same-day cache whose entries aren't actually dated for tomorrow must be discarded.
+
+    Regression test for a real post-release bug report: a cache poisoned by
+    the (now-fixed) unauthenticated tomorrow-fetch bug has last_fetch_tomorrow
+    dated today, so the short-circuit treated it as a legitimate same-day
+    fetch forever — surviving reloads, restarts, and the manual refresh
+    button, since nothing ever re-validated the cached data against the date
+    it claims to represent.
+    """
+    from datetime import date
+
+    today = date(2026, 7, 20)
+    tomorrow = date(2026, 7, 21)
+    now_utc = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+    # Poisoned: claims to be fetched "today", but its entries are dated today,
+    # not tomorrow (exactly what the old bug produced).
+    coordinator.cached_prices_tomorrow = _make_market_prices("2026-07-20T10:00:00.000Z")
+    coordinator.last_fetch_tomorrow = now_utc
+
+    fresh_tomorrow_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+    coordinator._fetch_tomorrow_data = AsyncMock(return_value=fresh_tomorrow_prices)
+
+    result = await coordinator._refresh_tomorrow_cache(today, tomorrow, now_utc)
+
+    coordinator._fetch_tomorrow_data.assert_called_once()
+    assert result is fresh_tomorrow_prices
+    assert coordinator.cached_prices_tomorrow is fresh_tomorrow_prices
+
+
+@pytest.mark.asyncio
+async def test_refresh_tomorrow_cache_returns_valid_same_day_cache(
+    coordinator: FrankEnergieCoordinator,
+) -> None:
+    """A genuinely valid same-day cache must still short-circuit without an API call."""
+    from datetime import date
+
+    today = date(2026, 7, 20)
+    tomorrow = date(2026, 7, 21)
+    now_utc = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+    valid_tomorrow_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+    coordinator.cached_prices_tomorrow = valid_tomorrow_prices
+    coordinator.last_fetch_tomorrow = now_utc
+
+    coordinator._fetch_tomorrow_data = AsyncMock()
+
+    result = await coordinator._refresh_tomorrow_cache(today, tomorrow, now_utc)
+
+    coordinator._fetch_tomorrow_data.assert_not_called()
+    assert result is valid_tomorrow_prices

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1702,22 +1702,26 @@ async def test_price_data_after_and_build_tomorrow_cache_with_real_pricedata() -
     assert built.gas.all == []
 
 
-def _make_market_prices(entry_date_iso: str):
-    """Build a minimal real MarketPrices with one electricity entry at the given ISO start."""
+def _make_market_prices(*entry_date_isos: str):
+    """Build a minimal real MarketPrices with one electricity entry per given ISO start."""
     from datetime import timedelta as _timedelta
 
     from python_frank_energie.models import MarketPrices, PriceData
 
-    entry_start = datetime.fromisoformat(entry_date_iso.replace("Z", "+00:00"))
-    raw_price = {
-        "from": entry_date_iso,
-        "till": (entry_start + _timedelta(minutes=15)).isoformat(),
-        "marketPrice": 0.1,
-        "marketPriceTax": 0.02,
-        "sourcingMarkupPrice": 0.01,
-        "energyTaxPrice": 0.1,
-    }
-    electricity = PriceData([raw_price], energy_type="electricity")
+    raw_prices = []
+    for entry_date_iso in entry_date_isos:
+        entry_start = datetime.fromisoformat(entry_date_iso.replace("Z", "+00:00"))
+        raw_prices.append(
+            {
+                "from": entry_date_iso,
+                "till": (entry_start + _timedelta(minutes=15)).isoformat(),
+                "marketPrice": 0.1,
+                "marketPriceTax": 0.02,
+                "sourcingMarkupPrice": 0.01,
+                "energyTaxPrice": 0.1,
+            }
+        )
+    electricity = PriceData(raw_prices, energy_type="electricity")
     gas = PriceData([], energy_type="gas")
     return MarketPrices(electricity=electricity, gas=gas, energy_country="NL")
 
@@ -1777,3 +1781,68 @@ async def test_refresh_tomorrow_cache_returns_valid_same_day_cache(
 
     coordinator._fetch_tomorrow_data.assert_not_called()
     assert result is valid_tomorrow_prices
+
+
+@pytest.mark.asyncio
+async def test_refresh_tomorrow_cache_detects_poisoned_entry_after_a_valid_first_entry(
+    coordinator: FrankEnergieCoordinator,
+) -> None:
+    """A poisoned entry later in the series must be caught, not just entry[0].
+
+    Regression test raised in code review: checking only the first cached
+    entry would miss a partially-poisoned or unsorted series where a later
+    entry is dated today instead of tomorrow.
+    """
+    from datetime import date
+
+    today = date(2026, 7, 20)
+    tomorrow = date(2026, 7, 21)
+    now_utc = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+    # First entry is correctly dated tomorrow, second entry is poisoned (today).
+    coordinator.cached_prices_tomorrow = _make_market_prices(
+        "2026-07-20T22:00:00.000Z",  # tomorrow (local)
+        "2026-07-20T10:00:00.000Z",  # today (local) — poisoned
+    )
+    coordinator.last_fetch_tomorrow = now_utc
+
+    fresh_tomorrow_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+    coordinator._fetch_tomorrow_data = AsyncMock(return_value=fresh_tomorrow_prices)
+
+    result = await coordinator._refresh_tomorrow_cache(today, tomorrow, now_utc)
+
+    coordinator._fetch_tomorrow_data.assert_called_once()
+    assert result is fresh_tomorrow_prices
+
+
+@pytest.mark.asyncio
+async def test_refresh_tomorrow_cache_accepts_legitimate_multi_day_window(
+    coordinator: FrankEnergieCoordinator,
+) -> None:
+    """A cache spanning tomorrow and the day after must still short-circuit.
+
+    Regression test raised in code review: tightening the date check to
+    require every entry to match tomorrow exactly (rather than tomorrow or
+    later) would incorrectly discard legitimately-cached multi-day API
+    windows, which _price_data_after/_build_tomorrow_cache/
+    promote_tomorrow_prices are specifically designed to preserve.
+    """
+    from datetime import date
+
+    today = date(2026, 7, 20)
+    tomorrow = date(2026, 7, 21)
+    now_utc = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+    multi_day_prices = _make_market_prices(
+        "2026-07-20T22:00:00.000Z",  # tomorrow (local)
+        "2026-07-21T22:00:00.000Z",  # day after tomorrow (local)
+    )
+    coordinator.cached_prices_tomorrow = multi_day_prices
+    coordinator.last_fetch_tomorrow = now_utc
+
+    coordinator._fetch_tomorrow_data = AsyncMock()
+
+    result = await coordinator._refresh_tomorrow_cache(today, tomorrow, now_utc)
+
+    coordinator._fetch_tomorrow_data.assert_not_called()
+    assert result is multi_day_prices


### PR DESCRIPTION
## Summary
`_refresh_tomorrow_cache`'s same-day short-circuit trusted `last_fetch_tomorrow`'s timestamp alone as proof that tomorrow's prices were genuinely fetched. A cache poisoned by the (now-fixed) unauthenticated tomorrow-fetch bug has `last_fetch_tomorrow` dated the same day the poisoning happened, so it looked like a legitimate same-day fetch forever — surviving reloads, restarts, and the manual refresh button, since nothing ever re-validated the cached data against the date it actually claims to represent.

Adds `_tomorrow_cache_matches_date()`, which checks that the cached series' first entry is genuinely dated for tomorrow before trusting the short-circuit. If it isn't, the stale cache is discarded and a fresh fetch is attempted immediately — self-healing any pre-existing poisoned cache on the very next refresh, with no user action needed.

## Why this matters
 A clean install (which never had a chance to get poisoned) worked fine — pointing at the pre-existing on-disk cache surviving the upgrade unvalidated, exactly as traced through here.

## Test plan
- `test_refresh_tomorrow_cache_detects_poisoned_same_day_cache` — reproduces the exact poisoned state (`last_fetch_tomorrow` dated today, cached entries actually dated today rather than tomorrow) and confirms it's discarded and re-fetched.
- `test_refresh_tomorrow_cache_returns_valid_same_day_cache` — confirms a genuinely valid same-day cache still short-circuits without an unnecessary API call (no regression).
- Full suite: 164 passed, 3 skipped. Ruff clean.

## Samenvatting door Sourcery

Valideer en herstel automatisch de gecachte morgen-prijsgegevens om te voorkomen dat verouderde of onjuist gedateerde entries permanent als betrouwbaar worden beschouwd.

Bugfixes:
- Voorkom dat een vergiftigde morgen-prijscache met tijdstempels van dezelfde dag maar onjuiste datums onbeperkt als geldig wordt behandeld.

Tests:
- Voeg regressietests toe om te garanderen dat vergiftigde morgen-prijscaches van dezelfde dag worden verworpen en dat geldige caches van dezelfde dag nog steeds kortgesloten worden zonder extra API-call.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate and self-heal the cached tomorrow-price data to prevent stale or incorrectly dated entries from being permanently trusted.

Bug Fixes:
- Prevent a poisoned tomorrow-price cache with same-day timestamps but incorrect dates from being treated as valid indefinitely.

Tests:
- Add regression tests to ensure poisoned same-day tomorrow-price caches are discarded and valid same-day caches still short-circuit without an extra API call.

</details>