### PR TITLE
fix: apply the tomorrow-cache poisoning check to _is_cache_fresh too

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2867,7 +2867,20 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             return False
 
         if self.last_fetch_tomorrow and self.last_fetch_tomorrow.date() == today:
-            return True
+            tomorrow = today + timedelta(days=1)
+            if self._tomorrow_cache_matches_date(self.cached_prices_tomorrow, tomorrow):
+                _LOGGER.debug(
+                    "Cached tomorrow prices (fetched today) validated as "
+                    "genuinely dated for %s — cache is fresh",
+                    tomorrow,
+                )
+                return True
+            _LOGGER.debug(
+                "Cached tomorrow prices claim to be fetched today but are not "
+                "actually dated for %s — cache is not fresh",
+                tomorrow,
+            )
+            return False
 
         return now_local.time() < time(TOMORROW_PUBLICATION_HOUR_LOCAL, 0)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1846,3 +1846,63 @@ async def test_refresh_tomorrow_cache_accepts_legitimate_multi_day_window(
 
     coordinator._fetch_tomorrow_data.assert_not_called()
     assert result is multi_day_prices
+
+
+@pytest.mark.asyncio
+async def test_is_cache_fresh_detects_poisoned_same_day_tomorrow_cache(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """_is_cache_fresh must not be fooled by a poisoned same-day tomorrow cache.
+
+    Regression test: _is_cache_fresh had the same last_fetch_tomorrow-only
+    trust issue as the old _refresh_tomorrow_cache short-circuit. Since a
+    "fresh" verdict here makes async_config_entry_first_refresh skip the
+    live refresh entirely (super().async_config_entry_first_refresh() is
+    never called), a poisoned cache could survive every reload/restart
+    indefinitely — the _refresh_tomorrow_cache validation never even runs,
+    because _async_update_data is never reached on that path.
+    """
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    now_utc = datetime(2026, 7, 20, 18, 0, tzinfo=timezone.utc)
+
+    price_coordinator.last_fetch_today = now_utc
+    price_coordinator._static_prices_today = None  # bypass resolution check
+
+    # Poisoned: claims to be fetched today, but entries are dated today too.
+    price_coordinator.last_fetch_tomorrow = now_utc
+    price_coordinator.cached_prices_tomorrow = _make_market_prices(
+        "2026-07-20T10:00:00.000Z"
+    )
+
+    assert price_coordinator._is_cache_fresh(now_utc) is False
+
+
+@pytest.mark.asyncio
+async def test_is_cache_fresh_accepts_valid_same_day_tomorrow_cache(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """_is_cache_fresh must still return True for a genuinely valid same-day cache."""
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    now_utc = datetime(2026, 7, 20, 18, 0, tzinfo=timezone.utc)
+
+    price_coordinator.last_fetch_today = now_utc
+    price_coordinator._static_prices_today = None  # bypass resolution check
+
+    price_coordinator.last_fetch_tomorrow = now_utc
+    price_coordinator.cached_prices_tomorrow = _make_market_prices(
+        "2026-07-20T22:00:00.000Z"  # genuinely tomorrow (local)
+    )
+
+    assert price_coordinator._is_cache_fresh(now_utc) is True


### PR DESCRIPTION
## Summary
`_is_cache_fresh()` had the same `last_fetch_tomorrow`-only trust issue that `_refresh_tomorrow_cache` was fixed — but fixing it there wasn't enough. When `_is_cache_fresh()` returns `True`, `async_config_entry_first_refresh()` skips `super().async_config_entry_first_refresh()` entirely, so `_async_update_data()` — and therefore `_refresh_tomorrow_cache()` and its validation — never runs at all on that path. A poisoned cache could still survive every reload and restart indefinitely, because the one place that actually validates it was never reached.

Reuses `_tomorrow_cache_matches_date()` so both call sites share the same check, rather than duplicating the logic. Also adds a debug log on the success path (previously only the failure path logged anything), so a validated fresh cache is now visible in the logs instead of only ever showing the generic `"Fresh cache loaded, skipping initial API fetch"` message with no indication the poisoning check ran.

## Test plan
- `test_is_cache_fresh_detects_poisoned_same_day_tomorrow_cache` — confirms a poisoned same-day cache is correctly rejected as not fresh.
- `test_is_cache_fresh_accepts_valid_same_day_tomorrow_cache` — confirms a genuinely valid same-day cache still returns fresh (no regression).
- Full suite: 168 passed, 3 skipped. Ruff clean.
- Verified the new success-path log fires directly against the same reload scenario reported in logs while debugging this.

## Summary by Sourcery

Zorg ervoor dat de versheidscontroles van de morgen-prijs-cache de gecachte datums valideren in plaats van te vertrouwen op de ophaaltijdstempels.

Bugfixes:
- Voorkom dat vergiftigde morgen-prijs-caches voor dezelfde dag als vers worden behandeld door hun datums te valideren in de cache-versheidscontrole.

Verbeteringen:
- Hergebruik de gedeelde helper voor datumvalidatie van de morgen-cache in het cache-versheidspad en voeg debug-logging toe wanneer morgenprijzen succesvol worden gevalideerd.

Tests:
- Voeg regressietests toe die zowel het afwijzen van vergiftigde morgen-caches voor dezelfde dag als het accepteren van geldige morgen-caches voor dezelfde dag in de cache-versheidslogica afdekken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure tomorrow-price cache freshness checks validate cached dates rather than trusting fetch timestamps.

Bug Fixes:
- Prevent poisoned same-day tomorrow-price caches from being treated as fresh by validating their dates in the cache freshness check.

Enhancements:
- Reuse the shared tomorrow-cache date validation helper in the cache freshness path and add debug logging when tomorrow prices are successfully validated.

Tests:
- Add regression tests covering rejection of poisoned same-day tomorrow caches and acceptance of valid same-day tomorrow caches in the cache freshness logic.

</details>