### PR TITLE
fix: log entry counts when loading cached prices from disk

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -209,6 +209,16 @@ def _dict_to_market_prices(data: dict[str, Any]) -> MarketPrices:
     )
 
 
+def _price_count(market_prices: MarketPrices | None, energy_type: str) -> int:
+    """Count entries for one energy type ("electricity" or "gas") in a MarketPrices."""
+    if market_prices is None:
+        return 0
+    price_series = getattr(market_prices, energy_type, None)
+    if not price_series:
+        return 0
+    return len(price_series.all)
+
+
 def _resolution_state_to_dict(state: ContractPriceResolutionState) -> dict[str, Any]:
     """Convert ContractPriceResolutionState to serializable dict."""
     return {
@@ -2791,6 +2801,15 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             _LOGGER.debug("Loading cached prices from disk into coordinator data")
 
             self._parse_cached_data(cached_data)
+
+            _LOGGER.debug(
+                "Loaded from disk: today electricity=%s gas=%s, "
+                "tomorrow electricity=%s gas=%s",
+                _price_count(self._static_prices_today, "electricity"),
+                _price_count(self._static_prices_today, "gas"),
+                _price_count(self.cached_prices_tomorrow, "electricity"),
+                _price_count(self.cached_prices_tomorrow, "gas"),
+            )
 
             cache = PricesTodayCache(
                 prices_today=self._static_prices_today,

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1983,10 +1983,19 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 source_data.get(DATA_GAS), prices_tomorrow.gas
             )
         except ValueError:
+            today_elec = source_data.get(DATA_ELECTRICITY)
+            today_gas = source_data.get(DATA_GAS)
             _LOGGER.warning(
-                "Cannot merge price data: resolution or type mismatch "
-                "(likely a contract resolution change). Using tomorrow's "
-                "prices for the new day instead of yesterday's stale resolution"
+                "Cannot merge today's and tomorrow's price data: resolution "
+                "or type mismatch (today electricity=%s gas=%s, tomorrow "
+                "electricity=%s gas=%s). This can happen on a genuine "
+                "contract resolution change, or simply because the API "
+                "returned different resolutions for the two fetches. Using "
+                "tomorrow's prices for the new day instead of merging",
+                getattr(today_elec, "resolution_minutes", None),
+                getattr(today_gas, "resolution_minutes", None),
+                getattr(prices_tomorrow.electricity, "resolution_minutes", None),
+                getattr(prices_tomorrow.gas, "resolution_minutes", None),
             )
             # An empty PriceData instance is truthy, so check for actual
             # entries — the tomorrow cache holds an empty series for an

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -209,14 +209,22 @@ def _dict_to_market_prices(data: dict[str, Any]) -> MarketPrices:
     )
 
 
-def _price_count(market_prices: MarketPrices | None, energy_type: str) -> int:
-    """Count entries for one energy type ("electricity" or "gas") in a MarketPrices."""
+def _price_counts(market_prices: MarketPrices | None) -> tuple[int, int]:
+    """Return (electricity_count, gas_count) for a MarketPrices.
+
+    Explicit attribute access rather than getattr(..., energy_type) so a
+    typo'd energy type can't silently resolve to 0 instead of failing —
+    there's no string parameter here to misuse. Centralized so any future
+    logging that needs these counts reuses this instead of duplicating the
+    electricity/gas lookup at each call site.
+    """
     if market_prices is None:
-        return 0
-    price_series = getattr(market_prices, energy_type, None)
-    if not price_series:
-        return 0
-    return len(price_series.all)
+        return 0, 0
+    electricity_count = (
+        len(market_prices.electricity.all) if market_prices.electricity else 0
+    )
+    gas_count = len(market_prices.gas.all) if market_prices.gas else 0
+    return electricity_count, gas_count
 
 
 def _resolution_state_to_dict(state: ContractPriceResolutionState) -> dict[str, Any]:
@@ -2811,13 +2819,17 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
 
             self._parse_cached_data(cached_data)
 
+            today_elec_count, today_gas_count = _price_counts(self._static_prices_today)
+            tomorrow_elec_count, tomorrow_gas_count = _price_counts(
+                self.cached_prices_tomorrow
+            )
             _LOGGER.debug(
                 "Loaded from disk: today electricity=%s gas=%s, "
                 "tomorrow electricity=%s gas=%s",
-                _price_count(self._static_prices_today, "electricity"),
-                _price_count(self._static_prices_today, "gas"),
-                _price_count(self.cached_prices_tomorrow, "electricity"),
-                _price_count(self.cached_prices_tomorrow, "gas"),
+                today_elec_count,
+                today_gas_count,
+                tomorrow_elec_count,
+                tomorrow_gas_count,
             )
 
             cache = PricesTodayCache(

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -5201,7 +5201,7 @@ async def async_setup_entry(
 
     enode_vehicles = vehicle_coordinator.data.get(DATA_ENODE_VEHICLES)
     num_vehicles = len(enode_vehicles.vehicles) if enode_vehicles else 0
-    _LOGGER.debug("Aantal voertuigen gevonden: %d", num_vehicles)
+    _LOGGER.debug("Number of vehicles found: %d", num_vehicles)
 
     if enode_vehicles and enode_vehicles.vehicles:
         enode_vehicle_sensors = []


### PR DESCRIPTION
## Summary
`_async_setup()` logged that it loaded cached prices from disk, but nothing about what was actually in them. On a reload where `_is_cache_fresh()` decides to skip the live refresh entirely (#241), the only visibility into the tomorrow cache was the pass/fail validation message — no indication of how many electricity/gas periods were actually loaded for either today or tomorrow.

Adds one debug line reporting all four counts (today electricity/gas, tomorrow electricity/gas) right after the cache is parsed, so cache contents are visible on this path too, not just after a live fetch.

## Test plan
- Full suite: 168 passed, 3 skipped. Ruff clean.
- Verified directly: `_price_count()` correctly counts entries for a realistic 96-entry PT15M series and returns 0 for a `None` series.

## Summary by Sourcery

Verbeter de logging van gecachete prijsgegevens en voertuig­aantallen om het debuggen en de zichtbaarheid van de coördinatorstatus te verbeteren.

Verbeteringen:
- Voeg een helper toe om het aantal entries voor elektriciteits- en gasprijzen in gecachete `MarketPrices` te tellen en log de aantallen voor vandaag/morgen na het parsen van de schijfcache.
- Breid de waarschuwing uit wanneer het samenvoegen van prijzen voor vandaag en morgen mislukt, zodat de resoluties van beide contracten voor elektriciteit en gas worden opgenomen.
- Standaardiseer het debug-logbericht voor het aantal voertuigen in de sensormodule zodat Engelse bewoording wordt gebruikt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging of cached price data and vehicle counts to aid debugging and visibility into coordinator state.

Enhancements:
- Add a helper to count electricity and gas price entries in cached MarketPrices and log today/tomorrow counts after parsing disk cache.
- Expand the warning when merging today and tomorrow prices fails to include both contracts' resolutions for electricity and gas.
- Standardize the vehicle count debug log message in the sensor module to use English wording.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when energy price data cannot be merged, including clearer details about resolution or type mismatches.
  * Added visibility into cached electricity and gas price entry counts during loading.
  * Updated vehicle discovery logging to use clear English wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->