### PR TITLE
fix: crash in vehicle sensor setup that could take the whole platform down

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -5215,7 +5215,9 @@ async def async_setup_entry(
                 )
 
         for entity in enode_vehicle_sensors:
-            _LOGGER.debug("Toegevoegde voertuig sensor: %s", entity.name)
+            # entity.name isn't safe here: it needs self.platform, which
+            # is only set once async_add_entities registers the entity below.
+            _LOGGER.debug("Added vehicle sensor: %s", entity.unique_id)
 
         entities.extend(enode_vehicle_sensors)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -610,6 +610,77 @@ def test_enode_charger_sensor_properties_and_value(
     assert sensor_rate.native_value == pytest.approx(11.0)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("num_vehicles", [1, 2])
+async def test_async_setup_entry_with_vehicles_does_not_crash(
+    hass: HomeAssistant, num_vehicles
+):
+    """Regression test for the vehicle sensor setup crash (see 7e97f7c).
+
+    async_setup_entry used to log entity.name for each vehicle sensor right
+    after creating it, but before async_add_entities had run - i.e. before
+    the entity had a platform. Entity.name requires self.platform, so this
+    raised AttributeError and aborted the *entire* sensor platform setup for
+    anyone with Enode vehicles connected, taking every other queued entity
+    (battery, PV, price, etc.) down with it. The fix logs entity.unique_id
+    instead, which has no platform dependency.
+
+    This calls the real async_setup_entry with 1+ vehicles present to prove
+    setup completes and every vehicle/description pair is added.
+    """
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import DATA_ENODE_VEHICLES
+    from custom_components.frank_energie.sensor import (
+        EnodeVehicleSensor,
+        ENODE_VEHICLE_SENSOR_TYPES,
+        async_setup_entry,
+    )
+
+    def make_coordinator():
+        coordinator = MagicMock()
+        coordinator.data = {}
+        coordinator.api.is_authenticated = False
+        return coordinator
+
+    runtime_data = MagicMock()
+    runtime_data.settings_coordinator = make_coordinator()
+    runtime_data.price_coordinator = make_coordinator()
+    runtime_data.battery_coordinator = make_coordinator()
+    runtime_data.charger_coordinator = make_coordinator()
+    runtime_data.pv_coordinator = make_coordinator()
+    runtime_data.statistics_coordinator = make_coordinator()
+
+    vehicle_coordinator = make_coordinator()
+    vehicles_obj = MagicMock()
+    vehicles_obj.vehicles = [
+        {"id": f"veh_{i}", "information": {"brand": "Tesla", "model": "Model 3"}}
+        for i in range(num_vehicles)
+    ]
+    vehicle_coordinator.data = {DATA_ENODE_VEHICLES: vehicles_obj}
+    runtime_data.vehicle_coordinator = vehicle_coordinator
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry_id"
+    config_entry.unique_id = "test_unique_id"
+    config_entry.runtime_data = runtime_data
+
+    added_entities: list = []
+
+    def async_add_entities(new_entities, update_before_add=False):
+        added_entities.extend(new_entities)
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    vehicle_entities = [e for e in added_entities if isinstance(e, EnodeVehicleSensor)]
+    assert len(vehicle_entities) == num_vehicles * len(ENODE_VEHICLE_SENSOR_TYPES)
+    assert {e.unique_id for e in vehicle_entities} == {
+        f"frank_energie_veh_{i}_{description.key}"
+        for i in range(num_vehicles)
+        for description in ENODE_VEHICLE_SENSOR_TYPES
+    }
+
+
 def test_calculate_market_percent_tax() -> None:
     """Test the _calculate_market_percent_tax helper function under various pricing scenarios."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
Logging `entity.name` before an entity is registered raises `AttributeError` — `Entity.name` needs `self.platform`, which is only set once `async_add_entities` runs. That exception was never caught inside `async_setup_entry`, so it propagated all the way up and aborted the **entire** sensor platform setup for anyone with Enode vehicles connected — including every entity queued earlier in the same call (battery, PV, price, etc.), since `entities.extend()` / the final `async_add_entities()` call for the accumulated list happens *after* this point in the function.

Switches to `entity.unique_id`, a plain `self._attr_unique_id` return with no platform dependency.

## Why this matters
Likely explains reports of "almost all entities unavailable" after upgrading, for users who also have Enode vehicles connected — not limited to vehicle sensors specifically, since the crash takes the whole platform setup down with it.

Fixes #239 

## Test plan
- Full suite: 168 passed, 3 skipped. Ruff clean.
- Verified `Entity.unique_id` has no platform dependency by reading the installed Home Assistant source directly.

## Summary by Sourcery

Voorkom dat het opzetten van voertuigsensoren het hele sensorplatform laat crashen wanneer Enode-voertuigen aanwezig zijn door een veilige identifier te gebruiken voor logging.

Bugfixes:
- Voorkom een `AttributeError` tijdens het opzetten van Enode-voertuigsensoren door de unieke ID van de entiteit te loggen in plaats van de naam vóór registratie van de entiteit.

Tests:
- Voeg een regressietest toe die garandeert dat `async_setup_entry` voltooit zonder te crashen en alle verwachte voertuigsensor-entiteiten aanmaakt voor één of meer voertuigen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent vehicle sensor setup from crashing the entire sensor platform when Enode vehicles are present by using a safe identifier for logging.

Bug Fixes:
- Avoid AttributeError during Enode vehicle sensor setup by logging the entity unique ID instead of the name before entity registration.

Tests:
- Add regression test ensuring async_setup_entry completes without crashing and creates all expected vehicle sensor entities for one or more vehicles.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle sensor setup reliability by preventing errors during platform initialization.
  * Vehicle sensor logging now uses stable identifiers for clearer diagnostics.

* **Tests**
  * Added regression coverage for setups with varying numbers of vehicles.
  * Verified that all expected vehicle sensors are created with the correct identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->