### PR TITLE
fix: preserve previous day's prices when a live fetch crosses local midnight

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2962,6 +2962,64 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             )
             self.update_interval = new_interval
 
+    def _carry_forward_previous_day(
+        self, new_prices: MarketPrices | None, today: date
+    ) -> MarketPrices | None:
+        """Preserve yesterday's cached prices when a live fetch crosses local midnight.
+
+        Normally `promote_tomorrow_prices` merges the previous day's prices
+        with the already-cached tomorrow prices at exactly 00:00 local time,
+        so `previous_hour`/history-dependent sensors don't go unavailable.
+        But if tomorrow's prices weren't cached yet when midnight hit (late
+        API publication, a failed fetch, a restart), promotion has nothing to
+        promote, and this method's caller ends up doing a live, today-only
+        fetch instead. Without this, that fetch would replace `today - 1`'s
+        data outright and `previous_hour` would have no matching entry for
+        the entire first hour of the new day.
+        """
+        previous = self._static_prices_today
+        if previous is None or new_prices is None:
+            return new_prices
+
+        tz_amsterdam = ZoneInfo(TIMEZONE_AMSTERDAM)
+
+        def is_from_before_today(price_data: PriceData | None) -> bool:
+            return bool(
+                price_data
+                and price_data.all
+                and price_data.all[-1].date_from.astimezone(tz_amsterdam).date()
+                < today
+            )
+
+        if not (
+            is_from_before_today(previous.electricity)
+            or is_from_before_today(previous.gas)
+        ):
+            return new_prices
+
+        try:
+            merged_electricity = self._merge_prices(
+                previous.electricity, new_prices.electricity
+            )
+            merged_gas = self._merge_prices(previous.gas, new_prices.gas)
+        except ValueError:
+            _LOGGER.debug(
+                "Cannot carry yesterday's prices over local midnight "
+                "(resolution or energy-type mismatch); using freshly "
+                "fetched today prices only"
+            )
+            return new_prices
+
+        # Keep yesterday + today only; anything older would just accumulate.
+        cutoff = today - timedelta(days=2)
+        return MarketPrices(
+            electricity=self._price_data_after(merged_electricity, cutoff)
+            or merged_electricity,
+            gas=self._price_data_after(merged_gas, cutoff) or merged_gas,
+            energy_country=new_prices.energy_country,
+            energy_type=new_prices.energy_type,
+        )
+
     async def _async_update_data(self) -> FrankEnergieData:
         """Fetch price data."""
         now_utc = datetime.now(ZoneInfo("UTC"))
@@ -2999,8 +3057,11 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                 or self.last_fetch_today.date() != today
             ):
                 try:
-                    prices_today = await self._fetch_prices_with_fallback(
+                    fetched_prices_today = await self._fetch_prices_with_fallback(
                         today, tomorrow, use_fallback=True
+                    )
+                    prices_today = self._carry_forward_previous_day(
+                        fetched_prices_today, today
                     )
                     self._update_today_prices(prices_today)
                     self.last_fetch_today = now_utc

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2987,8 +2987,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             return bool(
                 price_data
                 and price_data.all
-                and price_data.all[-1].date_from.astimezone(tz_amsterdam).date()
-                < today
+                and price_data.all[-1].date_from.astimezone(tz_amsterdam).date() < today
             )
 
         if not (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1492,6 +1492,139 @@ async def test_price_coordinator_midnight_rollover_resolution_mismatch(
 
 
 @pytest.mark.asyncio
+async def test_carry_forward_previous_day_merges_yesterday_tail(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """A live today-only fetch across midnight must keep yesterday's tail.
+
+    Regression test: promote_tomorrow_prices only merges yesterday's prices
+    with the already-cached tomorrow prices at exactly 00:00 local time. If
+    tomorrow's prices weren't cached yet when midnight hit (late API
+    publication, a failed fetch, a restart), promotion has nothing to
+    promote, and _async_update_data instead does a live, today-only fetch.
+    Without carrying yesterday's cached prices forward, that fetch replaced
+    `_static_prices_today` outright and `previous_hour` had no matching entry
+    for the entire first hour of the new day.
+    """
+    from datetime import date
+
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    # Amsterdam is UTC+2 in July (CEST): 21:00 UTC on the 20th is 23:00 local
+    # on the 20th (yesterday), and 22:00 UTC on the 20th is 00:00 local on
+    # the 21st (the new "today").
+    price_coordinator._static_prices_today = _make_market_prices(
+        "2026-07-20T21:00:00.000Z"
+    )
+
+    new_today = date(2026, 7, 21)
+    fresh_today_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+
+    merged = price_coordinator._carry_forward_previous_day(
+        fresh_today_prices, new_today
+    )
+
+    dates = {p.date_from for p in merged.electricity.all}
+    assert datetime(2026, 7, 20, 21, 0, tzinfo=timezone.utc) in dates
+    assert datetime(2026, 7, 20, 22, 0, tzinfo=timezone.utc) in dates
+
+
+@pytest.mark.asyncio
+async def test_carry_forward_previous_day_noop_within_same_day(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """No merge should happen on an ordinary same-day refetch.
+
+    Merging on every same-day fetch (not just the midnight-crossing one)
+    would needlessly re-run the merge machinery and risk unbounded growth.
+    """
+    from datetime import date
+
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    today = date(2026, 7, 21)
+    price_coordinator._static_prices_today = _make_market_prices(
+        "2026-07-21T10:00:00.000Z"
+    )
+    fresh_today_prices = _make_market_prices("2026-07-21T11:00:00.000Z")
+
+    result = price_coordinator._carry_forward_previous_day(fresh_today_prices, today)
+
+    assert result is fresh_today_prices
+
+
+@pytest.mark.asyncio
+async def test_carry_forward_previous_day_prunes_older_than_yesterday(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """Stale multi-day-old cached data must not accumulate forever."""
+    from datetime import date
+
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    # Cached data is two days stale (e.g. HA was offline over midnight twice):
+    # 21:00 UTC on the 19th is 23:00 local on the 19th.
+    price_coordinator._static_prices_today = _make_market_prices(
+        "2026-07-19T21:00:00.000Z"
+    )
+
+    new_today = date(2026, 7, 21)
+    fresh_today_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+
+    merged = price_coordinator._carry_forward_previous_day(
+        fresh_today_prices, new_today
+    )
+
+    dates = {p.date_from for p in merged.electricity.all}
+    assert datetime(2026, 7, 19, 21, 0, tzinfo=timezone.utc) not in dates
+    assert datetime(2026, 7, 20, 22, 0, tzinfo=timezone.utc) in dates
+
+
+@pytest.mark.asyncio
+async def test_carry_forward_previous_day_falls_back_on_resolution_mismatch(
+    mock_frank_energie, mock_config_entry
+) -> None:
+    """A resolution/energy-type change across midnight must not crash; use fresh data."""
+    from datetime import date
+
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    price_coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+
+    price_coordinator._static_prices_today = _make_market_prices(
+        "2026-07-20T21:00:00.000Z"
+    )
+    new_today = date(2026, 7, 21)
+    fresh_today_prices = _make_market_prices("2026-07-20T22:00:00.000Z")
+
+    price_coordinator._merge_prices = MagicMock(side_effect=ValueError("mismatch"))
+
+    result = price_coordinator._carry_forward_previous_day(
+        fresh_today_prices, new_today
+    )
+
+    assert result is fresh_today_prices
+
+
+@pytest.mark.asyncio
 async def test_sub_coordinators_properties(
     mock_frank_energie, mock_config_entry
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1493,7 +1493,7 @@ async def test_price_coordinator_midnight_rollover_resolution_mismatch(
 
 @pytest.mark.asyncio
 async def test_carry_forward_previous_day_merges_yesterday_tail(
-    mock_frank_energie, mock_config_entry
+    mock_frank_energie: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
     """A live today-only fetch across midnight must keep yesterday's tail.
 
@@ -1530,13 +1530,13 @@ async def test_carry_forward_previous_day_merges_yesterday_tail(
     )
 
     dates = {p.date_from for p in merged.electricity.all}
-    assert datetime(2026, 7, 20, 21, 0, tzinfo=timezone.utc) in dates
-    assert datetime(2026, 7, 20, 22, 0, tzinfo=timezone.utc) in dates
+    assert datetime(2026, 7, 20, 21, 0, tzinfo=UTC) in dates
+    assert datetime(2026, 7, 20, 22, 0, tzinfo=UTC) in dates
 
 
 @pytest.mark.asyncio
 async def test_carry_forward_previous_day_noop_within_same_day(
-    mock_frank_energie, mock_config_entry
+    mock_frank_energie: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
     """No merge should happen on an ordinary same-day refetch.
 
@@ -1565,7 +1565,7 @@ async def test_carry_forward_previous_day_noop_within_same_day(
 
 @pytest.mark.asyncio
 async def test_carry_forward_previous_day_prunes_older_than_yesterday(
-    mock_frank_energie, mock_config_entry
+    mock_frank_energie: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
     """Stale multi-day-old cached data must not accumulate forever."""
     from datetime import date
@@ -1591,13 +1591,13 @@ async def test_carry_forward_previous_day_prunes_older_than_yesterday(
     )
 
     dates = {p.date_from for p in merged.electricity.all}
-    assert datetime(2026, 7, 19, 21, 0, tzinfo=timezone.utc) not in dates
-    assert datetime(2026, 7, 20, 22, 0, tzinfo=timezone.utc) in dates
+    assert datetime(2026, 7, 19, 21, 0, tzinfo=UTC) not in dates
+    assert datetime(2026, 7, 20, 22, 0, tzinfo=UTC) in dates
 
 
 @pytest.mark.asyncio
 async def test_carry_forward_previous_day_falls_back_on_resolution_mismatch(
-    mock_frank_energie, mock_config_entry
+    mock_frank_energie: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
     """A resolution/energy-type change across midnight must not crash; use fresh data."""
     from datetime import date


### PR DESCRIPTION
## Summary

- `previous_hour` (and related history-dependent) sensors went unavailable for the first hour after local midnight specifically on unauthenticated (public-price) setups.
- `promote_tomorrow_prices()` merges yesterday's cached prices with tomorrow's at exactly 00:00 local time, but only when tomorrow's prices were already cached by then. Public/unauthenticated tomorrow-price fetches are less reliable than the authenticated `user_prices` fetch, so this condition is more often not met for unauthenticated users.
- When it isn't met, `promote_tomorrow_prices()` has nothing to promote, and the coordinator's next live "today" fetch replaced `_static_prices_today` outright — discarding yesterday's last hour(s) and leaving `previous_hour` with no matching entry until the next successful fetch.
- Added `FrankEnergiePriceCoordinator._carry_forward_previous_day()`, which detects when a live fetch is crossing local midnight and merges in whatever's still cached from the previous day (reusing the existing
  `_merge_prices`/`_price_data_after` helpers), pruning anything older than yesterday so the series doesn't grow unbounded. Falls back gracefully to the freshly-fetched data alone on a resolution/energy-type mismatch.

## Test plan

- [x] `pytest tests/test_coordinator.py -q` — 82 passed (4 new regression tests: merges yesterday's tail across midnight, no-ops on an ordinary same-day refetch, prunes multi-day-stale data, falls back cleanly on a resolution mismatch)
- [x] `pytest tests/ -q` — 174 passed, 3 skipped (full suite, no regressions)
- [x] Verified against a live unauthenticated setup across an actual local midnight rollover

## Summary by Sourcery

Behoud de in de cache opgeslagen prijzen van de vorige dag wanneer een live, uitsluitend-today-fetch de lokale middernacht overschrijdt, zodat geschiedenis-afhankelijke sensoren beschikbaar blijven, terwijl de gecachte reeks begrensd en veerkrachtig blijft bij gegevensafwijkingen.

Bug Fixes:
- Voorkom dat `previous_hour` en andere geschiedenis-afhankelijke sensoren onbeschikbaar worden tijdens het eerste uur na lokale middernacht wanneer de prijzen van morgen nog niet in de cache staan.
- Vermijd crashes of inconsistente toestand wanneer de prijsresolutie of het energietype rond middernacht verandert door in dat geval uitsluitend terug te vallen op vers opgehaalde data.

Enhancements:
- Introduceer logica om de gecachte prijzen van gisteren samen te voegen met de nieuw opgehaalde prijzen van vandaag bij updates die de middernacht overschrijden, terwijl data ouder dan gisteren wordt opgeschoond om onbegrensde groei te voorkomen.

Tests:
- Voeg regressietests toe voor gedrag bij middernachtoverschrijdende samenvoeging, no-op-gedrag binnen dezelfde dag, opruimen van data die meerdere dagen oud is, en een gracieuze fallback bij resolutie-mismatches.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve previous day's cached prices when a live today-only fetch crosses local midnight so history-dependent sensors remain available, while keeping the cached series bounded and resilient to data mismatches.

Bug Fixes:
- Prevent previous_hour and other history-dependent sensors from going unavailable during the first hour after local midnight when tomorrow's prices were not yet cached.
- Avoid crashes or inconsistent state when price resolution or energy type changes across midnight by falling back to freshly fetched data only.

Enhancements:
- Introduce logic to merge yesterday's cached prices into newly fetched today prices on midnight-crossing updates while pruning data older than yesterday to avoid unbounded growth.

Tests:
- Add regression tests covering midnight rollover merging behaviour, same-day no-op behaviour, pruning of multi-day-stale data, and graceful fallback on resolution mismatch.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price continuity around local midnight by preserving relevant previous-day data during refreshes.
  * Prevented early-day price sensors from losing historical entries after overnight updates.
  * Avoided retaining stale data and safely handled incompatible price data during refreshes.

* **Tests**
  * Added coverage for midnight merging, same-day refreshes, stale-data cleanup, and resolution mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->