### PR TITLE
fix: add missing Standard battery strategy option and fix vehicle sensor availability

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -167,6 +167,7 @@ BATTERY_STRATEGY_OPTIONS: Final[list[str]] = [
     "conservative",
     "aggressive",
     "imbalance_only",
+    "standard",
 ]
 
 ENODE_CHARGING_MODE_OPTIONS: Final[list[str]] = [

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -336,6 +336,7 @@ class EnodeVehicleEntityDescription(SensorEntityDescription):
     value_fn: Callable[[dict], object]
     attr_fn: Callable[[dict], dict] = field(default_factory=lambda: lambda _: {})
     unique_id_fn: Callable[[dict], str] | None = None
+    available_fn: Callable[[dict], bool] | None = None
     authenticated: bool = False
     service_name: str = SERVICE_NAME_ENODE_VEHICLES
     translation_key: str | None = None
@@ -352,6 +353,7 @@ class EnodeVehicleEntityDescription(SensorEntityDescription):
         service_name: Union[str, None] = None,
         value_fn: Callable[[dict[str, StateType]], StateType] | None = None,
         unique_id_fn: Callable[[dict], str] | None = None,
+        available_fn: Callable[[dict], bool] | None = None,
         attr_fn: Callable[[dict], dict[str, StateType | list | None]] = field(
             default_factory=lambda: lambda _: {}
         ),
@@ -380,6 +382,7 @@ class EnodeVehicleEntityDescription(SensorEntityDescription):
             else entity_category,
         )
         object.__setattr__(self, "value_fn", value_fn or (lambda _: STATE_UNKNOWN))
+        object.__setattr__(self, "available_fn", available_fn)
 
     def get_state(self, data: dict[str, object]) -> StateType:
         """Return validated state value."""
@@ -5263,15 +5266,17 @@ def _get_nested(data: object, *keys: str) -> object | None:
     return data
 
 
-def _parse_iso_datetime(dt_str: str | None) -> datetime | None:
+def _parse_iso_datetime(dt_value: datetime | str | None) -> datetime | None:
     """Parse ISO 8601 datetime string to aware datetime or return None."""
-    if not dt_str:
+    if not dt_value:
         return None
+    if isinstance(dt_value, datetime):
+        return dt_value
     try:
         # Zorg dat 'Z' vervangen wordt door '+00:00' voor UTC
-        if dt_str.endswith("Z"):
-            dt_str = dt_str[:-1] + "+00:00"
-        return datetime.fromisoformat(dt_str)
+        if dt_value.endswith("Z"):
+            dt_value = dt_value[:-1] + "+00:00"
+        return datetime.fromisoformat(dt_value)
     except ValueError:
         return None
 

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -5267,7 +5267,7 @@ def _get_nested(data: object, *keys: str) -> object | None:
 
 
 def _parse_iso_datetime(dt_value: datetime | str | None) -> datetime | None:
-    """Parse ISO 8601 datetime string to aware datetime or return None."""
+    """Return dt_value unchanged if already a datetime, else parse it as an ISO 8601 string."""
     if not dt_value:
         return None
     if isinstance(dt_value, datetime):

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -232,9 +232,10 @@
         "name": "Smart battery strategy",
         "state": {
           "aggressive": "Aggressive",
-          "balanced": "Standard",
+          "balanced": "Balanced",
           "conservative": "Conservative",
           "imbalance_only": "Imbalance only",
+          "standard": "Standard",
           "unknown": "Unknown"
         }
       },
@@ -985,10 +986,11 @@
       "battery_imbalance_trading_strategy": {
         "name": "Imbalance Trading Strategy",
         "state": {
-          "balanced": "Standard",
+          "balanced": "Balanced",
           "conservative": "Conservative",
           "imbalance_only": "Imbalance only",
           "aggressive": "Aggressive",
+          "standard": "Standard",
           "unknown": "Unknown"
         }
       },

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -232,9 +232,10 @@
         "name": "Smart battery strategy",
         "state": {
           "aggressive": "Aggressive",
-          "balanced": "Standard",
+          "balanced": "Balanced",
           "conservative": "Conservative",
           "imbalance_only": "Imbalance only",
+          "standard": "Standard",
           "unknown": "Unknown"
         }
       },
@@ -989,6 +990,7 @@
           "conservative": "Conservative",
           "imbalance_only": "Imbalance only",
           "aggressive": "Aggressive",
+          "standard": "Standard",
           "unknown": "Unknown"
         }
       },

--- a/custom_components/frank_energie/translations/fr.json
+++ b/custom_components/frank_energie/translations/fr.json
@@ -232,9 +232,10 @@
         "name": "Stratégie de batterie intelligente",
         "state": {
           "aggressive": "Agressive",
-          "balanced": "Standard",
+          "balanced": "Équilibrée",
           "conservative": "Conservatrice",
           "imbalance_only": "Équilibrage uniquement",
+          "standard": "Standard",
           "unknown": "Inconnu"
         }
       },
@@ -985,10 +986,11 @@
       "battery_imbalance_trading_strategy": {
         "name": "Stratégie de trading d'équilibrage",
         "state": {
-          "balanced": "Standard",
+          "balanced": "Équilibrée",
           "conservative": "Conservatrice",
           "imbalance_only": "Équilibrage uniquement",
           "aggressive": "Agressive",
+          "standard": "Standard",
           "unknown": "Inconnu"
         }
       },

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -794,10 +794,11 @@
       "battery_imbalance_trading_strategy": {
         "name": "Onbalans handelsstrategie",
         "state": {
-          "balanced": "Standaard",
+          "balanced": "Gebalanceerd",
           "conservative": "Conservatief",
           "imbalance_only": "Alleen onbalans",
           "aggressive": "Agressief",
+          "standard": "Standaard",
           "unknown": "Unknown"
         }
       },
@@ -1024,9 +1025,10 @@
         "name": "Slimme batterijstrategie",
         "state": {
           "aggressive": "Agressief",
-          "balanced": "Standaard",
+          "balanced": "Gebalanceerd",
           "conservative": "Conservatief",
           "imbalance_only": "Alleen onbalans",
+          "standard": "Standaard",
           "unknown": "Unknown"
         }
       },

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -794,10 +794,11 @@
       "battery_imbalance_trading_strategy": {
         "name": "Onbalans handelsstrategie",
         "state": {
-          "balanced": "Standaard",
+          "balanced": "Gebalanceerd",
           "conservative": "Conservatief",
           "imbalance_only": "Alleen onbalans",
           "aggressive": "Agressief",
+          "standard": "Standaard",
           "unknown": "Unknown"
         }
       },
@@ -1024,9 +1025,10 @@
         "name": "Slimme batterijstrategie",
         "state": {
           "aggressive": "Agressief",
-          "balanced": "Standaard",
+          "balanced": "Gebalanceerd",
           "conservative": "Conservatief",
           "imbalance_only": "Alleen onbalans",
+          "standard": "Standaard",
           "unknown": "Unknown"
         }
       },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -681,6 +681,136 @@ async def test_async_setup_entry_with_vehicles_does_not_crash(
     }
 
 
+def _make_tesla_model_3(last_seen: datetime) -> object:
+    """Build a real EnodeVehicle (Tesla Model 3), as returned by python-frank-energie."""
+    from python_frank_energie.models import (
+        ChargeSettings,
+        ChargeState,
+        EnodeVehicle,
+        PowerDeliveryState,
+        VehicleInformation,
+    )
+
+    now = dt.utcnow()
+    return EnodeVehicle(
+        id="veh_123",
+        can_smart_charge=True,
+        charge_settings=ChargeSettings(
+            calculated_deadline=now,
+            capacity=75.0,
+            deadline=None,
+            hour_friday=7,
+            hour_monday=7,
+            hour_saturday=7,
+            hour_sunday=7,
+            hour_thursday=7,
+            hour_tuesday=7,
+            hour_wednesday=7,
+            id="cs-1",
+            is_smart_charging_enabled=True,
+            is_solar_charging_enabled=False,
+            max_charge_limit=100,
+            min_charge_limit=20,
+        ),
+        charge_state=ChargeState(
+            battery_capacity=75.0,
+            battery_level=80,
+            charge_limit=100,
+            charge_rate=11.0,
+            charge_time_remaining=0,
+            is_charging=False,
+            is_fully_charged=True,
+            is_plugged_in=True,
+            last_updated=now,
+            power_delivery_state=PowerDeliveryState.PLUGGED_IN_FINISHED,
+            range=300,
+        ),
+        information=VehicleInformation(
+            brand="Tesla", model="Model 3", vin="VIN123", year=2022
+        ),
+        interventions=[],
+        is_reachable=True,
+        last_seen=last_seen,
+    )
+
+
+def test_enode_vehicle_available_does_not_crash_without_available_fn(
+    hass: HomeAssistant,
+) -> None:
+    """Test that EnodeVehicleSensor.available handles descriptions with no available_fn."""
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import DATA_ENODE_VEHICLES
+    from custom_components.frank_energie.sensor import (
+        ENODE_VEHICLE_SENSOR_TYPES,
+        EnodeVehicleSensor,
+    )
+
+    vehicle = _make_tesla_model_3(last_seen=dt.utcnow())
+    vehicles_obj = MagicMock()
+    vehicles_obj.vehicles = [vehicle]
+
+    coordinator = MagicMock()
+    coordinator.data = {DATA_ENODE_VEHICLES: vehicles_obj}
+
+    for description in ENODE_VEHICLE_SENSOR_TYPES:
+        assert description.available_fn is None
+        sensor = EnodeVehicleSensor(
+            hass=hass,
+            coordinator=coordinator,
+            description=description,
+            vehicle_data=vehicle,
+            vehicle_index=0,
+        )
+        assert sensor.available in (True, False)
+
+    battery_level_desc = next(
+        d for d in ENODE_VEHICLE_SENSOR_TYPES if d.key == "battery_level"
+    )
+    battery_level_sensor = EnodeVehicleSensor(
+        hass=hass,
+        coordinator=coordinator,
+        description=battery_level_desc,
+        vehicle_data=vehicle,
+        vehicle_index=0,
+    )
+    assert battery_level_sensor.available is True
+
+
+def test_enode_vehicle_last_seen_handles_already_parsed_datetime(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the last_seen sensor returns the datetime unchanged when EnodeVehicle.last_seen is already parsed."""
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import DATA_ENODE_VEHICLES
+    from custom_components.frank_energie.sensor import (
+        ENODE_VEHICLE_SENSOR_TYPES,
+        EnodeVehicleSensor,
+    )
+
+    last_seen = dt.utcnow()
+    vehicle = _make_tesla_model_3(last_seen=last_seen)
+    vehicles_obj = MagicMock()
+    vehicles_obj.vehicles = [vehicle]
+
+    coordinator = MagicMock()
+    coordinator.data = {DATA_ENODE_VEHICLES: vehicles_obj}
+
+    last_seen_description = next(
+        d for d in ENODE_VEHICLE_SENSOR_TYPES if d.key == "last_seen"
+    )
+    sensor = EnodeVehicleSensor(
+        hass=hass,
+        coordinator=coordinator,
+        description=last_seen_description,
+        vehicle_data=vehicle,
+        vehicle_index=0,
+    )
+
+    assert sensor.native_value == last_seen
+
+
 def test_calculate_market_percent_tax() -> None:
     """Test the _calculate_market_percent_tax helper function under various pricing scenarios."""
     from unittest.mock import MagicMock

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -754,7 +754,6 @@ def test_enode_vehicle_available_does_not_crash_without_available_fn(
     coordinator.data = {DATA_ENODE_VEHICLES: vehicles_obj}
 
     for description in ENODE_VEHICLE_SENSOR_TYPES:
-        assert description.available_fn is None
         sensor = EnodeVehicleSensor(
             hass=hass,
             coordinator=coordinator,
@@ -767,6 +766,7 @@ def test_enode_vehicle_available_does_not_crash_without_available_fn(
     battery_level_desc = next(
         d for d in ENODE_VEHICLE_SENSOR_TYPES if d.key == "battery_level"
     )
+    assert battery_level_desc.available_fn is None
     battery_level_sensor = EnodeVehicleSensor(
         hass=hass,
         coordinator=coordinator,


### PR DESCRIPTION
## Summary
- Battery strategy select showed "Standard" as unavailable since `BATTERY_STRATEGY_OPTIONS` and the translation files didn't have a "standard" entry. Also fixes a pre-existing translation bug where "balanced" was mislabeled "Standard"/"Standaard" in every language, which would have collided with the real "standard" value.
- All Enode vehicle sensors were reporting unavailable because `EnodeVehicleEntityDescription` never declared the `available_fn` field that the shared `available` property checks for on every entity description, raising `AttributeError`.
- The `last_seen` vehicle sensor crashed because `EnodeVehicle.last_seen` arrives already parsed into a `datetime` by python-frank-energie, but `_parse_iso_datetime` called `.endswith()` on it as if it were still a raw ISO string.
- Adds two regression tests using a real `EnodeVehicle` fixture (Tesla Model 3) that reproduce both crashes when reverted.

Depends on HiDiHo01/python-frank-energie#133 for the STANDARD enum value.

Fixes #246, #247

## Test plan
- [x] `pytest tests/` passes (180 passed, 3 skipped)
- [x] Confirmed both new tests fail with the original errors from the issues when the fix is reverted, and pass with it applied

## Summary by Sourcery

Herstel beschikbaarheid van Enode-voertuigsensoren en datetime-parsing, en voeg de standaard batterijstrategie-optie toe met vertalingen.

Nieuwe functionaliteiten:
- Ondersteuning toevoegen voor de optie 'standard' batterijstrategie in configuratie en vertalingen.

Bugfixes:
- Zorgen dat Enode-voertuigsensoren de beschikbaarheidsafhandeling correct definiëren en gebruiken om AttributeError-crashes te voorkomen.
- Datetime-parsing voor vehicle `last_seen` bijwerken zodat reeds geparste datetime-objecten worden afgehandeld zonder crash.
- Batterijstrategielabels corrigeren zodat de balanced-strategie niet langer ten onrechte als standard wordt gelabeld in vertalingen.

Tests:
- Regressietests toevoegen met een echte `EnodeVehicle` fixture om het gedrag van sensorbeschikbaarheid en `last_seen`-parsing te dekken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Enode vehicle sensor availability and datetime parsing, and add standard battery strategy option with translations.

New Features:
- Add support for the 'standard' battery strategy option in configuration and translations.

Bug Fixes:
- Ensure Enode vehicle sensors correctly define and use availability handling to avoid AttributeError crashes.
- Update datetime parsing for vehicle last_seen to handle already-parsed datetime objects without crashing.
- Correct battery strategy labels so the balanced strategy is no longer mislabeled as standard across translations.

Tests:
- Add regression tests using a real EnodeVehicle fixture to cover sensor availability and last_seen parsing behavior.

</details>