### PR TITLE
perf: parallelize sub-coordinator first refresh on startup

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -2,6 +2,7 @@
 # __init__.py
 # version 2026.06.15
 
+import asyncio
 import logging
 import warnings
 from dataclasses import dataclass, field
@@ -277,15 +278,18 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         )
 
         try:
-            # Perform the initial refresh sequentially for sub-coordinators in dependency order
+            # settings_coordinator refreshes first; the other six only read its
+            # data and not each other's, so they refresh concurrently.
             _LOGGER.debug("Performing initial refresh for sub-coordinators")
             await settings_coordinator.async_config_entry_first_refresh()
-            await price_coordinator.async_config_entry_first_refresh()
-            await statistics_coordinator.async_config_entry_first_refresh()
-            await battery_coordinator.async_config_entry_first_refresh()
-            await charger_coordinator.async_config_entry_first_refresh()
-            await pv_coordinator.async_config_entry_first_refresh()
-            await vehicle_coordinator.async_config_entry_first_refresh()
+            await asyncio.gather(
+                price_coordinator.async_config_entry_first_refresh(),
+                statistics_coordinator.async_config_entry_first_refresh(),
+                battery_coordinator.async_config_entry_first_refresh(),
+                charger_coordinator.async_config_entry_first_refresh(),
+                pv_coordinator.async_config_entry_first_refresh(),
+                vehicle_coordinator.async_config_entry_first_refresh(),
+            )
 
             # Forward entry setups to platforms
             _LOGGER.debug("Forwarding entry setups to platforms")


### PR DESCRIPTION
## Summary
- Integration setup awaited settings/price/statistics/battery/charger/pv/vehicle coordinators' first refresh one at a time. Only settings_coordinator's data is actually a dependency for the other six — they don't read each other — so running them sequentially just added up their round trips instead of overlapping them.
- `async_setup_entry` now awaits `settings_coordinator` first (everything else depends on its data), then refreshes the remaining six concurrently via `asyncio.gather`.

## Test plan
- [x] `pytest` — 200 passed, 3 skipped (pre-existing)
- [x] `ruff check` / `ruff format --check` on the changed file
- [x] Verified in a running Docker instance (debug logs) that all six coordinators now issue their GraphQL operations within ~15ms of each other instead of one after another, cutting the traced coordinator-refresh phase from several seconds to under 1s

## Summary by Sourcery

Enhancements:
- Voer niet-instellingen subcoördinator first-refresh-bewerkingen gelijktijdig uit zodra instellingengegevens beschikbaar zijn om de opstartlatentie te verminderen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Run non-settings sub-coordinator first-refresh operations concurrently after settings data is available to reduce startup latency.

</details>