### PR TITLE
fix: redact access/refresh tokens from debug logs

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -82,7 +82,13 @@ async def async_setup_entry(
     """Set up the Frank Energie component from a config entry."""
     _LOGGER.debug("Setting up Frank Energie component for entry: %s", entry.entry_id)
     _LOGGER.debug("Setting up Frank Energie entry: %s", entry)
-    _LOGGER.debug("Setting up Frank Energie entry data: %s", entry.data)
+    _LOGGER.debug(
+        "Setting up Frank Energie entry data: %s",
+        {
+            key: "**REDACTED**" if key in (CONF_ACCESS_TOKEN, CONF_TOKEN) else value
+            for key, value in entry.data.items()
+        },
+    )
     _LOGGER.debug("Setting up Frank Energie entry domain: %s", entry.domain)
     _LOGGER.debug("Setting up Frank Energie entry unique_id: %s", entry.unique_id)
     _LOGGER.debug("Setting up Frank Energie entry options: %s", entry.options)


### PR DESCRIPTION
## Summary

`async_setup_entry` logs `entry.data` verbatim at DEBUG level, which includes the raw `access_token` and `refresh_token` (JWTs — the refresh token is long-lived, on the order of months). DEBUG logs are routinely pasted into GitHub issues and HA log exports when troubleshooting, which would leak live credentials capable of authenticating as the user.

The adjacent `password` field was already safe to log (HA stores it encrypted), but the tokens were not.

## Fix

Redact `access_token` and `token` (the refresh token) before logging entry data, replacing both with `**REDACTED**`. No other fields are affected.

## Test plan
- [x] Verified locally: entry data logged in a container startup now shows `access_token`/`token` redacted while all other fields (`site_reference`, `password`, etc.) log unchanged.

## Summary by Sourcery

Bug Fixes:
- Voorkomt dat toegangstokens en vernieuwingstokens letterlijk worden gelogd in DEBUG-logs voor Frank Energie-items.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent access and refresh tokens from being logged verbatim in DEBUG logs for Frank Energie entries.

</details>