### PR TITLE
fix: add plugged_in_stopped power delivery state option

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -181,6 +181,7 @@ POWER_DELIVERY_STATES: Final[tuple[str, ...]] = (
     "plugged_in_not_charging",
     "plugged_in_finished",
     "plugged_in_no_power",
+    "plugged_in_stopped",
     "unknown",
     "error",
 )

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -843,6 +843,7 @@
           "plugged_in_not_charging": "Plugged In: Not Charging",
           "plugged_in_finished": "Plugged In: Finished",
           "plugged_in_no_power": "Plugged In: No Power",
+          "plugged_in_stopped": "Plugged In: Stopped",
           "unknown": "Unknown",
           "error": "Error"
         }

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -843,6 +843,7 @@
           "plugged_in_not_charging": "Plugged In: Not Charging",
           "plugged_in_finished": "Plugged In: Finished",
           "plugged_in_no_power": "Plugged In: No Power",
+          "plugged_in_stopped": "Plugged In: Stopped",
           "unknown": "Unknown",
           "error": "Error"
         }

--- a/custom_components/frank_energie/translations/fr.json
+++ b/custom_components/frank_energie/translations/fr.json
@@ -843,6 +843,7 @@
           "plugged_in_not_charging": "Branché : pas en charge",
           "plugged_in_finished": "Branché : charge terminée",
           "plugged_in_no_power": "Branché : pas d'alimentation",
+          "plugged_in_stopped": "Branché : arrêté",
           "unknown": "Inconnu",
           "error": "Erreur"
         }

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -651,6 +651,7 @@
           "plugged_in_not_charging": "Gekoppeld, laadt niet op",
           "plugged_in_finished": "Gekoppeld, laden voltooid",
           "plugged_in_no_power": "Gekoppeld, geen stroom",
+          "plugged_in_stopped": "Gekoppeld, gestopt",
           "unknown": "Onbekend",
           "error": "Fout"
         }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -651,6 +651,7 @@
           "plugged_in_not_charging": "Gekoppeld, laadt niet op",
           "plugged_in_finished": "Gekoppeld, laden voltooid",
           "plugged_in_no_power": "Gekoppeld, geen stroom",
+          "plugged_in_stopped": "Gekoppeld, gestopt",
           "unknown": "Onbekend",
           "error": "Fout"
         }


### PR DESCRIPTION
## Summary
- python-frank-energie now exposes `PLUGGED_IN:STOPPED` as a `PowerDeliveryState` (see companion PR in python-frank-energie).
- Add `plugged_in_stopped` to `POWER_DELIVERY_STATES` in `const.py` so the `power_delivery_state` ENUM sensor accepts it as a valid option, for both the EV charger sensor and the vehicle (car) sensor, which share this option list.
- Add the `plugged_in_stopped` translation string to `strings.json` and all locale files (en, nl, nl-BE, fr).

## Test plan
- [x] `pytest tests/test_sensor.py` passes.
- [x] All modified translation JSON files validated as well-formed JSON.

## Summary by Sourcery

Ondersteuning toevoegen voor de nieuwe `plugged_in_stopped` stroomleveringsstatus in sensoren en vertalingen.

Nieuwe functionaliteit:
- `plugged_in_stopped` beschikbaar maken als geldige stroomleveringsstatusoptie voor EV-laadpaal- en voertuigsensoren.

Verbeteringen:
- Kernconstanten en vertaalresources bijwerken zodat de `plugged_in_stopped` status wordt herkend in alle ondersteunde locales.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the new `plugged_in_stopped` power delivery state across sensors and translations.

New Features:
- Expose `plugged_in_stopped` as a valid power delivery state option for EV charger and vehicle sensors.

Enhancements:
- Update core constants and translation resources to recognize the `plugged_in_stopped` state in all supported locales.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Plugged In: Stopped” power-delivery state.
  * Added localized labels in English, French, and Dutch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->