### PR TITLE
fix: don't crash coordinator on a contract price resolution mismatch

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1419,7 +1419,51 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
                 "In-place merge of %s failed, falling back to __add__",
                 type(today_data).__name__,
             )
-            return today_data + tomorrow_data
+            try:
+                return today_data + tomorrow_data
+            except ValueError as err:
+                return self._resolve_price_data_merge_conflict(
+                    today_data, tomorrow_data, err
+                )
+        except ValueError as err:
+            return self._resolve_price_data_merge_conflict(
+                today_data, tomorrow_data, err
+            )
+
+    @staticmethod
+    def _resolve_price_data_merge_conflict(
+        today_data: Any, tomorrow_data: Any, err: ValueError
+    ) -> Any:
+        """Fall back when today's and tomorrow's price data can't be merged.
+
+        A resolution or energy-type mismatch here is expected on a genuine
+        contract price resolution change (e.g. PT15M -> PT60M) rather than a
+        bug, so this must not crash the whole coordinator update.
+
+        Unlike the midnight-rollover promotion (where tomorrow legitimately
+        *becomes* the new today), this runs while today is still today:
+        today_data holds the real, currently-active prices, so it must never
+        be dropped in favor of tomorrow's forward-looking entries — doing so
+        previously made "today" sensors go unavailable the moment a
+        resolution-change window began. Each Price entry is self-describing
+        via date_from/date_till (see PriceData.current/.today/.tomorrow), so
+        a mixed-resolution series is still valid for display; only
+        PriceData.__add__'s strict equality guard rejects it. Merge the
+        entries directly instead of picking a side.
+        """
+        _LOGGER.warning(
+            "Today's and tomorrow's %s price data have mismatched metadata "
+            "(%s); merging entries directly instead of failing the update",
+            type(today_data).__name__,
+            err,
+        )
+        merged = copy.copy(today_data)
+        unique_prices = {price.date_from: price for price in today_data.price_data}
+        unique_prices.update(
+            {price.date_from: price for price in tomorrow_data.price_data}
+        )
+        merged.price_data = sorted(unique_prices.values(), key=lambda p: p.date_from)
+        return merged
 
     def _aggregate_data(
         self,

--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -1463,6 +1463,21 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
             {price.date_from: price for price in tomorrow_data.price_data}
         )
         merged.price_data = sorted(unique_prices.values(), key=lambda p: p.date_from)
+
+        # `merged` is a shallow copy, so resolution_minutes still reflects
+        # today_data's entry spacing, not the mixed-resolution price_data we
+        # just built. Recompute it the same way PriceData.__post_init__
+        # does (smallest positive interval wins) so downstream consumers
+        # like _is_cache_resolution_valid() don't see stale metadata.
+        intervals = [
+            int((price.date_till - price.date_from).total_seconds() // 60)
+            for price in merged.price_data
+            if price.date_from and price.date_till
+        ]
+        positive_intervals = [minutes for minutes in intervals if minutes > 0]
+        if positive_intervals:
+            merged.resolution_minutes = min(positive_intervals)
+
         return merged
 
     def _aggregate_data(
@@ -1642,6 +1657,16 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # Keep the combined data (yesterday + today) to prevent historical sensors
         # from becoming None at exactly 0:00. Merge the tomorrow cache in case it
         # never made it into an aggregation cycle before midnight.
+        #
+        # On a ValueError (resolution/energy-type mismatch) this deliberately
+        # picks tomorrow's series and drops the rest, unlike
+        # _resolve_price_data_merge_conflict's entry-level merge used in
+        # _aggregate_data. The two failure sites aren't equivalent: here,
+        # "tomorrow" genuinely *becomes* the new "today" at this exact
+        # instant, so its resolution is the correct one going forward and
+        # source_data's incompatible entries are, by definition, about to be
+        # the wrong resolution for the new day. Merging them in anyway would
+        # just reintroduce the same mismatch one call later.
         try:
             combined_electricity = self._merge_prices(
                 source_data.get(DATA_ELECTRICITY), prices_tomorrow.electricity

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1458,6 +1458,105 @@ async def test_full_day_cycle_fetch_promote_refetch(
 
 
 @pytest.mark.asyncio
+async def test_full_day_cycle_survives_contract_resolution_change(
+    mock_frank_energie, mock_config_entry, freezer
+) -> None:
+    """A real end-to-end contract resolution change (PT15M -> PT60M) must not
+    crash the update or make "today" sensors go unavailable, across the
+    transition day and into the day after.
+
+    Drives the same real entry points as test_full_day_cycle_fetch_promote_refetch
+    (_async_update_data + promote_tomorrow_prices), but with day1's "today" fetch
+    at 15-minute resolution and day1's "tomorrow" fetch already at 60-minute
+    resolution — the exact shape of a genuine in-progress contract resolution
+    change reported in production. Confirms three things:
+    1. Day 1's live aggregation survives the mismatch and keeps both today's
+       and tomorrow's entries visible (regression: an earlier fix dropped
+       today's entries in favor of tomorrow's here).
+    2. Midnight promotion still cleanly adopts the new (60-minute) resolution.
+    3. Day 2 onward, now that both sides agree on resolution, merging goes
+       through the normal path with no further conflict.
+    """
+    from datetime import date
+
+    tz = ZoneInfo(TIMEZONE_AMSTERDAM)
+    day1, day2, day3 = date(2026, 7, 31), date(2026, 8, 1), date(2026, 8, 2)
+
+    settings_coordinator = FrankEnergieSettingsCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie
+    )
+    settings_coordinator.data = {}
+
+    coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), mock_config_entry, mock_frank_energie, settings_coordinator
+    )
+    coordinator._fetch_contract_price_resolution_state = AsyncMock(return_value=None)
+    coordinator.store.async_save = AsyncMock()
+
+    day1_today = _make_market_prices_with_resolution(15, "2026-07-31T10:00:00.000Z")
+    day1_tomorrow = _make_market_prices_with_resolution(
+        60, "2026-07-31T22:00:00.000Z"
+    )  # day2, already on the new resolution
+    day2_tomorrow = _make_market_prices_with_resolution(
+        60, "2026-08-01T22:00:00.000Z"
+    )  # day3, resolution has settled
+
+    today_fetches = {day1: day1_today}
+    tomorrow_fetches = {day2: day1_tomorrow, day3: day2_tomorrow}
+
+    async def fake_fetch_prices_with_fallback(start_date, end_date, use_fallback=True):
+        return today_fetches[start_date]
+
+    async def fake_fetch_tomorrow_data(tomorrow):
+        return tomorrow_fetches[tomorrow]
+
+    coordinator._fetch_prices_with_fallback = AsyncMock(
+        side_effect=fake_fetch_prices_with_fallback
+    )
+    coordinator._fetch_tomorrow_data = AsyncMock(side_effect=fake_fetch_tomorrow_data)
+
+    # --- Day 1, 13:00: today=15min, tomorrow=60min. Must not crash. ---
+    freezer.move_to(datetime(day1.year, day1.month, day1.day, 13, 0, tzinfo=tz))
+    result = await coordinator._async_update_data()
+
+    merged_electricity = result[DATA_ELECTRICITY]
+    assert len(merged_electricity.today) == 1
+    assert merged_electricity.today[0].date_from.astimezone(tz).date() == day1
+    assert len(merged_electricity.tomorrow) == 1
+    assert merged_electricity.tomorrow[0].date_from.astimezone(tz).date() == day2
+
+    # --- Midnight day1 -> day2: promote tomorrow's (60min) cache ---
+    freezer.move_to(datetime(day2.year, day2.month, day2.day, 0, 0, tzinfo=tz))
+    coordinator.promote_tomorrow_prices()
+
+    assert coordinator.cached_prices_tomorrow is None
+    assert coordinator._static_prices_today.electricity.resolution_minutes == 60
+    assert (
+        coordinator._static_prices_today.electricity.all[-1]
+        .date_from.astimezone(tz)
+        .date()
+        == day2
+    )
+
+    # --- Day 2, 13:00: both sides now agree on 60min, no more conflict ---
+    freezer.move_to(datetime(day2.year, day2.month, day2.day, 13, 0, tzinfo=tz))
+    coordinator._static_prices_today = coordinator._static_prices_today
+    coordinator.last_fetch_today = None  # force a live "today" re-check this cycle
+    coordinator._fetch_prices_with_fallback = AsyncMock(
+        side_effect=lambda *a, **kw: coordinator._static_prices_today
+    )
+
+    result_day2 = await coordinator._async_update_data()
+
+    assert coordinator.cached_prices_tomorrow is day2_tomorrow
+    assert len(result_day2[DATA_ELECTRICITY].tomorrow) == 1
+    assert (
+        result_day2[DATA_ELECTRICITY].tomorrow[0].date_from.astimezone(tz).date()
+        == day3
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_falls_back_to_cached_today_on_fetch_failure(
     mock_frank_energie, mock_config_entry, freezer
 ) -> None:
@@ -1985,6 +2084,11 @@ async def test_price_data_after_and_build_tomorrow_cache_with_real_pricedata() -
 
 def _make_market_prices(*entry_date_isos: str):
     """Build a minimal real MarketPrices with one electricity entry per given ISO start."""
+    return _make_market_prices_with_resolution(15, *entry_date_isos)
+
+
+def _make_market_prices_with_resolution(resolution_minutes: int, *entry_date_isos: str):
+    """Build a minimal real MarketPrices with entries spaced `resolution_minutes` apart."""
     from datetime import timedelta as _timedelta
 
     from python_frank_energie.models import MarketPrices, PriceData
@@ -1995,7 +2099,9 @@ def _make_market_prices(*entry_date_isos: str):
         raw_prices.append(
             {
                 "from": entry_date_iso,
-                "till": (entry_start + _timedelta(minutes=15)).isoformat(),
+                "till": (
+                    entry_start + _timedelta(minutes=resolution_minutes)
+                ).isoformat(),
                 "marketPrice": 0.1,
                 "marketPriceTax": 0.02,
                 "sourcingMarkupPrice": 0.01,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -28,7 +28,13 @@ from custom_components.frank_energie import FrankEnergieComponent
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import FrankEnergieException, RequestException
-from python_frank_energie.models import MonthSummary, Invoices, User, PriceData
+from python_frank_energie.models import (
+    MonthSummary,
+    Invoices,
+    User,
+    PriceData,
+    MarketPrices,
+)
 from aiohttp import ClientError
 
 
@@ -233,6 +239,45 @@ async def test_aggregate_data_handles_contract_resolution_change(coordinator):
         today_electricity.price_data[0].date_from,
         tomorrow_electricity.price_data[0].date_from,
     ]
+
+
+def test_resolve_price_data_merge_conflict_recomputes_resolution_minutes():
+    """The merged series' resolution_minutes must reflect its actual entries.
+
+    Regression test: _resolve_price_data_merge_conflict builds `merged` via
+    copy.copy(today_data), a shallow copy that keeps today_data's stale
+    resolution_minutes even after price_data is replaced. Uses PT60M ->
+    PT15M (the reverse direction of the other regression test) so a
+    leftover stale value (60) is distinguishable from the correctly
+    recomputed one (15, from tomorrow's finer-grained entries).
+    """
+    raw_today = {
+        "from": "2026-07-31T20:00:00.000Z",
+        "till": "2026-07-31T21:00:00.000Z",
+        "marketPrice": 0.1,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    raw_tomorrow = {
+        "from": "2026-08-01T20:00:00.000Z",
+        "till": "2026-08-01T20:15:00.000Z",
+        "marketPrice": 0.2,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    today_electricity = PriceData([raw_today], energy_type="electricity")
+    tomorrow_electricity = PriceData([raw_tomorrow], energy_type="electricity")
+    assert today_electricity.resolution_minutes == 60
+    assert tomorrow_electricity.resolution_minutes == 15
+
+    err = ValueError("Cannot merge PriceData with different resolutions: 60 vs 15")
+    merged = FrankEnergiePriceCoordinator._resolve_price_data_merge_conflict(
+        today_electricity, tomorrow_electricity, err
+    )
+
+    assert merged.resolution_minutes == 15
 
 
 @pytest.mark.asyncio
@@ -1540,7 +1585,7 @@ async def test_full_day_cycle_survives_contract_resolution_change(
 
     # --- Day 2, 13:00: both sides now agree on 60min, no more conflict ---
     freezer.move_to(datetime(day2.year, day2.month, day2.day, 13, 0, tzinfo=tz))
-    coordinator._static_prices_today = coordinator._static_prices_today
+    # day2's "today" prices are already the ones promoted at midnight (60min).
     coordinator.last_fetch_today = None  # force a live "today" re-check this cycle
     coordinator._fetch_prices_with_fallback = AsyncMock(
         side_effect=lambda *a, **kw: coordinator._static_prices_today
@@ -2087,11 +2132,11 @@ def _make_market_prices(*entry_date_isos: str):
     return _make_market_prices_with_resolution(15, *entry_date_isos)
 
 
-def _make_market_prices_with_resolution(resolution_minutes: int, *entry_date_isos: str):
+def _make_market_prices_with_resolution(
+    resolution_minutes: int, *entry_date_isos: str
+) -> MarketPrices:
     """Build a minimal real MarketPrices with entries spaced `resolution_minutes` apart."""
     from datetime import timedelta as _timedelta
-
-    from python_frank_energie.models import MarketPrices, PriceData
 
     raw_prices = []
     for entry_date_iso in entry_date_isos:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -28,7 +28,7 @@ from custom_components.frank_energie import FrankEnergieComponent
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from python_frank_energie import FrankEnergie
 from python_frank_energie.exceptions import FrankEnergieException, RequestException
-from python_frank_energie.models import MonthSummary, Invoices, User
+from python_frank_energie.models import MonthSummary, Invoices, User, PriceData
 from aiohttp import ClientError
 
 
@@ -162,6 +162,77 @@ async def test_aggregate_data(coordinator):
     assert isinstance(aggregated_data[DATA_MONTH_SUMMARY], MagicMock)
     assert isinstance(aggregated_data[DATA_INVOICES], MagicMock)
     assert isinstance(aggregated_data[DATA_USER], MagicMock)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_data_handles_contract_resolution_change(coordinator):
+    """A contract resolution change (e.g. PT15M -> PT60M) must not crash the update.
+
+    Regression test: cached "today" prices at one resolution combined with
+    freshly-fetched "tomorrow" prices at a different resolution used to raise
+    ValueError out of PriceData.__add__ and crash the whole coordinator
+    refresh (_aggregate_data -> _combine_price_data). Today's prices carry a
+    real 15-minute contract resolution here; tomorrow's switch to 60 minutes.
+    """
+    raw_today = {
+        "from": "2026-07-31T22:00:00.000Z",
+        "till": "2026-07-31T22:15:00.000Z",
+        "marketPrice": 0.1,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    raw_tomorrow = {
+        "from": "2026-08-01T22:00:00.000Z",
+        "till": "2026-08-01T23:00:00.000Z",
+        "marketPrice": 0.2,
+        "marketPriceTax": 0.02,
+        "sourcingMarkupPrice": 0.01,
+        "energyTaxPrice": 0.1,
+    }
+    today_electricity = PriceData([raw_today], energy_type="electricity")
+    tomorrow_electricity = PriceData([raw_tomorrow], energy_type="electricity")
+    assert today_electricity.resolution_minutes == 15
+    assert tomorrow_electricity.resolution_minutes == 60
+
+    prices_today = MagicMock()
+    prices_today.electricity = today_electricity
+    prices_today.gas = None
+    prices_tomorrow = MagicMock()
+    prices_tomorrow.electricity = tomorrow_electricity
+    prices_tomorrow.gas = None
+    data_month_summary = MagicMock(spec=MonthSummary)
+    data_invoices = MagicMock(spec=Invoices)
+    data_user = MagicMock(spec=User)
+
+    cache = PricesTodayCache(
+        prices_today=prices_today,
+        data_month_summary=data_month_summary,
+        data_invoices=data_invoices,
+        data_user=data_user,
+        user_sites=None,
+        data_period_usage=None,
+        data_enode_chargers=None,
+        data_smart_batteries=None,
+        data_smart_battery_details=[],
+        data_smart_battery_sessions=[],
+        data_enode_vehicles=None,
+        data_pv_systems=None,
+        data_pv_summary=None,
+        data_user_smart_feed_in=None,
+        data_contract_price_resolution_state=None,
+    )
+
+    aggregated_data = coordinator._aggregate_data(cache, prices_tomorrow)
+
+    # Today's real entry must survive the merge (regression: an earlier fix
+    # discarded it in favor of tomorrow's, making "today" sensors go
+    # unavailable), and tomorrow's entry must still be present too.
+    merged_electricity = aggregated_data[DATA_ELECTRICITY]
+    assert [p.date_from for p in merged_electricity.price_data] == [
+        today_electricity.price_data[0].date_from,
+        tomorrow_electricity.price_data[0].date_from,
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_aggregate_data` merges cached "today" prices with freshly-fetched "tomorrow" prices via `PriceData.__add__`, which raises `ValueError` when the two series have different `resolution_minutes` (e.g. PT15M vs PT60M). Only `TypeError` was being caught, so the `ValueError` propagated and crashed the whole coordinator refresh on every update cycle — reproduced in the wild by an authenticated user mid-way through a contract resolution change (15-minute → 60-minute), where the API applies the change on a future effective date rather than immediately.
- The fallback now merges both series' entries directly (by `date_from`) instead of raising. An earlier version of this fix picked tomorrow's data outright on conflict, which briefly made "today" sensors go unavailable — each `Price` entry is self-describing via `date_from`/`date_till`, so a mixed-resolution series is safe to combine directly instead of discarding one side.
- Added a regression test for `_aggregate_data` merging mismatched resolutions, and an end-to-end test driving the real `_async_update_data` → `promote_tomorrow_prices` → `_async_update_data` sequence across a full resolution-change day (day1: 15min today / 60min tomorrow → midnight promotion → day2: 60min/60min, settled).

## Test plan
- [x] `pytest tests/test_coordinator.py -q` — 84 passed
- [x] `pytest tests/ -q` — 202 passed, 3 skipped
- [x] Confirm on a real instance mid-resolution-change (electricity/gas price sensors stay available through the transition and midnight rollover)

## Summary by Sourcery

Voorkom dat coördinator-updates crashen wanneer prijsdata voor vandaag en morgen verschillende contractresoluties hebben, door conflicterende reeksen netjes samen te voegen in plaats van te falen.

Bug Fixes:
- Zorg ervoor dat aggregatie van prijsdata blijft werken bij wijzigingen in contractresolutie door terug te vallen op directe samenvoeging van entries bij een `ValueError` in plaats van de coördinator te laten crashen.

Enhancements:
- Introduceer een speciale helper voor conflictoplossing om prijsentries van vandaag en morgen samen te voegen tot één reeks wanneer er metadata-mismatches optreden.
- Refactor de test-marktprijsfactory om configureerbare resolutie-intervallen te ondersteunen voor realistischer testsituaties.

Tests:
- Voeg een regressietest toe voor `_aggregate_data` die omgaat met verschillende prijsresoluties tussen gecachte data van vandaag en opgehaalde data van morgen.
- Voeg een end-to-endtest toe die een volledige dagcyclus over een wijziging in contractresolutie dekt om te bevestigen dat sensoren beschikbaar blijven en dat het samenvoegen correct verloopt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent coordinator updates from crashing when today and tomorrow price data have mismatched contract resolutions by gracefully merging conflicting series instead of failing.

Bug Fixes:
- Ensure price data aggregation survives contract resolution changes by falling back to direct entry merging on ValueError instead of crashing the coordinator.

Enhancements:
- Introduce a dedicated conflict-resolution helper to merge today and tomorrow price entries into a single series when metadata mismatches occur.
- Refactor the test market price factory to support configurable resolution intervals for more realistic test scenarios.

Tests:
- Add a regression test for _aggregate_data handling mismatched price resolutions between cached today and fetched tomorrow data.
- Add an end-to-end test covering a full day cycle across a contract resolution change to confirm sensors remain available and merging behaves correctly.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price-data handling when market-price resolutions or energy types change.
  * Coordinator updates now continue successfully during resolution transitions, including across midnight.
  * Preserved and chronologically organized price entries from both today and tomorrow.
  * Prevented duplicate price records during fallback data merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->