### PR TITLE
fix: EV charging mode select stuck on unknown

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -171,8 +171,8 @@ BATTERY_STRATEGY_OPTIONS: Final[list[str]] = [
 ]
 
 ENODE_CHARGING_MODE_OPTIONS: Final[list[str]] = [
-    "on_off",
-    "smart",
+    "smart_charging",
+    "boost_charging",
 ]
 
 POWER_DELIVERY_STATES: Final[tuple[str, ...]] = (

--- a/custom_components/frank_energie/statistics.py
+++ b/custom_components/frank_energie/statistics.py
@@ -59,6 +59,7 @@ def working_lowest_window(
         lowest_end,
     )
 
+
 def lowest_window(
     data: FrankEnergieData,
     window: int,


### PR DESCRIPTION
## Summary
- `ENODE_CHARGING_MODE_OPTIONS` in `const.py` listed `["on_off", "smart"]`, but the select entities (`FrankEnergieEnodeChargingModeSelect` for vehicles and `FrankEnergieEnodeChargerChargingModeSelect` for chargers/wallboxes) and all translation files (`en.json`, `nl.json`, `fr.json`, `nl-BE.json`, `strings.json`) use `smart_charging`/`boost_charging`.
- Because `current_option` never matched anything in `options`, Home Assistant treated the state as invalid and rendered the entity as **unknown**, regardless of actual charging mode.
- The dropdown also showed raw `smart`/`on_off` instead of translated labels, since those keys don't exist in the translation `state` maps.
- Worse: selecting `"smart"` from the dropdown compared false against the `"smart_charging"` literal in `async_select_option`, so it silently sent `isSmartChargingEnabled: False` to the API — actually turning off smart charging instead of enabling it.

## Fix
Update `ENODE_CHARGING_MODE_OPTIONS` to `["smart_charging", "boost_charging"]` so it matches the values already used in `select.py` and the translation files. No changes needed elsewhere — the coordinator/API data path was already correct.

## Test plan
- [x] Confirmed by user: after the fix, `select.wallbox_copper_business_ev_charging_mode` reports a valid state and dropdown shows translated "Smart charging"/"Boost charging" labels.
- [x] Verify selecting "Smart charging" persists correctly and reflects real backend state after a coordinator refresh.

## Samenvatting door Sourcery

Breng de opties voor EV-laadmodus in lijn met bestaande select-entiteiten en vertalingen om een correcte verwerking van statussen en labeling in Home Assistant te garanderen.

Bugfixes:
- Verhelp dat EV-laadmodus-select-entiteiten in een onbekende status blijven hangen door niet-overeenkomende optie‑waarden.
- Voorkom dat slimme laadselecties worden geïnterpreteerd als het uitschakelen van slim laden vanwege inconsistente modusidentificaties.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align EV charging mode options with existing select entities and translations to ensure correct state handling and labeling in Home Assistant.

Bug Fixes:
- Fix EV charging mode select entities being stuck in an unknown state due to mismatched option values.
- Prevent smart charging selections from being interpreted as disabling smart charging because of inconsistent mode identifiers.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated charging mode options to use the current “Smart Charging” and “Boost Charging” labels.
  * Removed outdated “On/Off” and “Smart” charging mode values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->