### PR TITLE
fix: add plugged_in_initializing and plugged_in_complete power delivery state options

### DIFF
--- a/custom_components/frank_energie/const.py
+++ b/custom_components/frank_energie/const.py
@@ -182,6 +182,8 @@ POWER_DELIVERY_STATES: Final[tuple[str, ...]] = (
     "plugged_in_finished",
     "plugged_in_no_power",
     "plugged_in_stopped",
+    "plugged_in_initializing",
+    "plugged_in_complete",
     "unknown",
     "error",
 )

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -844,6 +844,8 @@
           "plugged_in_finished": "Plugged In: Finished",
           "plugged_in_no_power": "Plugged In: No Power",
           "plugged_in_stopped": "Plugged In: Stopped",
+          "plugged_in_initializing": "Plugged In: Initializing",
+          "plugged_in_complete": "Plugged In: Complete",
           "unknown": "Unknown",
           "error": "Error"
         }

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -844,6 +844,8 @@
           "plugged_in_finished": "Plugged In: Finished",
           "plugged_in_no_power": "Plugged In: No Power",
           "plugged_in_stopped": "Plugged In: Stopped",
+          "plugged_in_initializing": "Plugged In: Initializing",
+          "plugged_in_complete": "Plugged In: Complete",
           "unknown": "Unknown",
           "error": "Error"
         }

--- a/custom_components/frank_energie/translations/fr.json
+++ b/custom_components/frank_energie/translations/fr.json
@@ -844,6 +844,8 @@
           "plugged_in_finished": "Branché : charge terminée",
           "plugged_in_no_power": "Branché : pas d'alimentation",
           "plugged_in_stopped": "Branché : arrêté",
+          "plugged_in_initializing": "Branché : initialisation",
+          "plugged_in_complete": "Branché : terminé",
           "unknown": "Inconnu",
           "error": "Erreur"
         }

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -652,6 +652,8 @@
           "plugged_in_finished": "Gekoppeld, laden voltooid",
           "plugged_in_no_power": "Gekoppeld, geen stroom",
           "plugged_in_stopped": "Gekoppeld, gestopt",
+          "plugged_in_initializing": "Gekoppeld, initialiseert",
+          "plugged_in_complete": "Gekoppeld, voltooid",
           "unknown": "Onbekend",
           "error": "Fout"
         }

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -652,6 +652,8 @@
           "plugged_in_finished": "Gekoppeld, laden voltooid",
           "plugged_in_no_power": "Gekoppeld, geen stroom",
           "plugged_in_stopped": "Gekoppeld, gestopt",
+          "plugged_in_initializing": "Gekoppeld, initialiseert",
+          "plugged_in_complete": "Gekoppeld, voltooid",
           "unknown": "Onbekend",
           "error": "Fout"
         }


### PR DESCRIPTION
## Summary
- python-frank-energie now exposes `PLUGGED_IN:INITIALIZING` and `PLUGGED_IN:COMPLETE` as `PowerDeliveryState` values (see companion PR in python-frank-energie).
- Add `plugged_in_initializing` and `plugged_in_complete` to `POWER_DELIVERY_STATES` in `const.py` so the `power_delivery_state` ENUM sensor accepts them as valid options, for both the EV charger sensor and the vehicle sensor, which share this option list.
- Add the `plugged_in_initializing` and `plugged_in_complete` translation strings to `strings.json` and all locale files (en, nl, nl-BE, fr).

## Test plan
- [x] All modified translation JSON files validated as well-formed JSON.
- [x] `pytest tests/test_sensor.py`

Closes #272.

Note: this depends on a not-yet-released `python-frank-energie` version that includes the new enum members — the `manifest.json`/`pyproject.toml` pin will need bumping once that's published.

## Summary by Sourcery

Accepteer en lokaliseer de nieuw beschikbare ingeplugde power delivery‑statussen.

Nieuwe functies:
- Ondersteun de `plugged_in_initializing` en `plugged_in_complete` power delivery‑statussen voor EV‑laadpaal- en voertuigsensoren.

Klusjes:
- Voeg vertalingen toe voor de nieuwe power delivery‑statussen in het Engels, Frans, Nederlands en Belgisch Nederlands.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Accept and localize the newly available plugged-in power delivery states.

New Features:
- Support the `plugged_in_initializing` and `plugged_in_complete` power delivery states for EV charger and vehicle sensors.

Chores:
- Add translations for the new power delivery states in English, French, Dutch, and Belgian Dutch.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two power-delivery states: “Plugged in—initializing” and “Plugged in—complete.”
  * These states are now displayed with localized labels in English, French, Dutch, and Belgian Dutch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->