### PR TITLE
fix: add inactive to the PV steering status sensor

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -672,7 +672,7 @@ PV_SENSORS: tuple[FrankEnergieEntityDescription, ...] = (
         translation_key="pv_steering_status",
         icon="mdi:solar-power",
         device_class=SensorDeviceClass.ENUM,
-        options=["active", "steering", "no_steering", "unknown"],
+        options=["active", "inactive", "steering", "no_steering", "unknown"],
         value_fn=lambda summary: str(summary.steering_status).lower(),
     ),
 )
@@ -727,7 +727,9 @@ class FrankEnergiePvSensor(CoordinatorEntity[FrankEnergieCoordinator], SensorEnt
                     (s for s in systems_obj.systems if s.id == self._system_id), None
                 )
                 if pv_system:
-                    return pv_system.steering_status
+                    # Match value_fn: HA's ENUM sensor validates the state
+                    # against the lowercase ``options`` list.
+                    return str(pv_system.steering_status).lower()
             return None
 
         if summary and self.entity_description.value_fn:

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -738,6 +738,7 @@
         "name": "Steering status",
         "state": {
           "active": "Active",
+          "inactive": "Inactive",
           "steering": "Steering",
           "no_steering": "No steering",
           "unknown": "Unknown"

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -738,6 +738,7 @@
         "name": "Steering status",
         "state": {
           "active": "Active",
+          "inactive": "Inactive",
           "steering": "Steering",
           "no_steering": "No steering",
           "unknown": "Unknown"

--- a/custom_components/frank_energie/translations/fr.json
+++ b/custom_components/frank_energie/translations/fr.json
@@ -738,6 +738,7 @@
         "name": "Statut de pilotage",
         "state": {
           "active": "Actif",
+          "inactive": "Inactif",
           "steering": "Pilotage en cours",
           "no_steering": "Pas de pilotage",
           "unknown": "Inconnu"

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -593,6 +593,7 @@
         "name": "Sturingsstatus",
         "state": {
           "active": "Actief",
+          "inactive": "Inactief",
           "steering": "Sturend",
           "no_steering": "Niet sturend",
           "unknown": "Onbekend"

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -593,6 +593,7 @@
         "name": "Sturingsstatus",
         "state": {
           "active": "Actief",
+          "inactive": "Inactief",
           "steering": "Sturend",
           "no_steering": "Niet sturend",
           "unknown": "Onbekend"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,10 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
     MockConfigEntry,
 )
+from python_frank_energie.domain import (
+    SmartPvOperationalStatus,
+    SmartPvSteeringStatus,
+)
 
 from custom_components.frank_energie import const
 from tests.utils import ResponseMocks
@@ -893,3 +897,153 @@ def test_safe_session_result_sum():
 
     # Test empty
     assert _safe_session_result_sum([]) == pytest.approx(0.0)
+
+
+def _pv_sensor_description(key: str) -> object:
+    """Return the PV_SENSORS entity description with the given key."""
+    from custom_components.frank_energie.sensor import PV_SENSORS
+
+    return next(d for d in PV_SENSORS if d.key == key)
+
+
+@pytest.mark.parametrize(
+    ("sensor_key", "enum_cls"),
+    [
+        ("operational_status", SmartPvOperationalStatus),
+        ("steering_status", SmartPvSteeringStatus),
+    ],
+)
+def test_pv_enum_sensor_options_cover_domain_and_translations(
+    sensor_key: str, enum_cls: type[SmartPvOperationalStatus | SmartPvSteeringStatus]
+) -> None:
+    """PV ENUM sensor options must cover every python-frank-energie status value
+    and have a matching shipped strings.json translation.
+
+    Regression guard for issue #277: python-frank-energie added
+    SmartPvSteeringStatus.INACTIVE, but the sensor's ``options`` list and the
+    translation files were missing it, which trips Home Assistant's
+    SensorEntity ENUM validation ("not in the list of options provided") and
+    leaves the sensor unavailable. The options list is allowed to run *ahead*
+    of the currently pinned library (forward-compat for an unreleased status),
+    but must never lag it, and every option must be translated.
+    """
+    import json
+    from pathlib import Path
+
+    description = _pv_sensor_description(sensor_key)
+
+    strings = json.loads(
+        Path(__file__)
+        .parents[1]
+        .joinpath("custom_components/frank_energie/strings.json")
+        .read_text(encoding="utf-8")
+    )
+    state_strings = strings["entity"]["sensor"][description.translation_key]["state"]
+
+    options = set(description.options or ())
+    enum_values = {member.value.lower() for member in enum_cls}
+    translated = set(state_strings)
+
+    assert enum_values <= options, f"options missing {enum_values - options}"
+    assert options == translated, (
+        f"options vs strings.json state mismatch {options ^ translated}"
+    )
+
+
+async def _pv_steering_status_state(
+    hass: HomeAssistant, coordinator_data: dict[str, object]
+) -> str | None:
+    """Register the PV steering_status sensor on a real entity platform and
+    return the state Home Assistant computed for it (running the real
+    SensorEntity ENUM ``options`` validation)."""
+    from unittest.mock import MagicMock
+
+    from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+    from pytest_homeassistant_custom_component.common import MockEntityPlatform
+
+    from custom_components.frank_energie.const import DOMAIN
+    from custom_components.frank_energie.sensor import FrankEnergiePvSensor
+
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    coordinator.get_pv_system_metadata.return_value = {
+        "brand": "SolarEdge",
+        "model": "SE3000",
+        "display_name": "Roof",
+        "serial_number": "SN1",
+    }
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass, domain=SENSOR_DOMAIN, platform_name=DOMAIN)
+    platform.config_entry = entry
+
+    sensor = FrankEnergiePvSensor(
+        coordinator, "pv_1", _pv_sensor_description("steering_status")
+    )
+    await platform.async_add_entities([sensor])
+
+    state = hass.states.get(sensor.entity_id)
+    return state.state if state else None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", list(SmartPvSteeringStatus))
+async def test_pv_steering_status_summary_path_passes_ha_enum_validation(
+    hass: HomeAssistant, status: SmartPvSteeringStatus
+) -> None:
+    """Every real SmartPvSteeringStatus from the summary endpoint yields a state
+    Home Assistant's ENUM ``options`` validation accepts (issue #277)."""
+    from python_frank_energie.domain import SmartPvOperationalStatus
+    from python_frank_energie.models import SmartPvSystemSummary
+
+    from custom_components.frank_energie.const import DATA_PV_SUMMARY
+
+    summary = SmartPvSystemSummary(
+        operational_status=SmartPvOperationalStatus.OPERATIONAL,
+        operational_status_timestamp=None,
+        steering_status=status,
+        total_bonus=None,
+        total_result=None,
+    )
+    state = await _pv_steering_status_state(hass, {DATA_PV_SUMMARY: {"pv_1": summary}})
+    assert state == status.value.lower()
+
+
+@pytest.mark.asyncio
+async def test_pv_steering_status_inactive_passes_ha_enum_validation(
+    hass: HomeAssistant,
+) -> None:
+    """``INACTIVE`` (issue #277) must be an accepted sensor option even when the
+    pinned python-frank-energie release does not know it yet - fed as a raw
+    string so the check is independent of the installed library version."""
+    from types import SimpleNamespace
+
+    from custom_components.frank_energie.const import DATA_PV_SUMMARY
+
+    state = await _pv_steering_status_state(
+        hass, {DATA_PV_SUMMARY: {"pv_1": SimpleNamespace(steering_status="INACTIVE")}}
+    )
+    assert state == "inactive"
+
+
+@pytest.mark.asyncio
+async def test_pv_steering_status_systems_fallback_passes_ha_enum_validation(
+    hass: HomeAssistant,
+) -> None:
+    """When the summary endpoint has no entry for a system, native_value falls
+    back to the systems list; that value must also pass HA's ENUM validation
+    (regression: the fallback returned the raw enum whose str() is ``ACTIVE``,
+    never present in the lowercase ``options``)."""
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import DATA_PV_SYSTEMS
+
+    pv_system = MagicMock()
+    pv_system.id = "pv_1"
+    pv_system.steering_status = SmartPvSteeringStatus.ACTIVE
+    systems_obj = MagicMock()
+    systems_obj.systems = [pv_system]
+
+    state = await _pv_steering_status_state(hass, {DATA_PV_SYSTEMS: systems_obj})
+    assert state == "active"


### PR DESCRIPTION
## Summary

`python-frank-energie` added `SmartPvSteeringStatus.INACTIVE` for PV systems that are not currently being steered. Home Assistant validates ENUM sensor state against `options`, so once the API reports `INACTIVE` the `steering_status` sensor raises `ValueError` ("not in the list of options provided") and goes unavailable.

## Type of Change

- [x] Bug fix
- [x] Test improvement

## Related Issues

Fixes #277

## Changes

- Add `inactive` to the `steering_status` sensor `options` and to every translation file (`strings.json`, `en`, `nl`, `nl-BE`, `fr`).
- Lowercase the systems-list fallback in `FrankEnergiePvSensor.native_value` the same way `value_fn` does — it previously returned the raw enum (`str()` → `"ACTIVE"`), which is never in the lowercase `options`, so that branch broke for *every* steering value once reached.

## Testing

- [x] Existing tests pass
- [x] New tests added

### Test Details

- `pytest` — 211 passed, 3 skipped.
- New tests register the sensor on a real `MockEntityPlatform` and run HA's actual `SensorEntity` ENUM `options` validation, for both the summary path (parametrised over `SmartPvSteeringStatus`), the forward-compat `INACTIVE` string, and the systems-list fallback path.
- A static guard asserts each PV ENUM sensor's `options` covers its `python-frank-energie` enum and matches the shipped `strings.json` state keys.

## Home Assistant Checklist

- [x] Uses timezone-aware datetimes where applicable
- [x] Includes type hints
- [x] Translations updated (if required)

## Additional Notes

The warning itself (`Unknown SmartPvSteeringStatus encountered: INACTIVE`) comes from the bundled `python-frank-energie`; it stops for end users once a release containing `INACTIVE` ships and the `manifest.json` pin is bumped (currently `==2026.8.8`). This PR is the integration-side change needed so the sensor doesn't break when that lands.

## Samenvatting door Sourcery

Ondersteuning voor inactieve PV-sturingsstatussen en behoud van compatibiliteit van alle sturingssensorstatussen met de enum-validatie van Home Assistant.

Bugfixes:
- Voorkomen dat PV-sturingsstatussensoren niet beschikbaar worden wanneer de API de inactieve status rapporteert.
- Zorgen dat sturingsstatussen uit de fallback van de systeemenlijst overeenkomen met de door de sensor geaccepteerde statuswaarden.

Tests:
- Dekking toevoegen voor enum-opties, vertalingen, inactieve waarden die compatibel zijn met toekomstige versies, samenvattingsstatussen en validatie van de fallback van de systeemenlijst.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Ondersteun inactieve PV-sturingsstatussen en zorg ervoor dat alle statussen van de sturingssensor compatibel blijven met de enum-validatie van Home Assistant.

Bugfixes:
- Voorkom dat de PV-sturingsstatussensor niet beschikbaar wordt wanneer de API de inactieve status rapporteert.
- Zorg ervoor dat PV-sturingsstatussen uit de fallback van de systemenlijst overeenkomen met de door de sensor geaccepteerde enum-waarden.

Tests:
- Voeg testdekking toe voor consistentie tussen PV-enumopties en vertalingen, compatibiliteit met de inactieve status, samenvattingsstatussen en validatie van de fallback van de systemenlijst.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support inactive PV steering statuses and keep all steering sensor states compatible with Home Assistant enum validation.

Bug Fixes:
- Prevent the PV steering status sensor from becoming unavailable when the API reports the inactive status.
- Ensure PV steering statuses from the systems-list fallback match the sensor’s accepted enum values.

Tests:
- Add coverage for PV enum option and translation consistency, inactive status compatibility, summary statuses, and systems-list fallback validation.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Inactive** state to the PV steering status sensor.
  * PV steering statuses are now consistently displayed in a format supported by Home Assistant.
  * Added translations for the new state in English, French, Dutch, and Dutch (Belgium).

* **Bug Fixes**
  * Improved PV steering status handling when summary data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->