### PR TITLE
Fix #286: keep price coordinator alive when idle

### DIFF
--- a/tests/test_price_coordinator_liveness.py
+++ b/tests/test_price_coordinator_liveness.py
@@ -1,0 +1,58 @@
+"""Regression tests for price coordinator refresh scheduling."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.frank_energie.coordinator import FrankEnergiePriceCoordinator
+
+
+@pytest.fixture
+def price_coordinator() -> FrankEnergiePriceCoordinator:
+    """Create a minimally initialized price coordinator for interval tests."""
+    coordinator = object.__new__(FrankEnergiePriceCoordinator)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {"resolution": "PT15M"}
+    coordinator._api_resolution_state = None
+    coordinator._resolution_change_pending = False
+    coordinator.cached_prices_tomorrow = object()
+    coordinator.last_fetch_tomorrow = datetime(2026, 8, 31, 11, tzinfo=UTC)
+    coordinator.update_interval = None
+    return coordinator
+
+
+@pytest.mark.parametrize(
+    ("resolution", "expected_interval"),
+    [("PT15M", timedelta(minutes=15)), ("PT60M", timedelta(minutes=60))],
+)
+def test_cached_tomorrow_prices_keep_coordinator_alive(
+    price_coordinator: FrankEnergiePriceCoordinator,
+    resolution: str,
+    expected_interval: timedelta,
+) -> None:
+    """Keep a non-None fallback interval after tomorrow prices are cached."""
+    price_coordinator.config_entry.options["resolution"] = resolution
+    now_utc = datetime(2026, 8, 31, 14, 0, tzinfo=UTC)
+
+    with patch.object(
+        FrankEnergiePriceCoordinator,
+        "_tomorrow_cache_matches_date",
+        return_value=True,
+    ):
+        price_coordinator._adjust_update_interval(now_utc)
+
+    assert price_coordinator.update_interval == expected_interval
+
+
+def test_before_publication_keeps_coordinator_alive(
+    price_coordinator: FrankEnergiePriceCoordinator,
+) -> None:
+    """Keep a low-frequency fallback interval before tomorrow's publication."""
+    price_coordinator.cached_prices_tomorrow = None
+    price_coordinator.last_fetch_tomorrow = None
+    now_utc = datetime(2026, 8, 31, 10, 0, tzinfo=UTC)
+
+    price_coordinator._adjust_update_interval(now_utc)
+
+    assert price_coordinator.update_interval == timedelta(hours=1)

--- a/tests/test_price_coordinator_liveness.py
+++ b/tests/test_price_coordinator_liveness.py
@@ -56,12 +56,7 @@ def test_cached_tomorrow_prices_keep_coordinator_alive(
     price_coordinator.config_entry.options["resolution"] = resolution
     now_utc = datetime(2026, 8, 31, 14, 0, tzinfo=UTC)
 
-    with patch.object(
-        FrankEnergiePriceCoordinator,
-        "_tomorrow_cache_matches_date",
-        return_value=True,
-    ):
-        price_coordinator._adjust_update_interval(now_utc)
+    price_coordinator._adjust_update_interval(now_utc)
 
     assert price_coordinator.update_interval == expected_interval
 

--- a/tests/test_price_coordinator_liveness.py
+++ b/tests/test_price_coordinator_liveness.py
@@ -1,22 +1,43 @@
 """Regression tests for price coordinator refresh scheduling."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+from python_frank_energie.models import MarketPrices, PriceData
 
 from custom_components.frank_energie.coordinator import FrankEnergiePriceCoordinator
 
 
+def _market_prices_dated(*iso_starts: str) -> MarketPrices:
+    """Minimal real MarketPrices with one electricity entry per ISO start."""
+    raw = [
+        {
+            "from": iso,
+            "till": iso,
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        }
+        for iso in iso_starts
+    ]
+    return MarketPrices(
+        electricity=PriceData(raw, energy_type="electricity"),
+        gas=PriceData([], energy_type="gas"),
+        energy_country="NL",
+    )
+
+
 @pytest.fixture
 def price_coordinator() -> FrankEnergiePriceCoordinator:
-    """Create a minimally initialized price coordinator for interval tests."""
-    coordinator = object.__new__(FrankEnergiePriceCoordinator)
-    coordinator.config_entry = MagicMock()
-    coordinator.config_entry.options = {"resolution": "PT15M"}
-    coordinator._api_resolution_state = None
-    coordinator._resolution_change_pending = False
-    coordinator.cached_prices_tomorrow = object()
+    """Create a price coordinator with lightweight mocks for interval tests."""
+    config_entry = MagicMock()
+    config_entry.options = {"resolution": "PT15M"}
+    coordinator = FrankEnergiePriceCoordinator(
+        MagicMock(), config_entry, MagicMock(), MagicMock()
+    )
+    coordinator.cached_prices_tomorrow = _market_prices_dated("2026-08-31T22:00:00.000Z")
     coordinator.last_fetch_tomorrow = datetime(2026, 8, 31, 11, tzinfo=UTC)
     coordinator.update_interval = None
     return coordinator


### PR DESCRIPTION
## Summary

Fixes #286 by preventing `FrankEnergiePriceCoordinator` from becoming permanently idle when `update_interval` is set to `None`.

The price coordinator uses an aligned scheduler for exact refresh boundaries, but it must also retain a coordinator-level fallback interval. If an aligned scheduler callback is missed or cancelled, a `None` interval leaves `DataUpdateCoordinator` with no mechanism to wake itself and re-evaluate its scheduling state.

## Changes

- Add regression coverage for the coordinator's fallback refresh intervals.
- Verify that PT15M configurations retain a 15-minute fallback interval after tomorrow's prices are cached.
- Verify that PT60M configurations retain a 60-minute fallback interval after tomorrow's prices are cached.
- Verify that the coordinator retains a one-hour fallback interval before tomorrow's prices are published.
- Keep the aligned scheduler as the primary mechanism for exact `:00`, `:15`, `:30`, and `:45` refreshes.

## Why

Previously, `_adjust_update_interval()` could set `update_interval` to `None`. Once the coordinator stopped scheduling updates itself, it depended entirely on the external aligned scheduler to trigger another refresh. If that callback was missed or cancelled, `_adjust_update_interval()` was never reached again and the coordinator could remain idle indefinitely.

A non-null fallback interval removes this liveness failure while preserving the existing aligned refresh behaviour.

## Testing

Regression tests cover:

- cached tomorrow prices with PT15M resolution;
- cached tomorrow prices with PT60M resolution; and
- the period before tomorrow's publication window.

The existing aligned scheduler remains responsible for precise slot-boundary updates.

Fixes #286

## Samenvatting door Sourcery

Houd de prijscoördinator actief met fallback-verversingsintervallen zonder het uitgelijnde planningsgedrag te wijzigen.

Bugfixes:
- Voorkom dat de prijscoördinator permanent inactief wordt wanneer uitgelijnde verversingscallbacks worden gemist of geannuleerd, door een niet-null fallback-verversingsinterval te behouden.

Verbeteringen:
- Behoud nauwkeurige uitlijning op kwartieren en hele uren voor verversingsplanning, en voeg coördinatorbrede fallback-intervallen toe voor gecachte en nog niet gepubliceerde prijzen.

Tests:
- Voeg regressietests toe voor fallback-intervallen met resoluties van PT15M en PT60M en voor het moment waarop de prijzen voor morgen nog niet zijn gepubliceerd.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Voorkom dat de prijscoördinator permanent inactief wordt en behoud tegelijkertijd een nauwkeurige uitlijning van de vernieuwingsplanning.

Bugfixes:
- Houd de prijscoördinator actief met niet-null-reservevernieuwingsintervallen wanneer callbacks van de uitgelijnde planner worden gemist of geannuleerd.

Verbeteringen:
- Behoud uitgelijnde planning voor nauwkeurige vernieuwingsmomenten op kwartieren en hele uren, terwijl intervallen op coördinatorniveau als reserve behouden blijven.

Tests:
- Voeg regressiedekking toe voor reservevernieuwingsintervallen met resoluties van PT15M en PT60M, inclusief de periode voordat de prijzen voor morgen worden gepubliceerd.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent the price coordinator from becoming permanently idle while preserving precise aligned refresh scheduling.

Bug Fixes:
- Keep the price coordinator alive with non-null fallback refresh intervals when aligned scheduler callbacks are missed or cancelled.

Enhancements:
- Preserve aligned scheduling for precise quarter-hour and hourly refresh boundaries while retaining coordinator-level fallback intervals.

Tests:
- Add regression coverage for fallback intervals with PT15M and PT60M resolutions, including the period before tomorrow’s prices are published.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for price coordinator liveness using realistic dated market-price data.
  - Verified cached-price scheduling at 15- and 60-minute intervals.
  - Added coverage for the one-hour period before prices are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->