### PR TITLE
fix: link child devices via via_device_id, not deprecated via_device

### DIFF
--- a/custom_components/frank_energie/__init__.py
+++ b/custom_components/frank_energie/__init__.py
@@ -26,9 +26,7 @@ from python_frank_energie.models import UserSites
 from .const import (
     CONF_COORDINATOR,
     DOMAIN,
-    SERVICE_NAME_BATTERIES,
     SERVICE_NAME_BATTERY_SESSIONS,
-    SERVICE_NAME_ENODE_CHARGERS,
     TIMEZONE_AMSTERDAM,
     TOMORROW_PUBLICATION_HOUR_LOCAL,
 )
@@ -224,19 +222,18 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         # For backwards compatibility, update the unique ID
         self._update_unique_id()
 
-        # Clean up obsolete umbrella devices ("Smart Batteries", "Chargers", "Battery Sessions") from registry
+        # Clean up the obsolete "Frank Energie - Battery Sessions" umbrella device
+        # from the registry; session sensors are grouped under their individual
+        # battery devices now. The "Batteries" and "Chargers" service devices are
+        # NOT obsolete - they carry the aggregate sensors and are the parent the
+        # per-battery / per-charger child devices link to via `via_device_id`.
         device_registry = dr.async_get(self.hass)
-        for obsolete_service in (
-            SERVICE_NAME_BATTERIES,
-            SERVICE_NAME_BATTERY_SESSIONS,
-            SERVICE_NAME_ENODE_CHARGERS,
+        if device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{self.entry.entry_id}_{SERVICE_NAME_BATTERY_SESSIONS}"),
+            config_entry_id=self.entry.entry_id,
         ):
-            if device := device_registry.async_get_device_by_identifier(
-                (DOMAIN, f"{self.entry.entry_id}_{obsolete_service}"),
-                config_entry_id=self.entry.entry_id,
-            ):
-                device_registry.async_remove_device(device.id)
-                _LOGGER.debug("Removed obsolete umbrella device: %s", obsolete_service)
+            device_registry.async_remove_device(device.id)
+            _LOGGER.debug("Removed obsolete Battery Sessions umbrella device")
 
         # Create API and Coordinators
         _LOGGER.debug("Creating Frank Energie API instance")
@@ -439,7 +436,7 @@ class FrankEnergieComponent:  # pylint: disable=too-few-public-methods
         platforms (binary_sensor, button, switch, datetime) run. This ensures
         all parent service devices (Frank Energie - Batteries, Chargers, etc.)
         are registered in the device registry before child devices attempt to
-        link to them via via_device.
+        link to them via via_device_id.
         """
         _LOGGER.debug("Starting to forward entry setups to platforms")
         try:

--- a/custom_components/frank_energie/helpers.py
+++ b/custom_components/frank_energie/helpers.py
@@ -11,16 +11,23 @@ from typing import TYPE_CHECKING, Final
 
 from cryptography.fernet import Fernet, InvalidToken  # type: ignore[import]
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.storage import Store
 
 from .const import (
+    API_CONF_URL,
+    COMPONENT_TITLE,
     DOMAIN,
+    SERVICE_NAME_PRICES,
     UNIT_GAS_BE,
     UNIT_GAS_NL,
+    VERSION,
 )
 from .exceptions import EncryptionError
 
 if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
     from python_frank_energie.models import ChargeSettings
 
 _LOGGER = logging.getLogger(__name__)
@@ -127,3 +134,62 @@ def decrypt_password(hass: HomeAssistant, password: str) -> str | None:
 def device_translation_key(service_name: str) -> str:
     """Generate a lowercase slugified device translation key from a service name."""
     return f"{DOMAIN}_{service_name.lower().replace(' ', '_')}"
+
+
+def service_device_info(
+    entry_id: str,
+    service_name: str,
+    *,
+    configuration_url: str | None = None,
+) -> DeviceInfo:
+    """Return the DeviceInfo for a Frank Energie service (parent) device.
+
+    Individual batteries, chargers and vehicles are child devices that link
+    back to one of these via ``via_device_id``. Building the parent identity
+    in a single place keeps the child's ``via_device_id`` lookup and the
+    parent the sensor platform registers exactly in sync.
+    """
+    identifier = (
+        entry_id
+        if service_name == SERVICE_NAME_PRICES
+        else f"{entry_id}_{service_name}"
+    )
+    return DeviceInfo(
+        identifiers={(DOMAIN, identifier)},
+        name=f"{COMPONENT_TITLE} - {service_name}",
+        translation_key=device_translation_key(service_name),
+        manufacturer=COMPONENT_TITLE,
+        entry_type=DeviceEntryType.SERVICE,
+        configuration_url=configuration_url or API_CONF_URL,
+        model=service_name,
+        sw_version=VERSION,
+    )
+
+
+def register_service_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    service_name: str,
+    *,
+    configuration_url: str | None = None,
+) -> str:
+    """Register a Frank Energie service (parent) device and return its id.
+
+    Child devices reference the parent by ``via_device_id``. ``DeviceInfo`` no
+    longer accepts the deprecated ``via_device`` identifier tuple -- HA Core
+    2026.9 rejects it in ``async_get_or_create`` while entities are added (the
+    deprecation report is raised, not just logged, so entity setup aborts) and
+    removes it entirely in 2027.8. Registering the parent here, before the child
+    entities are added, guarantees the id resolves regardless of the order in
+    which entities are processed.
+
+    Pass the same ``configuration_url`` the aggregate sensor uses so the shared
+    parent device is not rewritten with a different value moments later.
+    """
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **service_device_info(
+            entry.entry_id, service_name, configuration_url=configuration_url
+        ),
+    )
+    return device.id

--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import (
@@ -48,13 +48,11 @@ from homeassistant.util import dt as dt_util
 from python_frank_energie.models import EnodeCharger
 
 from .const import (
-    API_CONF_URL,
     ATTR_FROM_TIME,
     ATTR_LAST_UPDATE,
     ATTR_START_DATE,
     ATTR_TILL_TIME,
     ATTRIBUTION,
-    COMPONENT_TITLE,
     DATA_BATTERIES,
     DATA_CONTRACT_PRICE_RESOLUTION_STATE,
     DATA_ELECTRICITY,
@@ -94,7 +92,6 @@ from .const import (
     TIMEZONE_AMSTERDAM,
     UNIT_ELECTRICITY,
     UNIT_GAS_NL,
-    VERSION,
 )
 from .coordinator import (
     FrankEnergieBatterySessionCoordinator,
@@ -102,7 +99,11 @@ from .coordinator import (
     FrankEnergieData,
     SmartBatterySessions,
 )
-from .helpers import device_translation_key, resolve_gas_unit
+from .helpers import (
+    register_service_device,
+    resolve_gas_unit,
+    service_device_info,
+)
 from .statistics import lowest_window
 
 _DataT = TypeVar("_DataT")
@@ -4162,6 +4163,7 @@ class EnodeChargerSensor(CoordinatorEntity, SensorEntity):
         coordinator: FrankEnergieCoordinator,
         description: ChargerSensorDescription,
         charger: EnodeCharger,
+        via_device_id: str | None = None,
     ) -> None:
         """Initialize the Enode charger sensor."""
         super().__init__(coordinator)
@@ -4180,11 +4182,8 @@ class EnodeChargerSensor(CoordinatorEntity, SensorEntity):
             model=model,
             name=charger_name,
         )
-        if coordinator.config_entry:
-            self._attr_device_info["via_device"] = (
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_{SERVICE_NAME_ENODE_CHARGERS}",
-            )
+        if via_device_id:
+            self._attr_device_info["via_device_id"] = via_device_id
 
     def _get_charger(self) -> Any | None:
         """Look up the current charger object from coordinator data by ID."""
@@ -4336,26 +4335,16 @@ class FrankEnergieSensor(
 
         self._attr_unique_id = f"{entry.unique_id}.{description.key}"
 
-        # Do not set extra identifier for default service, backwards compatibility
-        device_info_identifiers: set[tuple[str, str]] = (
-            {(DOMAIN, f"{entry.entry_id}")}
-            if description.service_name == SERVICE_NAME_PRICES
-            else {(DOMAIN, f"{entry.entry_id}_{description.service_name}")}
-        )
-
         user_data = (
             coordinator.data.get(DATA_USER) if coordinator.data is not None else None
         )
 
-        self._attr_device_info = DeviceInfo(
-            identifiers=device_info_identifiers,
-            name=f"{COMPONENT_TITLE} - {description.service_name}",
-            translation_key=device_translation_key(description.service_name),
-            manufacturer=COMPONENT_TITLE,
-            entry_type=DeviceEntryType.SERVICE,
-            configuration_url=(getattr(user_data, "websiteUrl", None) or API_CONF_URL),
-            model=description.service_name,
-            sw_version=VERSION,
+        # The Prices service keeps the bare entry_id as its identifier for
+        # backwards compatibility; every other service is suffixed.
+        self._attr_device_info = service_device_info(
+            entry.entry_id,
+            description.service_name,
+            configuration_url=getattr(user_data, "websiteUrl", None),
         )
 
         # Set defaults or exceptions for non default sensors.
@@ -4428,25 +4417,28 @@ class FrankEnergieSmartBatterySensor(FrankEnergieSensor):
         battery_id: str,
         battery_name: str,
         battery_brand: str,
+        via_device_id: str | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, description, entry)
         self._battery_id = battery_id
         self._battery_name = battery_name
         self._battery_brand = battery_brand
-        self._entry_id = entry.entry_id
+        self._via_device_id = via_device_id
         self._attr_unique_id = f"{entry.unique_id}.{battery_id}_{description.key}"
 
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device info."""
-        return DeviceInfo(
+        info = DeviceInfo(
             identifiers={(DOMAIN, self._battery_id)},
             name=self._battery_name,
             manufacturer=self._battery_brand,
             model="SmartBattery",
-            via_device=(DOMAIN, f"{self._entry_id}_{SERVICE_NAME_BATTERIES}"),
         )
+        if self._via_device_id:
+            info["via_device_id"] = self._via_device_id
+        return info
 
 
 class FrankEnergieBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -4944,6 +4936,29 @@ def _build_aggregated_smart_batteries_descriptions() -> list[
     return descriptions
 
 
+def _service_parent_device_id(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: FrankEnergieCoordinator,
+    service_name: str,
+    user_data: object,
+) -> str | None:
+    """Return the id of the service parent device the child devices link to.
+
+    Returns ``None`` when the coordinator is unauthenticated: its child
+    sensors are all filtered out in that case, so registering the parent
+    would leave an entity-less device behind.
+    """
+    if not coordinator.api.is_authenticated:
+        return None
+    return register_service_device(
+        hass,
+        entry,
+        service_name,
+        configuration_url=getattr(user_data, "websiteUrl", None),
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -5104,6 +5119,14 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Setting up Enode charger sensors for %d chargers", len(enode.chargers)
         )
+        # Register the Chargers parent device before its child devices are added.
+        charger_via_device_id = _service_parent_device_id(
+            hass,
+            config_entry,
+            charger_coordinator,
+            SERVICE_NAME_ENODE_CHARGERS,
+            user_data,
+        )
         for description in STATIC_ENODE_SENSOR_TYPES:
             if (
                 not description.authenticated
@@ -5120,7 +5143,12 @@ async def async_setup_entry(
                     or charger_coordinator.api.is_authenticated
                 ):
                     entities.append(
-                        EnodeChargerSensor(charger_coordinator, description, charger)
+                        EnodeChargerSensor(
+                            charger_coordinator,
+                            description,
+                            charger,
+                            charger_via_device_id,
+                        )
                     )
 
     if (
@@ -5134,6 +5162,14 @@ async def async_setup_entry(
         _LOGGER.debug(
             "Setting up smart battery type: %s", type(batteries.batteries)
         )  # <class 'list'>
+        # Register the Batteries parent device before its child devices are added.
+        battery_via_device_id = _service_parent_device_id(
+            hass,
+            config_entry,
+            battery_coordinator,
+            SERVICE_NAME_BATTERIES,
+            user_data,
+        )
         aggregated_battery_descriptions = (
             _build_aggregated_smart_batteries_descriptions()
         )
@@ -5170,6 +5206,7 @@ async def async_setup_entry(
                             battery.id,
                             f"Smart Battery {battery.id}",
                             battery.brand,
+                            battery_via_device_id,
                         )
                     )
                     _LOGGER.debug(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,12 @@
+from collections.abc import Callable
 from datetime import datetime, timedelta
 
 import pytest
 from homeassistant import config_entries
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.util import dt
 from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
@@ -612,6 +615,121 @@ def test_enode_charger_sensor_properties_and_value(
         coordinator=mock_coordinator, description=rate_desc, charger=mock_charger
     )
     assert sensor_rate.native_value == pytest.approx(11.0)
+
+
+async def _parent_and_child_devices_after_add(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    sensor: SensorEntity,
+    service_name: str,
+) -> tuple[DeviceEntry | None, DeviceEntry | None]:
+    """Add ``sensor`` through a real entity platform and return the (parent,
+    child) device-registry entries HA created from its ``device_info`` -- so
+    HA's own ``async_get_or_create`` validation runs against what we build.
+    """
+    from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+    from homeassistant.helpers import device_registry as dr
+    from pytest_homeassistant_custom_component.common import MockEntityPlatform
+
+    from custom_components.frank_energie.const import DOMAIN
+
+    platform = MockEntityPlatform(hass, domain=SENSOR_DOMAIN, platform_name=DOMAIN)
+    platform.config_entry = entry
+    await platform.async_add_entities([sensor])
+
+    dev_reg = dr.async_get(hass)
+    parent = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{entry.entry_id}_{service_name}"), config_entry_id=entry.entry_id
+    )
+    child = dev_reg.async_get_device_by_identifier(
+        next(iter(sensor.device_info["identifiers"])), config_entry_id=entry.entry_id
+    )
+    return parent, child
+
+
+@pytest.mark.asyncio
+async def test_enode_charger_device_nests_under_parent(
+    hass: HomeAssistant, create_mock_charger: Callable[..., object]
+) -> None:
+    """An Enode charger's device links to the Chargers service device by id.
+
+    ``DeviceInfo`` no longer accepts the deprecated ``via_device`` identifier
+    tuple -- HA Core 2026.9 raises on it while entities are added and removes it
+    in 2027.8 -- so the child must reference the parent's registry id instead.
+    """
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import (
+        DOMAIN,
+        SERVICE_NAME_ENODE_CHARGERS,
+    )
+    from custom_components.frank_energie.helpers import register_service_device
+    from custom_components.frank_energie.sensor import (
+        ENODE_CHARGER_SENSOR_TYPES,
+        EnodeChargerSensor,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test")
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.last_update_success = True
+
+    via_device_id = register_service_device(hass, entry, SERVICE_NAME_ENODE_CHARGERS)
+    charger = create_mock_charger(charger_id="chg_1", brand="Wallbox", model="Copper")
+    description = next(
+        d for d in ENODE_CHARGER_SENSOR_TYPES if d.key == "charger_brand"
+    )
+    sensor = EnodeChargerSensor(coordinator, description, charger, via_device_id)
+    assert "via_device" not in sensor.device_info
+
+    parent, child = await _parent_and_child_devices_after_add(
+        hass, entry, sensor, SERVICE_NAME_ENODE_CHARGERS
+    )
+    assert parent is not None
+    assert parent.id == via_device_id
+    assert child is not None
+    assert child.via_device_id == via_device_id
+
+
+@pytest.mark.asyncio
+async def test_smart_battery_device_nests_under_parent(hass: HomeAssistant) -> None:
+    """A smart battery's device links to the Batteries service device by id
+    (the deprecated ``via_device`` tuple is rejected by HA Core)."""
+    from unittest.mock import MagicMock
+
+    from custom_components.frank_energie.const import DOMAIN, SERVICE_NAME_BATTERIES
+    from custom_components.frank_energie.helpers import register_service_device
+    from custom_components.frank_energie.sensor import (
+        STATIC_BATTERY_SENSOR_TYPES,
+        FrankEnergieSmartBatterySensor,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test")
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.last_update_success = True
+
+    via_device_id = register_service_device(hass, entry, SERVICE_NAME_BATTERIES)
+    sensor = FrankEnergieSmartBatterySensor(
+        coordinator,
+        STATIC_BATTERY_SENSOR_TYPES[0],
+        entry,
+        "bat_1",
+        "Smart Battery bat_1",
+        "Sessy",
+        via_device_id,
+    )
+    assert "via_device" not in sensor.device_info
+
+    parent, child = await _parent_and_child_devices_after_add(
+        hass, entry, sensor, SERVICE_NAME_BATTERIES
+    )
+    assert parent is not None
+    assert parent.id == via_device_id
+    assert child is not None
+    assert child.via_device_id == via_device_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

On HA 2026.9+, setting up the integration with an Enode charger or smart battery raises `RuntimeError` and aborts sensor entity setup:

```
WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'frank_energie' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead ... This will stop working in Home Assistant 2027.8.0
ERROR (MainThread) [homeassistant.components.sensor] Error adding entity None for domain sensor with platform frank_energie
...
RuntimeError: Detected code that calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead. Please report this issue
```

HA Core removed `via_device` from the `DeviceInfo` TypedDict. `entity_platform` forwards `**device_info` straight into `device_registry.async_get_or_create`, so a lingering `via_device` key now trips a `report_usage` that escalates to a raise while entities are being added. Removed entirely in 2027.8.

`EnodeChargerSensor` and `FrankEnergieSmartBatterySensor` still passed the `(DOMAIN, "<entry_id>_<service>")` identifier tuple.

## Type of Change

Please select all that apply:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation update
- [ ] Dependency update
- [ ] Test improvement
- [ ] CI/CD improvement

## Related Issues

<!-- Link related issues using: Fixes #123 -->

Fixes #

## Changes

- **`via_device` → `via_device_id`** for the per-charger and per-battery child devices. The parent "service" device is now registered up front in `sensor.async_setup_entry` (`register_service_device()`), and its registry **id** is threaded into the child entities — so the parent link no longer depends on parent/child entity add-ordering.
- **`service_device_info()`** in `helpers.py` is now the single builder for the `Frank Energie - <service>` parent `DeviceInfo` (was inlined in `FrankEnergieSensor.__init__`).
- **`setup()`'s obsolete-device cleanup no longer deletes the `Batteries` and `Chargers` service devices.** Those identifiers were in the "obsolete umbrella" delete list since #189, but the aggregate sensors (`total_batteries`, `enode_total_chargers`, …) have always lived on them and they are the `via_device` parent — so every reload was deleting and recreating a live device (and leaving children detached if a coordinator raised `ConfigEntryNotReady`). Only the never-created `Battery Sessions` umbrella is still pruned.

## Testing

- [x] Existing tests pass
- [x] New tests added
- [ ] Manually tested
- [ ] Home Assistant restarted and verified
- [ ] No testing required

### Test Details

`ruff` / `ruff format` / `flake8` clean (no new findings). `poetry run pytest` → `212 passed`; the 4 `test_coordinator.py` liveness failures are pre-existing and unrelated (reproduce on a clean `main`).

New in `tests/test_sensor.py`: `test_enode_charger_device_nests_under_parent` and `test_smart_battery_device_nests_under_parent` add the child entity through a real `MockEntityPlatform`, so HA's own `async_get_or_create` validation runs against the `device_info` we build, and assert `child.via_device_id == parent.id`. Verified they fail if `via_device` is reintroduced.

## Screenshots

N/A

## Home Assistant Checklist

- [x] Follows Home Assistant development guidelines
- [x] Uses asynchronous APIs where applicable
- [x] Uses timezone-aware datetimes where applicable
- [x] Includes appropriate logging
- [x] Includes error handling
- [x] Includes type hints
- [ ] Documentation updated (if required)
- [ ] Translations updated (if required)
- [ ] Diagnostics updated (if required)

## Breaking Changes

N/A for users. Note for reviewers: after this change the `Batteries` / `Chargers` service devices stop being deleted + recreated on every reload — existing installs keep the same device and entities are unaffected.

## Additional Notes

Follow-ups intentionally left out of this fix (each is a broader change):

1. `binary_sensor.py` / `button.py` / `number.py` / `select.py` still hand-roll the same parent `DeviceInfo` — should call `service_device_info()` (`binary_sensor.py`'s is an exact match).
2. The per-battery / per-charger child device is defined in 5 platforms with divergent `name` / `model` / `manufacturer`, and only `sensor` sets the parent link — wants one shared child-`DeviceInfo` helper consumed everywhere.
3. More HA-idiomatic: register the parent devices once in `__init__.py` `setup()` and stash the ids on `runtime_data`, dropping the `via_device_id` constructor params.
4. Replace the hardcoded every-startup obsolete-device delete list with `async_remove_config_entry_device` or a versioned migration.

The second reported warning — `async_get_device` is deprecated (`__init__.py` line 234) — is already fixed on `main` (`e27e189`), just not in the released `v2026.8.8`.

## Samenvatting door Sourcery

Vervang verouderde relaties tussen kindapparaten door stabiele koppelingen met registry-ID's en behoud de bovenliggende serviceapparaten die worden gebruikt door aggregaat- en kindsensoren.

Bugfixes:
- Voorkom fouten bij het instellen van sensoren in nieuwere Home Assistant-versies door opladers en slimme batterijapparaten via `via_device_id` te koppelen in plaats van het verouderde `via_device`.
- Behoud de bovenliggende apparaten Batteries en Chargers tijdens het opnieuw laden, zodat kindapparaten correct gekoppeld blijven.

Verbeteringen:
- Centraliseer de metadata van bovenliggende serviceapparaten en registreer bovenliggende apparaten voordat hun kindentiteiten worden aangemaakt.

Tests:
- Voeg tests op registry-niveau toe die verifiëren dat opladers en slimme batterijapparaten via hun registry-ID aan hun bovenliggende apparaten zijn gekoppeld en het verouderde veld niet gebruiken.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Vervang verouderde koppelingen naar kindapparaten door stabiele relaties op basis van register-ID's en behoud de serviceapparaten die eigenaar zijn van geaggregeerde en kind-sensoren.

Bugfixes:
- Voorkom fouten bij het instellen van sensoren in nieuwere Home Assistant-versies door kindapparaten van laders en slimme batterijen via register-ID's te koppelen in plaats van via het verouderde veld voor apparaatrelaties.
- Behoud de bovenliggende serviceapparaten Batteries en Chargers tijdens het opnieuw laden, zodat geaggregeerde sensoren en relaties met kindapparaten intact blijven.

Verbeteringen:
- Centraliseer metagegevens van serviceapparaten en registreer bovenliggende apparaten voordat kindentiteiten worden aangemaakt, zodat de apparaatstructuur stabiel genest blijft.

Tests:
- Voeg tests op registerniveau toe die controleren of apparaten van laders en slimme batterijen aan hun bovenliggende apparaten worden gekoppeld via de register-ID van het bovenliggende apparaat.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Behoud stabiele ouder-kindrelaties tussen apparaten voor oplader- en slimme-batterijsensoren tijdens Home Assistant-upgrades en het opnieuw laden van integraties.

Bugfixes:
- Vervang verouderde koppelingen naar kindapparaten door registry-gebaseerde `via_device_id`-relaties, zodat de configuratie van oplader- en slimme-batterijsensoren compatibel blijft met nieuwere Home Assistant-versies.
- Behoud de ouderapparaten Batteries en Chargers tijdens het opnieuw laden, in plaats van actieve apparaten te verwijderen en opnieuw aan te maken.

Verbeteringen:
- Centraliseer metadata voor serviceapparaten en registreer ouderapparaten voordat kindentiteiten worden aangemaakt, zodat de apparaatnesting stabiel blijft.

Tests:
- Voeg tests op registry-niveau toe die controleren of oplader- en slimme-batterijapparaten via de registry-ID van het ouderapparaat aan hun ouderapparaten zijn gekoppeld, zonder het verouderde veld te gebruiken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Maintain stable parent-child device relationships for charger and smart-battery sensors across Home Assistant upgrades and integration reloads.

Bug Fixes:
- Replace deprecated child-device links with registry-based `via_device_id` relationships so charger and smart-battery sensor setup remains compatible with newer Home Assistant versions.
- Preserve the Batteries and Chargers parent devices across reloads instead of removing and recreating active devices.

Enhancements:
- Centralize service-device metadata and register parent devices before creating child entities, ensuring stable device nesting.

Tests:
- Add registry-level tests verifying charger and smart-battery devices link to their parent devices through the parent registry ID without using the deprecated field.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device organization by grouping charger and battery sensors under their corresponding service devices.
  * Service devices now provide clearer identification and optional configuration links.
* **Bug Fixes**
  * Removed obsolete Battery Sessions device cleanup while preserving active Batteries and Chargers devices.
  * Corrected device relationship metadata for more reliable Home Assistant registry linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->