### PR TITLE
chore: fix CI - ruff format catch-up and stale coordinator interval tests

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -2600,7 +2600,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         now_local = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM))
         today = now_local.date()
         tomorrow = today + timedelta(days=1)
-    
+
         tomorrow_cache_valid = (
             self.cached_prices_tomorrow is not None
             and self.last_fetch_tomorrow is not None
@@ -2610,13 +2610,11 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
                 tomorrow,
             )
         )
-    
+
         if tomorrow_cache_valid:
             # Keep the coordinator alive as a safety fallback. The aligned
             # scheduler remains responsible for exact slot-boundary updates.
-            new_interval = timedelta(
-                minutes=15 if self.resolution == "PT15M" else 60
-            )
+            new_interval = timedelta(minutes=15 if self.resolution == "PT15M" else 60)
         elif now_local.time() < time(TOMORROW_PUBLICATION_HOUR_LOCAL):
             # Keep a low-frequency fallback alive before publication.
             new_interval = timedelta(hours=1)
@@ -2628,10 +2626,10 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             new_interval = timedelta(minutes=15)
         else:
             new_interval = timedelta(minutes=DEFAULT_INTERVAL_PRICES)
-    
+
         if self.update_interval == new_interval:
             return
-    
+
         _LOGGER.debug(
             "Price coordinator update interval changed to %s",
             new_interval,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1149,7 +1149,8 @@ async def test_promote_tomorrow_prices_updates_all_caches(coordinator) -> None:
 async def test_price_coordinator_before_window(
     mock_frank_energie, mock_config_entry, monkeypatch
 ) -> None:
-    """Test that price coordinator update interval is None before local 13:00 when tomorrow's prices are not cached."""
+    """Before local 13:00 with no cached tomorrow prices, the coordinator keeps
+    a low-frequency (hourly) fallback interval rather than going idle."""
     # Mock utcnow to 10:00 UTC (12:00 local time CEST on May 27th)
     mock_now = datetime(2026, 5, 27, 10, 0, 0, tzinfo=ZoneInfo("UTC"))
     from homeassistant.util import dt as dt_util
@@ -1166,7 +1167,7 @@ async def test_price_coordinator_before_window(
     price_coordinator.cached_prices_tomorrow = None
     price_coordinator._adjust_update_interval(mock_now)
 
-    assert price_coordinator.update_interval is None
+    assert price_coordinator.update_interval == timedelta(hours=1)
 
 
 @pytest.mark.asyncio
@@ -1197,7 +1198,8 @@ async def test_price_coordinator_inside_window(
 async def test_price_coordinator_skipped_when_cached(
     mock_frank_energie, mock_config_entry, monkeypatch
 ) -> None:
-    """Test that price coordinator update interval is None if tomorrow's prices are already cached."""
+    """With tomorrow's prices already cached, the coordinator keeps a fallback
+    interval (15 min at PT15M) rather than going idle."""
     # Mock utcnow to 12:00 UTC (14:00 local time CEST on May 27th)
     mock_now = datetime(2026, 5, 27, 12, 0, 0, tzinfo=ZoneInfo("UTC"))
     from homeassistant.util import dt as dt_util
@@ -1219,7 +1221,7 @@ async def test_price_coordinator_skipped_when_cached(
 
     price_coordinator._adjust_update_interval(mock_now)
 
-    assert price_coordinator.update_interval is None
+    assert price_coordinator.update_interval == timedelta(minutes=15)
 
 
 @pytest.mark.asyncio
@@ -1482,7 +1484,8 @@ async def test_full_day_cycle_fetch_promote_refetch(
             coordinator._fetch_prices_with_fallback.call_count
             == today_fetch_calls_after_first
         )
-        assert coordinator.update_interval is None  # now confirmed idle
+        # Stays alive on the fallback interval rather than going idle.
+        assert coordinator.update_interval == timedelta(minutes=15)
 
         # --- Midnight {today} -> {tomorrow}: promote tomorrow's cache ---
         freezer.move_to(
@@ -1738,7 +1741,8 @@ async def test_full_day_cycle_recovers_when_first_attempt_is_poisoned(
     coordinator._adjust_update_interval(now_utc_1)
 
     assert coordinator.cached_prices_tomorrow is day2_prices
-    assert coordinator.update_interval is None  # validated cache, safe to go idle
+    # Stays alive on the fallback interval rather than going idle.
+    assert coordinator.update_interval == timedelta(minutes=15)
 
     # --- Midnight Day 1 -> Day 2 ---
     freezer.move_to(datetime(2026, 7, 21, 0, 0, tzinfo=tz))
@@ -1780,7 +1784,8 @@ async def test_full_day_cycle_recovers_when_first_attempt_is_poisoned(
     assert result_retry is day3_prices
     assert coordinator.cached_prices_tomorrow is day3_prices
     assert coordinator.last_fetch_tomorrow == now_utc_2_retry
-    assert coordinator.update_interval is None  # now validated, safe to go idle
+    # Stays alive on the fallback interval rather than going idle.
+    assert coordinator.update_interval == timedelta(minutes=15)
 
 
 @pytest.mark.asyncio

--- a/tests/test_price_coordinator_liveness.py
+++ b/tests/test_price_coordinator_liveness.py
@@ -37,7 +37,9 @@ def price_coordinator() -> FrankEnergiePriceCoordinator:
     coordinator = FrankEnergiePriceCoordinator(
         MagicMock(), config_entry, MagicMock(), MagicMock()
     )
-    coordinator.cached_prices_tomorrow = _market_prices_dated("2026-08-31T22:00:00.000Z")
+    coordinator.cached_prices_tomorrow = _market_prices_dated(
+        "2026-08-31T22:00:00.000Z"
+    )
     coordinator.last_fetch_tomorrow = datetime(2026, 8, 31, 11, tzinfo=UTC)
     coordinator.update_interval = None
     return coordinator


### PR DESCRIPTION
## Summary

Greens both currently-red CI jobs on `main` (`Ruff`, `Flake8 and pytest`). Neither failure was caused by an open PR — the breakage is already on `main`:

- **Ruff** — `ruff format --check` flags `coordinator.py` and `test_price_coordinator_liveness.py`. Both landed unformatted via direct pushes to `main`, and `.github/workflows/ruff.yml` only runs on `pull_request`, so nothing caught it.
- **Flake8 and pytest** — 5 assertions in `test_coordinator.py` still expect the price coordinator to go idle (`update_interval is None`) once tomorrow's prices are cached. The "keep price coordinator alive when idle" change made `_adjust_update_interval` hold a fallback interval instead, and added `test_price_coordinator_liveness.py`, but these 5 were missed — one of them inside a test whose own docstring says *"the coordinator does not go idle after it"*.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Dependency update
- [ ] Test improvement
- [ ] CI/CD improvement

## Related Issues

Fixes #

## Changes

- `ruff format` on `coordinator.py` (4 blank lines with trailing whitespace, 1 un-wrapped line) and `test_price_coordinator_liveness.py` (1 wrapped line) — whitespace only, no logic change.
- Update the 5 stale `test_coordinator.py` assertions to the interval `_adjust_update_interval` now sets: `timedelta(hours=1)` before publication, `timedelta(minutes=15)` (PT15M) once tomorrow's prices are cached. Matches `test_price_coordinator_liveness.py` and the tests' own "does not go idle" comments.

## Testing

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manually tested
- [ ] Home Assistant restarted and verified
- [ ] No testing required

### Test Details

`ruff check` ✅ · `ruff format --check` ✅ (40/40) · `flake8 --select=E9,F63,F7,F82` → 0 · `poetry run pytest` → **214 passed, 3 skipped, 0 failed**.

## Screenshots

N/A

## Home Assistant Checklist

- [x] Follows Home Assistant development guidelines
- [x] Includes type hints

## Breaking Changes

N/A

## Additional Notes

No production code behaviour changes — `coordinator.py` is formatting only; the rest is tests.

## Samenvatting door Sourcery

CI herstellen door de betreffende bestanden te formatteren en verouderde verwachtingen voor coördinatorintervallen bij te werken.

Bugfixes:
- Verouderde coördinatortests bijwerken zodat ze de fallback-update-intervallen verwachten die worden gebruikt wanneer de prijscoördinator actief blijft.

CI:
- Ruff-formattering en Flake8/pytest-CI-controles weer laten slagen.

Tests:
- Beweringen over coördinatorintervallen en beschrijvingen afstemmen op het gedrag van de niet-inactieve coördinator.

Onderhoud:
- Ruff-formatteerwijzigingen toepassen op de coördinator- en liveness-testbestanden.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore CI by formatting affected files and updating stale coordinator interval expectations.

Bug Fixes:
- Update stale coordinator tests to expect the fallback update intervals used when the price coordinator remains active.

CI:
- Restore passing Ruff formatting and Flake8/pytest CI checks.

Tests:
- Align coordinator interval assertions and descriptions with the non-idle coordinator behavior.

Chores:
- Apply Ruff formatting fixes to the coordinator and liveness test files.

</details>