### PR TITLE
fix: compare last-fetch timestamps in Amsterdam-local days, not UTC

### DIFF
--- a/custom_components/frank_energie/coordinator.py
+++ b/custom_components/frank_energie/coordinator.py
@@ -135,6 +135,18 @@ def _get_refresh_token_expires_at(api: Any) -> datetime | None:
     return None
 
 
+def _amsterdam_date(moment: datetime) -> date:
+    """Return the Amsterdam-local calendar date of a timestamp.
+
+    ``last_fetch_today`` / ``last_fetch_tomorrow`` are stored as UTC instants,
+    but every freshness check compares them against ``today`` / ``tomorrow``,
+    which are Amsterdam-local dates. ``moment.date()`` on the raw UTC value is
+    a day behind for the ~1-2h after local midnight (Amsterdam is always ahead
+    of UTC), which would wrongly treat a just-completed fetch as stale.
+    """
+    return moment.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
+
+
 def _price_to_dict(price: Price) -> dict[str, Any]:
     """Convert Price to dict."""
     return {
@@ -620,11 +632,11 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         # method exists to clean up before trusting anything.
         if (
             self.last_fetch_tomorrow is not None
-            and self.last_fetch_tomorrow.date() != today
+            and _amsterdam_date(self.last_fetch_tomorrow) != today
         ):
             _LOGGER.debug(
                 "Invalidating stale tomorrow-price cache (was fetched on %s)",
-                self.last_fetch_tomorrow.date(),
+                _amsterdam_date(self.last_fetch_tomorrow),
             )
             self.cached_prices_tomorrow = None
             self.last_fetch_tomorrow = None
@@ -632,7 +644,7 @@ class FrankEnergieCoordinator(DataUpdateCoordinator[FrankEnergieData]):
         if (
             self.cached_prices_tomorrow is not None
             and self.last_fetch_tomorrow is not None
-            and self.last_fetch_tomorrow.date() == today
+            and _amsterdam_date(self.last_fetch_tomorrow) == today
         ):
             if self._tomorrow_cache_matches_date(self.cached_prices_tomorrow, tomorrow):
                 _LOGGER.debug(
@@ -2563,10 +2575,13 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
 
         now_local = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM))
         today = now_local.date()
-        if self.last_fetch_today.date() != today:
+        if _amsterdam_date(self.last_fetch_today) != today:
             return False
 
-        if self.last_fetch_tomorrow and self.last_fetch_tomorrow.date() == today:
+        if (
+            self.last_fetch_tomorrow
+            and _amsterdam_date(self.last_fetch_tomorrow) == today
+        ):
             tomorrow = today + timedelta(days=1)
             if self._tomorrow_cache_matches_date(self.cached_prices_tomorrow, tomorrow):
                 _LOGGER.debug(
@@ -2604,7 +2619,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         tomorrow_cache_valid = (
             self.cached_prices_tomorrow is not None
             and self.last_fetch_tomorrow is not None
-            and self.last_fetch_tomorrow.date() == today
+            and _amsterdam_date(self.last_fetch_tomorrow) == today
             and self._tomorrow_cache_matches_date(
                 self.cached_prices_tomorrow,
                 tomorrow,
@@ -2704,10 +2719,16 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
         self._adjust_update_interval(now_utc)
 
         # Reset daily flags on new day
-        if self.last_fetch_today is None or self.last_fetch_today.date() != today:
+        if (
+            self.last_fetch_today is None
+            or _amsterdam_date(self.last_fetch_today) != today
+        ):
             self._today_prices_logged = False
 
-        if self.last_fetch_tomorrow is None or self.last_fetch_tomorrow.date() != today:
+        if (
+            self.last_fetch_tomorrow is None
+            or _amsterdam_date(self.last_fetch_tomorrow) != today
+        ):
             self._tomorrow_prices_logged = False
 
         user_data = self.settings_coordinator.data.get(DATA_USER)
@@ -2727,7 +2748,7 @@ class FrankEnergiePriceCoordinator(FrankEnergieCoordinator):
             if (
                 self._static_prices_today is None
                 or self.last_fetch_today is None
-                or self.last_fetch_today.date() != today
+                or _amsterdam_date(self.last_fetch_today) != today
             ):
                 try:
                     fetched_prices_today = await self._fetch_prices_with_fallback(
@@ -3017,7 +3038,10 @@ class FrankEnergiePVCoordinator(FrankEnergieCoordinator):
             raise UpdateFailed("Maintenance window active")
 
         today = now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()
-        if self.last_fetch_today is None or self.last_fetch_today.date() != today:
+        if (
+            self.last_fetch_today is None
+            or _amsterdam_date(self.last_fetch_today) != today
+        ):
             self._has_pv_systems = None
         self.last_fetch_today = now_utc
 

--- a/tests/test_price_coordinator_liveness.py
+++ b/tests/test_price_coordinator_liveness.py
@@ -74,3 +74,27 @@ def test_before_publication_keeps_coordinator_alive(
     price_coordinator._adjust_update_interval(now_utc)
 
     assert price_coordinator.update_interval == timedelta(hours=1)
+
+
+def test_fetch_just_after_local_midnight_counts_as_today(
+    price_coordinator: FrankEnergiePriceCoordinator,
+) -> None:
+    """A fetch whose UTC timestamp still falls on the previous calendar day
+    (the ~1-2h after Amsterdam midnight) must count as "fetched today".
+
+    ``last_fetch_tomorrow`` is a UTC instant but the freshness checks reason
+    in Amsterdam-local days; taking ``.date()`` on the raw UTC value here
+    would drop back to the pre-publication hourly interval right after
+    midnight instead of the cached-and-fresh fallback.
+    """
+    # Amsterdam 2026-09-01 00:30 CEST == UTC 2026-08-31 22:30.
+    now_utc = datetime(2026, 8, 31, 22, 30, tzinfo=UTC)
+    price_coordinator.last_fetch_tomorrow = now_utc
+    # Cache holds prices for the new "tomorrow", Amsterdam 2026-09-02.
+    price_coordinator.cached_prices_tomorrow = _market_prices_dated(
+        "2026-09-01T22:00:00.000Z"
+    )
+
+    price_coordinator._adjust_update_interval(now_utc)
+
+    assert price_coordinator.update_interval == timedelta(minutes=15)


### PR DESCRIPTION
## Summary

`last_fetch_today` / `last_fetch_tomorrow` on the price (and PV) coordinator are stored as **UTC instants**, but every freshness check compares them against `today` / `tomorrow`, which are computed as **Amsterdam-local dates** (`now_utc.astimezone(ZoneInfo(TIMEZONE_AMSTERDAM)).date()`) — as is the rest of the coordinator, because Frank Energie sells Dutch day-ahead power (the 13:00 publication window, the midnight `promote_tomorrow_prices` rollover, `_tomorrow_cache_matches_date` all reason in the NL calendar).

Taking `.date()` on the raw UTC value is one day behind for the ~1–2 h after **local** midnight (Amsterdam is always ahead of UTC). Effect in that window:
- a fetch that *just* completed reads as "not today" → `_adjust_update_interval` drops the coordinator from the cached-and-fresh 15-min fallback back to the pre-publication hourly interval;
- `_refresh_tomorrow_cache` can invalidate a still-valid tomorrow cache as "stale from a previous day".

It's fail-safe (only ever *more* polling, never idle-when-it-shouldn't) and the common flow is masked by `promote_tomorrow_prices` + `_tomorrow_cache_matches_date`, so it's low-severity — but it's a real inconsistency, surfaced by a review comment on #289.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #

## Changes

- Add `_amsterdam_date(moment)` helper — the Amsterdam-local calendar date of a timestamp.
- Route every `last_fetch_*.date()` comparison (`_refresh_tomorrow_cache`, `_is_cache_fresh`, `_adjust_update_interval`, `FrankEnergiePriceCoordinator._async_update_data`, `FrankEnergiePVCoordinator._async_update_data`) plus one debug log through it.
- Storage is unchanged — `last_fetch_*` stay UTC instants; only the day-of interpretation moves to the zone the rest of the coordinator already uses.
- Regression test `test_fetch_just_after_local_midnight_counts_as_today` — a fetch at UTC 22:30 (Amsterdam 00:30 next day) must keep the 15-min fallback, not fall back to hourly. Verified it fails on the old code (1 h instead of 15 min).

## Testing

- [x] Existing tests pass
- [x] New tests added

### Test Details

`ruff check` ✅ · `ruff format --check` ✅ · `flake8 --select=E9,F63,F7,F82` → 0 · `poetry run pytest` → **215 passed, 3 skipped, 0 failed**.

## Home Assistant Checklist

- [x] Uses timezone-aware datetimes
- [x] Includes type hints

## Breaking Changes

N/A — no stored-data format change; behaviour only differs during the post-local-midnight window, and only toward keeping the coordinator on its correct interval.

## Additional Notes

The same UTC-`.date()`-vs-local-`today` shape exists in a few maintenance-window / statistics paths that don't touch `last_fetch_*`; those compare `today` to values that are already local and are out of scope here.
