### PR TITLE
feat: add previous/next quarter-hour electricity price sensors

### DIFF
--- a/custom_components/frank_energie/sensor.py
+++ b/custom_components/frank_energie/sensor.py
@@ -45,7 +45,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 from homeassistant.util import dt as dt_util
-from python_frank_energie.models import EnodeCharger
+from python_frank_energie.models import EnodeCharger, PriceData
 
 from .const import (
     ATTR_FROM_TIME,
@@ -2097,6 +2097,34 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         entity_registry_enabled_default=True,
     ),
     FrankEnergieEntityDescription(
+        key="elec_previousquarterhour",
+        translation_key="elec_previousquarterhour",
+        native_unit_of_measurement=UNIT_ELECTRICITY,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: (
+            data[DATA_ELECTRICITY].previous_quarter_hour.total
+            if data[DATA_ELECTRICITY].previous_quarter_hour
+            else None
+        ),
+        entity_registry_enabled_default=True,
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_nextquarterhour",
+        translation_key="elec_nextquarterhour",
+        native_unit_of_measurement=UNIT_ELECTRICITY,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: (
+            data[DATA_ELECTRICITY].next_quarter_hour.total
+            if data[DATA_ELECTRICITY].next_quarter_hour
+            else None
+        ),
+        entity_registry_enabled_default=True,
+    ),
+    FrankEnergieEntityDescription(
         key="elec_market_percent_tax",
         translation_key="elec_market_percent_tax",
         native_unit_of_measurement=PERCENTAGE,
@@ -2501,6 +2529,34 @@ SENSOR_TYPES: tuple[FrankEnergieEntityDescription, ...] = (
         value_fn=lambda data: (
             data[DATA_ELECTRICITY].next_hour.market_price
             if data[DATA_ELECTRICITY].next_hour
+            else None
+        ),
+        entity_registry_enabled_default=True,
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_previousquarterhour_market",
+        translation_key="elec_previousquarterhour_market",
+        native_unit_of_measurement=UNIT_ELECTRICITY,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: (
+            data[DATA_ELECTRICITY].previous_quarter_hour.market_price
+            if data[DATA_ELECTRICITY].previous_quarter_hour
+            else None
+        ),
+        entity_registry_enabled_default=True,
+    ),
+    FrankEnergieEntityDescription(
+        key="elec_nextquarterhour_market",
+        translation_key="elec_nextquarterhour_market",
+        native_unit_of_measurement=UNIT_ELECTRICITY,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: (
+            data[DATA_ELECTRICITY].next_quarter_hour.market_price
+            if data[DATA_ELECTRICITY].next_quarter_hour
             else None
         ),
         entity_registry_enabled_default=True,
@@ -4959,6 +5015,21 @@ def _service_parent_device_id(
     )
 
 
+# The previous/next quarter-hour price sensors rely on PriceData helpers added
+# in a later python-frank-energie release. Skip registering them on an older
+# pinned version so users don't get permanently-unavailable entities before the
+# dependency is bumped; they appear automatically once the library supports it.
+_QUARTER_HOUR_PRICE_KEYS: Final = frozenset(
+    {
+        "elec_previousquarterhour",
+        "elec_nextquarterhour",
+        "elec_previousquarterhour_market",
+        "elec_nextquarterhour_market",
+    }
+)
+_LIB_HAS_QUARTER_HOUR_PRICES: Final = hasattr(PriceData, "previous_quarter_hour")
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -5090,6 +5161,10 @@ async def async_setup_entry(
         for description in SENSOR_TYPES
         if (
             (
+                description.key not in _QUARTER_HOUR_PRICE_KEYS
+                or _LIB_HAS_QUARTER_HOUR_PRICES
+            )
+            and (
                 not description.authenticated
                 or _get_coordinator_for_description(description).api.is_authenticated
             )

--- a/custom_components/frank_energie/strings.json
+++ b/custom_components/frank_energie/strings.json
@@ -539,11 +539,23 @@
       "elec_nexthour_market": {
         "name": "Next hour electricity market price"
       },
+      "elec_nextquarterhour": {
+        "name": "Next quarter-hour electricity price (All-in)"
+      },
+      "elec_nextquarterhour_market": {
+        "name": "Next quarter-hour electricity market price"
+      },
       "elec_previoushour": {
         "name": "Previous hour electricity price (All-in)"
       },
       "elec_previoushour_market": {
         "name": "Previous hour electricity market price"
+      },
+      "elec_previousquarterhour": {
+        "name": "Previous quarter-hour electricity price (All-in)"
+      },
+      "elec_previousquarterhour_market": {
+        "name": "Previous quarter-hour electricity market price"
       },
       "elec_tax_only": {
         "name": "Current electricity tax only"

--- a/custom_components/frank_energie/translations/en.json
+++ b/custom_components/frank_energie/translations/en.json
@@ -539,11 +539,23 @@
       "elec_nexthour_market": {
         "name": "Next hour electricity market price"
       },
+      "elec_nextquarterhour": {
+        "name": "Next quarter-hour electricity price (All-in)"
+      },
+      "elec_nextquarterhour_market": {
+        "name": "Next quarter-hour electricity market price"
+      },
       "elec_previoushour": {
         "name": "Previous hour electricity price (All-in)"
       },
       "elec_previoushour_market": {
         "name": "Previous hour electricity market price"
+      },
+      "elec_previousquarterhour": {
+        "name": "Previous quarter-hour electricity price (All-in)"
+      },
+      "elec_previousquarterhour_market": {
+        "name": "Previous quarter-hour electricity market price"
       },
       "elec_tax_only": {
         "name": "Current electricity tax only"

--- a/custom_components/frank_energie/translations/fr.json
+++ b/custom_components/frank_energie/translations/fr.json
@@ -539,11 +539,23 @@
       "elec_nexthour_market": {
         "name": "Prix du marché de l'électricité heure suivante"
       },
+      "elec_nextquarterhour": {
+        "name": "Prix de l'électricité quart d'heure suivant (Tout compris)"
+      },
+      "elec_nextquarterhour_market": {
+        "name": "Prix du marché de l'électricité quart d'heure suivant"
+      },
       "elec_previoushour": {
         "name": "Prix de l'électricité heure précédente (Tout compris)"
       },
       "elec_previoushour_market": {
         "name": "Prix du marché de l'électricité heure précédente"
+      },
+      "elec_previousquarterhour": {
+        "name": "Prix de l'électricité quart d'heure précédent (Tout compris)"
+      },
+      "elec_previousquarterhour_market": {
+        "name": "Prix du marché de l'électricité quart d'heure précédent"
       },
       "elec_tax_only": {
         "name": "Taxe actuelle sur l'électricité uniquement"

--- a/custom_components/frank_energie/translations/nl-BE.json
+++ b/custom_components/frank_energie/translations/nl-BE.json
@@ -170,11 +170,23 @@
       "elec_nexthour": {
         "name": "Elektriciteitsprijs volgend uur (All-in)"
       },
+      "elec_previousquarterhour": {
+        "name": "Elektriciteitsprijs vorig kwartier (All-in)"
+      },
+      "elec_nextquarterhour": {
+        "name": "Elektriciteitsprijs volgend kwartier (All-in)"
+      },
       "elec_previoushour_market": {
         "name": "Elektriciteit inkoopprijs vorig uur"
       },
       "elec_nexthour_market": {
         "name": "Elektriciteit inkoopprijs volgend uur"
+      },
+      "elec_previousquarterhour_market": {
+        "name": "Elektriciteit inkoopprijs vorig kwartier"
+      },
+      "elec_nextquarterhour_market": {
+        "name": "Elektriciteit inkoopprijs volgend kwartier"
       },
       "average_electricity_market_price_today": {
         "name": "Gemiddelde elektriciteit inkoopprijs vandaag"

--- a/custom_components/frank_energie/translations/nl.json
+++ b/custom_components/frank_energie/translations/nl.json
@@ -170,11 +170,23 @@
       "elec_nexthour": {
         "name": "Elektriciteitsprijs volgend uur (All-in)"
       },
+      "elec_previousquarterhour": {
+        "name": "Elektriciteitsprijs vorig kwartier (All-in)"
+      },
+      "elec_nextquarterhour": {
+        "name": "Elektriciteitsprijs volgend kwartier (All-in)"
+      },
       "elec_previoushour_market": {
         "name": "Elektriciteit inkoopprijs vorig uur"
       },
       "elec_nexthour_market": {
         "name": "Elektriciteit inkoopprijs volgend uur"
+      },
+      "elec_previousquarterhour_market": {
+        "name": "Elektriciteit inkoopprijs vorig kwartier"
+      },
+      "elec_nextquarterhour_market": {
+        "name": "Elektriciteit inkoopprijs volgend kwartier"
       },
       "average_electricity_market_price_today": {
         "name": "Gemiddelde elektriciteit inkoopprijs vandaag"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,6 +16,7 @@ from python_frank_energie.domain import (
     SmartPvOperationalStatus,
     SmartPvSteeringStatus,
 )
+from python_frank_energie.models import PriceData
 
 from custom_components.frank_energie import const
 from tests.utils import ResponseMocks
@@ -356,6 +357,69 @@ async def test_sensors_hour_price_attr(
             "sensor.frank_energie_gas_prices_current_gas_price_including_tax"
         ).attributes["prices"]
     )
+
+
+_HAS_QUARTER_HOUR_LIB_API = hasattr(PriceData, "previous_quarter_hour")
+
+_QUARTER_HOUR_SENSOR_KEYS = (
+    "previous_quarter_hour_electricity_price_all_in",
+    "next_quarter_hour_electricity_price_all_in",
+    "previous_quarter_hour_electricity_market_price",
+    "next_quarter_hour_electricity_market_price",
+)
+
+
+async def test_sensors_quarter_hour_prices(
+    freezer,
+    aioclient_responses: ResponseMocks,
+    frank_energie_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+):
+    """previous/next quarter-hour price sensors track the adjacent PT15M intervals.
+
+    They are only registered when the installed python-frank-energie exposes the
+    quarter-hour helpers; on an older pinned version they must be absent rather
+    than permanently unavailable.
+    """
+    import zoneinfo
+
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    tz = zoneinfo.ZoneInfo("Europe/Amsterdam")
+    now = datetime.now(tz).replace(hour=5, minute=7, second=0, microsecond=0)
+    freezer.move_to(now)
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # 96 quarter-hour prices, one distinct value per interval (index == 15-min slot).
+    prices = [round(0.10 + i * 0.01, 2) for i in range(96)]
+    quarter = timedelta(minutes=15)
+    aioclient_responses.add(start_of_day, prices, [1.0] * 96, interval=quarter)
+    aioclient_responses.add(
+        start_of_day + timedelta(days=1), prices, [1.0] * 96, interval=quarter
+    )
+    aioclient_responses.cyclic()
+
+    await hass.config_entries.async_setup(frank_energie_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def state(key: str):
+        return hass.states.get(f"sensor.frank_energie_electricity_prices_{key}")
+
+    if not _HAS_QUARTER_HOUR_LIB_API:
+        assert all(state(key) is None for key in _QUARTER_HOUR_SENSOR_KEYS)
+        return
+
+    # 05:07 -> slot 20 [05:00, 05:15) is current, 19 is previous, 21 is next.
+    assert state("previous_quarter_hour_electricity_price_all_in").state == "0.29"
+    assert state("next_quarter_hour_electricity_price_all_in").state == "0.31"
+    assert state("previous_quarter_hour_electricity_market_price").state == "0.203"
+    assert state("next_quarter_hour_electricity_market_price").state == "0.217"
+
+    # Cross into the next interval: previous/next both shift by one slot.
+    freezer.move_to(now.replace(minute=22))
+    await trigger_update(hass, 7 * 3600)
+
+    assert state("previous_quarter_hour_electricity_price_all_in").state == "0.3"
+    assert state("next_quarter_hour_electricity_price_all_in").state == "0.32"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import pytest
 from homeassistant import config_entries
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.util import dt
@@ -401,7 +401,7 @@ async def test_sensors_quarter_hour_prices(
     await hass.config_entries.async_setup(frank_energie_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    def state(key: str):
+    def state(key: str) -> State | None:
         return hass.states.get(f"sensor.frank_energie_electricity_prices_{key}")
 
     if not _HAS_QUARTER_HOUR_LIB_API:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,8 +40,13 @@ class ResponseMocks:
         electricity_prices: list,
         gas_prices: list,
         http_status: int = HTTPStatus.OK,
+        interval: timedelta = timedelta(hours=1),
     ):
-        """Add a response mock."""
+        """Add a response mock.
+
+        ``interval`` is the width of each price entry; pass
+        ``timedelta(minutes=15)`` to emit PT15M data.
+        """
         self._responses.append(
             AiohttpClientMockResponse(
                 "POST",
@@ -50,10 +55,10 @@ class ResponseMocks:
                     "data": {
                         "marketPrices": {
                             "electricityPrices": self._generate_prices_response(
-                                start_date, electricity_prices
+                                start_date, electricity_prices, interval
                             ),
                             "gasPrices": self._generate_prices_response(
-                                start_date, gas_prices
+                                start_date, gas_prices, interval
                             ),
                         }
                     }
@@ -63,13 +68,18 @@ class ResponseMocks:
             )
         )
 
-    def _generate_prices_response(self, start: datetime, all_in_prices: list | range):
+    def _generate_prices_response(
+        self,
+        start: datetime,
+        all_in_prices: list | range,
+        interval: timedelta,
+    ):
         """Generate a list of prices."""
         start = start.replace(second=0, microsecond=0)
         return [
             {
-                "from": (start + timedelta(hours=i)).astimezone().isoformat(),
-                "till": (start + timedelta(hours=i + 1)).astimezone().isoformat(),
+                "from": (start + i * interval).astimezone().isoformat(),
+                "till": (start + (i + 1) * interval).astimezone().isoformat(),
                 "marketPrice": 0.7 * price,
                 "marketPriceTax": 0.05 * price,
                 "sourcingMarkupPrice": 0.1 * price,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,9 +71,9 @@ class ResponseMocks:
     def _generate_prices_response(
         self,
         start: datetime,
-        all_in_prices: list | range,
+        all_in_prices: list[float] | range,
         interval: timedelta,
-    ):
+    ) -> list[dict[str, str | float]]:
         """Generate a list of prices."""
         start = start.replace(second=0, microsecond=0)
         return [


### PR DESCRIPTION
## What

Adds four electricity price sensors, disabled-by-default off / enabled like their hourly siblings:

| key | value |
| --- | --- |
| `elec_previousquarterhour` | all-in `total` of the previous 15-min settlement interval |
| `elec_nextquarterhour` | all-in `total` of the next 15-min interval |
| `elec_previousquarterhour_market` | raw `market_price` of the previous interval |
| `elec_nextquarterhour_market` | raw `market_price` of the next interval |

They mirror `elec_previoushour` / `elec_nexthour` (+ `_market`) exactly, but resolve the adjacent **PT15M** intervals via `PriceData.previous_quarter_hour` / `next_quarter_hour` — a timestamp-based lookup on the underlying price list, so they stay correct across restarts, delayed coordinator updates and DST, independent of HA entity update order.

Motivation: HiDiHo01/home-assistant-frank_energie#252 — per-interval cost automations on 15-minute contracts (`previous 15-min kWh consumed × previous_quarter_hour price`).

## Dependency

`PriceData.previous_quarter_hour` / `next_quarter_hour` come from HiDiHo01/python-frank-energie#144, which is **not yet released**. This PR does **not** bump `manifest.json` / `pyproject.toml` — that's for a coordinated release.

To stay safe in the meantime, registration is gated on `hasattr(PriceData, "previous_quarter_hour")`:

- on the currently pinned `python-frank-energie==2026.8.8` the four descriptions are filtered out at setup — **absent**, not permanently `unavailable`;
- once the dependency ships the helpers and the manifest is bumped, the sensors appear automatically.

The gate (`_QUARTER_HOUR_PRICE_KEYS` / `_LIB_HAS_QUARTER_HOUR_PRICES` in `sensor.py` and the `if not _HAS_QUARTER_HOUR_LIB_API` branch in the test) can be deleted after the manifest update.

## Tests

- `tests/utils.py`: `ResponseMocks.add()` gains an `interval` arg so fixtures can emit PT15M data.
- `tests/test_sensor.py::test_sensors_quarter_hour_prices`: runs through the real `hass` / config-entry / entity platform. Branches on the installed library — asserts the entities are **absent** on the pinned version, and asserts the actual previous/next values plus the interval-crossing shift once the helpers are present (verified locally against python-frank-energie#144).
- Translation keys added to `strings.json` + `en` / `nl` / `nl-BE` / `fr`; `test_translations.py` passes.
- Full suite: `218 passed, 3 pre-existing skips`.

## Notes / follow-ups

- Like the existing `elec_*hour*` price sensors, these use `state_class=TOTAL`. `MEASUREMENT` (or none) would be more correct for an oscillating spot price; worth fixing across the whole price-sensor family in a separate PR rather than splitting the group here.

## Samenvatting door Sourcery

Voeg optionele sensoren toe voor de elektriciteitsprijzen van het vorige en volgende kwartier, gebaseerd op tijdstempelbewuste intervalgegevens.

Nieuwe functies:
- Voeg vier elektriciteitsprijssensoren toe voor de vorige en volgende afrekenintervallen van 15 minuten, met zowel all-in- als marktprijzen.

Verbeteringen:
- Laat de kwartiervensensoren afhangen van ondersteuning in de bibliotheek, zodat ze ontbreken in plaats van onbeschikbaar te zijn totdat de dependency de vereiste API biedt.
- Breid testfixtures en testdekking voor prijsreacties uit om PT15M-intervalgedrag, intervalovergangen en vertalingen te valideren.

Tests:
- Voeg integratietests toe voor de registratie van kwartiervensensoren en waarden van aangrenzende intervallen bij updates.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Voeg sensoren toe voor elektriciteitsprijzen van aangrenzende kwartieren, met compatibiliteitscontrole voor oudere versies van de prijslibrary.

Nieuwe functies:
- Voeg vier optionele sensoren voor elektriciteitsprijzen toe voor de vorige en volgende intervallen van 15 minuten, met zowel all-in- als marktprijzen.

Verbeteringen:
- Registreer kwartsensoren alleen wanneer de geïnstalleerde prijslibrary de vereiste intervalopvragingen ondersteunt, zodat niet-beschikbare entiteiten op oudere versies worden voorkomen.
- Breid prijsfixtures en integratiedekking uit om PT15M-intervalwaarden en -overgangen te valideren.

Tests:
- Voeg integratietests toe voor de registratie van kwartsensoren, waarden van aangrenzende intervallen, intervalovergangen en vertaaldekking.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add adjacent quarter-hour electricity price sensors with compatibility gating for older pricing-library versions.

New Features:
- Add four optional electricity price sensors for the previous and next 15-minute intervals, exposing both all-in and market prices.

Enhancements:
- Register quarter-hour sensors only when the installed pricing library supports the required interval lookups, avoiding unavailable entities on older versions.
- Extend price fixtures and integration coverage to validate PT15M interval values and transitions.

Tests:
- Add integration tests covering quarter-hour sensor registration, adjacent interval values, interval transitions, and translation coverage.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added electricity price sensors for the previous and next quarter-hour.
  * Added both all-in and market-price variants.
  * Sensors are available when supported by the installed integration version.

* **Translations**
  * Added English, French, Dutch, and Dutch-Belgian names for the new sensors.

* **Tests**
  * Added coverage for quarter-hour pricing across interval changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->