### PR TITLE
fix: contain the negative default in the export electricity fee range

### DIFF
--- a/custom_components/frank_energie/number.py
+++ b/custom_components/frank_energie/number.py
@@ -167,7 +167,8 @@ EXPORT_ELECTRICITY_FEE = FrankEnergieNumberEntityDescription(
     translation_key="export_electricity_fee",
     option_key=CONF_EXPORT_ELECTRICITY_FEE,
     service_name=SERVICE_NAME_COSTS,
-    native_min_value=0.00,
+    # Default is a negative per-kWh credit -- the lower bound must contain it.
+    native_min_value=-50.00,
     native_max_value=50.00,
     native_step=0.000001,
     native_unit_of_measurement=UNIT_ELECTRICITY,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from python_frank_energie.domain import SmartBatteryMode
 import pytest
 from unittest.mock import MagicMock, AsyncMock
@@ -8,6 +10,7 @@ from custom_components.frank_energie.const import (
     DATA_ENODE_CHARGERS,
 )
 from custom_components.frank_energie.number import (
+    CONFIG_NUMBER_DESCRIPTIONS,
     FrankEnergieBatteryThresholdNumber,
     FrankEnergieEnodeChargeLimitNumber,
 )
@@ -210,3 +213,16 @@ async def test_enode_charge_limit_validation(mock_coordinator):
     mock_coordinator.async_update_enode_charge_settings.assert_called_once_with(
         charger_id, False, {"maxChargeLimit": 85}
     )
+
+
+@pytest.mark.parametrize("description", CONFIG_NUMBER_DESCRIPTIONS, ids=lambda d: d.key)
+def test_config_number_default_within_declared_range(description) -> None:
+    """A config number's shipped default must sit inside its own min/max.
+
+    Otherwise the value shown on a fresh install is one HA's ``number.set_value``
+    rejects with ``ServiceValidationError`` (``value < min_value``), so it can
+    never be re-entered from the UI. Regression: ``export_electricity_fee``
+    shipped a ``-0.035090`` default with a ``0.0`` lower bound.
+    """
+    default = description.value_fn(SimpleNamespace(options={}))
+    assert description.native_min_value <= default <= description.native_max_value


### PR DESCRIPTION
## Problem

`DEFAULT_EXPORT_ELECTRICITY_FEE` is `-0.035090` (a per-kWh export credit), but the `export_electricity_fee` number entity declares `native_min_value=0.00`. So on a fresh install:

- the entity shows `-0.03509`, a value **below its own minimum**
- calling `number.set_value` with that same value — or any negative value — raises `ServiceValidationError: Value ... is outside valid range 0.0 - 50.0`, so it can never be re-entered from the UI or restored by a script

`energy_tax_reduction` handles its negative default correctly (`min=-100, max=0`); the export-fee bounds were just never updated for a negative value.

## Fix

Lower `native_min_value` to `-50.00`, mirroring the existing `native_max_value=50.00`.

## Test

Adds a parametrized regression test over `CONFIG_NUMBER_DESCRIPTIONS` asserting every config number's shipped default sits inside its declared `min`/`max`. Fails on `main` for `export_electricity_fee`, passes with the fix.

## Samenvatting door Sourcery

Corrigeer het bereik van de vergoeding voor geëxporteerde elektriciteit, zodat negatieve exporttegoeden kunnen worden hersteld en geconfigureerd.

Bugfixes:
- Sta toe dat de negatieve standaardvergoeding voor geëxporteerde elektriciteit wordt geaccepteerd binnen het geconfigureerde getalbereik.

Tests:
- Voeg regressiedekking toe om te controleren of de standaardwaarde van elk configureerbaar getal binnen de opgegeven grenzen valt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the export electricity fee range so negative export credits can be restored and configured.

Bug Fixes:
- Allow the negative default export electricity fee to be accepted by its configured number range.

Tests:
- Add regression coverage ensuring every configurable number's default falls within its declared bounds.

</details>