### PR TITLE
test: drive number/select/binary_sensor through the real HA platform

### DIFF
--- a/custom_components/frank_energie/number.py
+++ b/custom_components/frank_energie/number.py
@@ -167,7 +167,8 @@ EXPORT_ELECTRICITY_FEE = FrankEnergieNumberEntityDescription(
     translation_key="export_electricity_fee",
     option_key=CONF_EXPORT_ELECTRICITY_FEE,
     service_name=SERVICE_NAME_COSTS,
-    native_min_value=0.00,
+    # Default is a negative per-kWh credit -- the lower bound must contain it.
+    native_min_value=-50.00,
     native_max_value=50.00,
     native_step=0.000001,
     native_unit_of_measurement=UNIT_ELECTRICITY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import sys
+import zoneinfo
+from datetime import datetime
 from os.path import abspath, dirname
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
@@ -113,6 +115,39 @@ def config_entry_with_site(hass):
     )
     entry.add_to_hass(hass)
     return entry
+
+
+@pytest.fixture
+def frank_energie_setup(hass, aioclient_responses, freezer, enable_custom_integrations):
+    """Return a callable that runs a full, unauthenticated ``async_setup``.
+
+    Unlike the hand-rolled ``mock_coordinator`` fixture, this loads the real
+    coordinators and forwards to the real platforms, so Home Assistant's own
+    entity/service validation runs against what the integration builds.
+    """
+    from custom_components.frank_energie import const
+
+    async def _setup(options: dict | None = None) -> MockConfigEntry:
+        await hass.config.async_set_time_zone("Europe/Amsterdam")
+        tz = zoneinfo.ZoneInfo("Europe/Amsterdam")
+        now = datetime.now(tz).replace(hour=14, minute=15, second=0, microsecond=0)
+        freezer.move_to(now)
+        start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        aioclient_responses.add(start_of_day, [0.2] * 24, [1.23] * 24)
+        aioclient_responses.cyclic()
+
+        entry = MockConfigEntry(
+            domain=const.DOMAIN,
+            data={},
+            options=options or {},
+            unique_id=const.UNIQUE_ID,
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        return entry
+
+    return _setup
 
 
 @pytest.fixture

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,9 +1,19 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockEntityPlatform,
+)
 
 from custom_components.frank_energie.const import (
     DATA_USER,
     DATA_USER_SMART_FEED_IN,
     DATA_PV_SYSTEMS,
+    DOMAIN,
 )
 from custom_components.frank_energie.binary_sensor import (
     BINARY_SENSOR_DESCRIPTIONS,
@@ -216,3 +226,103 @@ def test_smart_pv_systems_binary_sensor(mock_coordinator, mock_config_entry):
     assert attrs["system_count"] == 1
     assert attrs["systems"][0]["id"] == "pv_123"
     assert attrs["systems"][0]["status"] == "CONNECTED"
+
+
+# --- Real-hass layer -------------------------------------------------------
+#
+# The tests above read ``sensor.is_on`` / ``sensor.extra_state_attributes``
+# straight off the entity. These add the entity through a real
+# ``MockEntityPlatform`` so Home Assistant resolves ``is_on`` into an actual
+# on/off/unknown state and serialises the attributes into the state machine --
+# the path that would reject a bad ``device_class`` or an unserialisable
+# attribute value.
+
+
+async def _add_through_real_platform(
+    hass: HomeAssistant, entry: MockConfigEntry, *sensors: FrankEnergieBinarySensor
+) -> None:
+    platform = MockEntityPlatform(
+        hass, domain=BINARY_SENSOR_DOMAIN, platform_name=DOMAIN
+    )
+    platform.config_entry = entry
+    await platform.async_add_entities(list(sensors))
+    await hass.async_block_till_done()
+
+
+def _entity_id(hass: HomeAssistant, unique_key: str) -> str:
+    return er.async_get(hass).async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"frank_energie_{unique_key}"
+    )
+
+
+async def test_smart_feature_binary_sensors_reach_the_state_machine(
+    hass: HomeAssistant,
+) -> None:
+    """A smart-feature sensor added through the real platform resolves to an
+    on/off state carrying its ``running`` device class and mapped attributes."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="frank_energie")
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = {
+        DATA_USER: SimpleNamespace(
+            smartHvac={
+                "isActivated": True,
+                "isAvailableInCountry": True,
+                "userId": "user-1",
+            },
+        ),
+        DATA_USER_SMART_FEED_IN: {"isActivated": False},
+    }
+
+    hvac = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == "smart_hvac")
+    feed_in = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == "smart_feed_in")
+    await _add_through_real_platform(
+        hass,
+        entry,
+        FrankEnergieBinarySensor(coordinator, hvac, entry),
+        FrankEnergieBinarySensor(coordinator, feed_in, entry),
+    )
+
+    hvac_state = hass.states.get(_entity_id(hass, "smart_hvac"))
+    assert hvac_state.state == "on"
+    assert hvac_state.attributes["device_class"] == "running"
+    assert hvac_state.attributes["available_in_country"] is True
+    assert hvac_state.attributes["user_id"] == "user-1"
+
+    assert hass.states.get(_entity_id(hass, "smart_feed_in")).state == "off"
+
+
+async def test_missing_smart_feature_data_resolves_to_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """No user data -> ``is_on`` is None -> HA renders the state as unknown,
+    not a stale value or an exception during the state write."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="frank_energie")
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = {}
+
+    trading = next(
+        d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == "smartTradingisActivated"
+    )
+    await _add_through_real_platform(
+        hass, entry, FrankEnergieBinarySensor(coordinator, trading, entry)
+    )
+
+    assert hass.states.get(_entity_id(hass, "smartTradingisActivated")).state == (
+        "unknown"
+    )
+
+
+# TODO: real-hass coverage for the per-battery binary sensors built by
+# _build_battery_descriptions(). Their attr_fn reads sb.capacity /
+# sb.max_charge_power / settings.battery_mode, so serialising them into the
+# state machine needs faithful SmartBatteryDetails objects -- build them from
+# python-frank-energie's smart_battery_details.json fixture (via the model
+# from_dict parsers) rather than MagicMock, then add via _add_through_real_platform
+# above. A full authenticated async_setup would also work but needs the
+# operationName->JSON dispatcher described in the other platform test files.

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -250,9 +250,11 @@ async def _add_through_real_platform(
 
 
 def _entity_id(hass: HomeAssistant, unique_key: str) -> str:
-    return er.async_get(hass).async_get_entity_id(
+    entity_id = er.async_get(hass).async_get_entity_id(
         BINARY_SENSOR_DOMAIN, DOMAIN, f"frank_energie_{unique_key}"
     )
+    assert entity_id is not None, unique_key
+    return entity_id
 
 
 async def test_smart_feature_binary_sensors_reach_the_state_machine(
@@ -286,12 +288,15 @@ async def test_smart_feature_binary_sensors_reach_the_state_machine(
     )
 
     hvac_state = hass.states.get(_entity_id(hass, "smart_hvac"))
+    assert hvac_state is not None
     assert hvac_state.state == "on"
     assert hvac_state.attributes["device_class"] == "running"
     assert hvac_state.attributes["available_in_country"] is True
     assert hvac_state.attributes["user_id"] == "user-1"
 
-    assert hass.states.get(_entity_id(hass, "smart_feed_in")).state == "off"
+    feed_in_state = hass.states.get(_entity_id(hass, "smart_feed_in"))
+    assert feed_in_state is not None
+    assert feed_in_state.state == "off"
 
 
 async def test_missing_smart_feature_data_resolves_to_unknown(
@@ -313,9 +318,9 @@ async def test_missing_smart_feature_data_resolves_to_unknown(
         hass, entry, FrankEnergieBinarySensor(coordinator, trading, entry)
     )
 
-    assert hass.states.get(_entity_id(hass, "smartTradingisActivated")).state == (
-        "unknown"
-    )
+    state = hass.states.get(_entity_id(hass, "smartTradingisActivated"))
+    assert state is not None
+    assert state.state == "unknown"
 
 
 # TODO: real-hass coverage for the per-battery binary sensors built by

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -296,7 +296,9 @@ async def test_config_numbers_register_with_real_hass(
         state = hass.states.get(entity_id)
         assert state is not None, entity_id
         assert float(state.state) == default
-        assert reg.async_get(entity_id).config_entry_id == entry.entry_id
+        registry_entry = reg.async_get(entity_id)
+        assert registry_entry is not None, entity_id
+        assert registry_entry.config_entry_id == entry.entry_id
 
 
 @pytest.mark.parametrize(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from python_frank_energie.domain import SmartBatteryMode
 import pytest
 from unittest.mock import MagicMock, AsyncMock
@@ -8,6 +10,7 @@ from custom_components.frank_energie.const import (
     DATA_ENODE_CHARGERS,
 )
 from custom_components.frank_energie.number import (
+    CONFIG_NUMBER_DESCRIPTIONS,
     FrankEnergieBatteryThresholdNumber,
     FrankEnergieEnodeChargeLimitNumber,
 )
@@ -210,3 +213,16 @@ async def test_enode_charge_limit_validation(mock_coordinator):
     mock_coordinator.async_update_enode_charge_settings.assert_called_once_with(
         charger_id, False, {"maxChargeLimit": 85}
     )
+
+
+@pytest.mark.parametrize("description", CONFIG_NUMBER_DESCRIPTIONS, ids=lambda d: d.key)
+def test_config_number_default_within_declared_range(description) -> None:
+    """A config number's shipped default must sit inside its own min/max.
+
+    Otherwise the value shown on a fresh install is one HA's ``number.set_value``
+    rejects with ``ServiceValidationError`` (``value < min_value``), so it can
+    never be re-entered from the UI. Regression: ``export_electricity_fee``
+    shipped a ``-0.035090`` default with a ``0.0`` lower bound.
+    """
+    default = description.value_fn(SimpleNamespace(options={}))
+    assert description.native_min_value <= default <= description.native_max_value

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -4,10 +4,19 @@ from python_frank_energie.domain import SmartBatteryMode
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+
 from custom_components.frank_energie.const import (
     DATA_BATTERY_DETAILS,
     DATA_ENODE_VEHICLES,
     DATA_ENODE_CHARGERS,
+    DEFAULT_ENERGY_TAX_ODE,
+    DEFAULT_ENERGY_TAX_REDUCTION,
+    DEFAULT_EXPORT_ELECTRICITY_FEE,
+    DEFAULT_MONTHLY_SUBSCRIPTION_FEE,
+    DEFAULT_NETWORK_CHARGES,
 )
 from custom_components.frank_energie.number import (
     CONFIG_NUMBER_DESCRIPTIONS,
@@ -226,3 +235,115 @@ def test_config_number_default_within_declared_range(description) -> None:
     """
     default = description.value_fn(SimpleNamespace(options={}))
     assert description.native_min_value <= default <= description.native_max_value
+
+
+# --- Real-hass layer -------------------------------------------------------
+#
+# The tests above build entities against a hand-rolled ``mock_coordinator`` and
+# call ``entity.async_set_native_value`` directly, which never reaches Home
+# Assistant's own ``number.set_value`` range validation. These drive the real
+# NUMBER platform through a full ``async_setup`` so that validation runs.
+
+# option key, entity_id, shipped default, an in-range value, an out-of-range value
+_CONFIG_NUMBERS = [
+    (
+        "monthly_subscription_fee",
+        "number.frank_energie_costs_monthly_subscription_fee",
+        DEFAULT_MONTHLY_SUBSCRIPTION_FEE,
+        5.5,
+        20.0,
+    ),
+    (
+        "energy_tax_ode",
+        "number.frank_energie_costs_energy_tax_ode",
+        DEFAULT_ENERGY_TAX_ODE,
+        30.0,
+        60.0,
+    ),
+    (
+        "energy_tax_reduction",
+        "number.frank_energie_costs_energy_tax_reduction",
+        DEFAULT_ENERGY_TAX_REDUCTION,
+        -40.0,
+        20.0,
+    ),
+    (
+        "network_charges",
+        "number.frank_energie_costs_network_charges",
+        DEFAULT_NETWORK_CHARGES,
+        40.0,
+        60.0,
+    ),
+    (
+        "export_electricity_fee",
+        "number.frank_energie_costs_export_electricity_fee",
+        DEFAULT_EXPORT_ELECTRICITY_FEE,
+        -0.02,
+        100.0,
+    ),
+]
+
+
+async def test_config_numbers_register_with_real_hass(
+    hass: HomeAssistant, frank_energie_setup
+) -> None:
+    """The always-present cost-configuration numbers reach the state machine at
+    their option-backed shipped defaults and are tied to the config entry."""
+    entry = await frank_energie_setup()
+    reg = er.async_get(hass)
+
+    for _, entity_id, default, _, _ in _CONFIG_NUMBERS:
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert float(state.state) == default
+        assert reg.async_get(entity_id).config_entry_id == entry.entry_id
+
+
+@pytest.mark.parametrize(
+    ("option_key", "entity_id", "in_range", "out_of_range"),
+    [(k, eid, lo, hi) for k, eid, _, lo, hi in _CONFIG_NUMBERS],
+)
+async def test_config_number_set_value_goes_through_ha_range_validation(
+    hass: HomeAssistant,
+    frank_energie_setup,
+    option_key: str,
+    entity_id: str,
+    in_range: float,
+    out_of_range: float,
+) -> None:
+    """``number.set_value`` persists an in-range value to the entry options and
+    rejects an out-of-range one with ``ServiceValidationError`` -- the check
+    the direct ``async_set_native_value`` unit tests bypass."""
+    entry = await frank_energie_setup()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": entity_id, "value": in_range},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == str(in_range)
+    assert entry.options[option_key] == in_range
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": entity_id, "value": out_of_range},
+            blocking=True,
+        )
+    # The rejected write left the in-range value untouched.
+    assert hass.states.get(entity_id).state == str(in_range)
+
+
+# TODO: real-hass coverage for the auth-gated number entities
+# (FrankEnergieBatteryThresholdNumber, FrankEnergieEnodeChargeLimitNumber).
+# Those are only reachable once the battery/vehicle/charger coordinators have
+# authenticated data, so a full async_setup here needs an operationName->JSON
+# dispatcher on aioclient_mock fed by python-frank-energie's own response
+# fixtures (smart_battery_details.json, enode_vehicles.json, ...), or a lighter
+# variant that patches custom_components.frank_energie.FrankEnergie and adds the
+# entities via MockEntityPlatform (see test_binary_sensor.py). Until then the
+# range/step checks on those two classes stay at the direct-call unit level
+# above and never see HA's own number.set_value validation.

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -171,9 +171,9 @@ async def test_resolution_select_registers_with_real_hass(
     assert state is not None
     assert state.state == "pt15m"
     assert state.attributes["options"] == ["pt15m", "pt60m"]
-    assert er.async_get(hass).async_get(_RESOLUTION_SELECT).config_entry_id == (
-        entry.entry_id
-    )
+    registry_entry = er.async_get(hass).async_get(_RESOLUTION_SELECT)
+    assert registry_entry is not None
+    assert registry_entry.config_entry_id == entry.entry_id
 
 
 async def test_resolution_select_option_goes_through_ha_validation(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,6 +2,10 @@ from python_frank_energie.domain import SmartBatteryMode
 import pytest
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+
 from custom_components.frank_energie.const import DATA_BATTERY_DETAILS
 from custom_components.frank_energie.select import (
     SELECT_DESCRIPTIONS,
@@ -144,3 +148,68 @@ def test_battery_strategy_select_availability(mock_coordinator, mock_config_entr
     # Available when battery mode is TRADING
     mock_battery.smart_battery.settings.battery_mode = SmartBatteryMode.TRADING
     assert entity.available is True
+
+
+# --- Real-hass layer -------------------------------------------------------
+#
+# The battery-select tests above call ``entity.async_select_option`` directly
+# on a hand-rolled ``mock_coordinator``. The resolution select is always
+# present (no auth needed), so it can go through a full ``async_setup`` and
+# HA's own ``select.select_option`` option validation.
+
+_RESOLUTION_SELECT = "select.frank_energie_settings_resolution"
+
+
+async def test_resolution_select_registers_with_real_hass(
+    hass: HomeAssistant, frank_energie_setup
+) -> None:
+    """The resolution select reaches the state machine at the default option
+    with the two real resolutions offered."""
+    entry = await frank_energie_setup()
+
+    state = hass.states.get(_RESOLUTION_SELECT)
+    assert state is not None
+    assert state.state == "pt15m"
+    assert state.attributes["options"] == ["pt15m", "pt60m"]
+    assert er.async_get(hass).async_get(_RESOLUTION_SELECT).config_entry_id == (
+        entry.entry_id
+    )
+
+
+async def test_resolution_select_option_goes_through_ha_validation(
+    hass: HomeAssistant, frank_energie_setup
+) -> None:
+    """``select.select_option`` persists a valid resolution to the entry
+    options (unauthenticated path) and rejects an unknown one with
+    ``ServiceValidationError`` before the entity is ever called."""
+    entry = await frank_energie_setup()
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": _RESOLUTION_SELECT, "option": "pt60m"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(_RESOLUTION_SELECT).state == "pt60m"
+    assert entry.options["resolution"] == "PT60M"
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": _RESOLUTION_SELECT, "option": "pt5m"},
+            blocking=True,
+        )
+    assert hass.states.get(_RESOLUTION_SELECT).state == "pt60m"
+
+
+# TODO: real-hass coverage for the auth-gated battery selects
+# (FrankEnergieBatteryModeSelect, FrankEnergieBatteryStrategySelect). They only
+# appear once the battery coordinator has authenticated data, so exercising
+# them through the real select platform + select.select_option needs an
+# operationName->JSON dispatcher on aioclient_mock fed by python-frank-energie's
+# smart_battery_details.json fixture, or a patched
+# custom_components.frank_energie.FrankEnergie + MockEntityPlatform (see
+# test_binary_sensor.py). Until then their option handling stays at the
+# direct-call unit level above.


### PR DESCRIPTION
Stacked on #292 — the first commit here is that fix; this PR should merge **after** #292 (its diff collapses to just the test commit once #292 lands).

## Why

The `number`, `select` and `binary_sensor` test suites built entities against a hand-rolled `mock_coordinator` and asserted on `entity.native_value` / `entity.is_on` directly. Home Assistant's own entity registration and service validation (`number.set_value` range checks, `select.select_option` option checks, state-machine serialisation) never ran — the exact gap where a hand-rolled double stays green while the real framework would reject the result.

`test_init.py` / `test_config_flow.py` / `test_sensor.py` already exercise the real framework; this extends that to the remaining platforms, per-file (matching the repo's convention) rather than as one monolithic file.

## What

- **`tests/conftest.py`** — `frank_energie_setup` fixture: a full unauthenticated `async_setup` through the real coordinators and platforms.
- **number** — config numbers register at their shipped defaults; `number.set_value` goes through HA range validation (in-range persists to entry options, out-of-range raises `ServiceValidationError`).
- **select** — resolution select registers; `select.select_option` goes through HA option validation.
- **binary_sensor** — smart-feature sensors added via `MockEntityPlatform` (the idiom already in `test_sensor.py`) resolve to on/off/unknown with `device_class` and attributes serialised into the state machine.
- **TODO** notes in each file marking where the auth-gated battery/Enode entities would be covered (needs an `operationName`→JSON dispatcher fed by `python-frank-energie`'s response fixtures, or a patched client + `MockEntityPlatform`).

No production code in this PR. Full suite green.

## Samenvatting door Sourcery

Laat de resterende platformtests gebruikmaken van de echte entiteits- en servicelagen van Home Assistant en los tegelijkertijd het bereik van de exportkosten op, zodat de negatieve standaardwaarde wordt geaccepteerd.

Bugfixes:
- Sta negatieve standaardwaarden voor exportelektriciteitskosten toe door de ondergrens van de getalentiteit uit te breiden zodat meegeleverde kredietwaarden worden geaccepteerd.

Verbeteringen:
- Test getal-, selectie- en binaire-sensorentiteiten via de echte platform-, statusmachine- en servicevalidatiepaden van Home Assistant.
- Voeg een herbruikbare fixture voor een volledige, niet-geauthenticeerde integratieconfiguratie toe voor tests op platformniveau.

Tests:
- Controleer of configuratiegetallen met hun standaardwaarden worden geregistreerd en geldige service-updates behouden, terwijl waarden buiten het toegestane bereik worden afgewezen.
- Controleer of de resolutieselectie wordt geregistreerd met de beschikbare opties en ongeldige serviceselecties afwijst.
- Controleer of slimme-functie-binaire sensoren de juiste aan/uit/onbekende statussen, apparaatklassen en attributen via Home Assistant serialiseren.

Onderhoud:
- Documenteer TODO-hiaten in de testdekking voor batterij- en Enode-entiteiten die authenticatie vereisen.

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Test de resterende platformentiteiten via de echte validatie- en statusbeheerprocessen van Home Assistant, terwijl negatieve standaardwaarden voor exportkosten worden geaccepteerd.

Bugfixes:
- Sta negatieve standaardwaarden voor exportkosten voor elektriciteit toe door de geaccepteerde ondergrens van de number-entiteit te verlagen.

Verbeteringen:
- Laat platformtests voor number, select en binary sensor verlopen via de echte entiteits-, status- en servicelagen van Home Assistant.
- Voeg een herbruikbare fixture toe voor de volledige installatie van niet-geauthenticeerde integraties in platformtests.

Tests:
- Controleer of configuratienummers en resolutieselecties met standaardwaarden worden geregistreerd, geldige service-updates behouden blijven en ongeldige waarden via de validatie van Home Assistant worden afgewezen.
- Controleer of binary sensors voor slimme functies correcte statussen, apparaatklassen en attributen serialiseren via de statusmachine van Home Assistant.

Onderhoud:
- Documenteer de resterende hiaten in de dekking van echte platformtests voor batterij- en Enode-entiteiten waarvoor authenticatie vereist is.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exercise the remaining platform entities through Home Assistant's real validation and state-management paths while accepting negative export fee defaults.

Bug Fixes:
- Allow negative default export electricity fees by expanding the number entity's accepted lower bound.

Enhancements:
- Route number, select, and binary sensor platform tests through Home Assistant's real entity, state, and service layers.
- Add a reusable fixture for full unauthenticated integration setup in platform tests.

Tests:
- Verify configuration numbers and resolution selection register with defaults, persist valid service updates, and reject invalid values through Home Assistant validation.
- Verify smart-feature binary sensors serialize correct states, device classes, and attributes through the Home Assistant state machine.

Chores:
- Document remaining real-platform test coverage gaps for authentication-gated battery and Enode entities.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expanded the allowed range for the electricity export fee to support negative per-kWh credits.

- **Tests**
  - Added integration coverage for binary sensor states, including unknown values.
  - Added validation tests for cost configuration numbers, including persistence and range enforcement.
  - Added coverage for resolution selection, including valid and invalid options.
  - Added shared setup support for realistic Home Assistant integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->